### PR TITLE
修改ClassUtil抛出NoSuchFieldException的使用问题

### DIFF
--- a/hutool-core/src/main/java/com/xiaoleilu/hutool/comparator/FieldComparator.java
+++ b/hutool-core/src/main/java/com/xiaoleilu/hutool/comparator/FieldComparator.java
@@ -21,10 +21,9 @@ public class FieldComparator<T> implements Comparator<T>, Serializable {
 	private final Field field;
 
 	public FieldComparator(Class<T> beanClass, String fieldName) {
-		try {
-			this.field = ClassUtil.getDeclaredField(beanClass, fieldName);
-		} catch (NoSuchFieldException | SecurityException e) {
-			throw new IllegalArgumentException(e);
+		this.field = ClassUtil.getDeclaredField(beanClass, fieldName);
+		if(this.field == null){
+			throw new IllegalArgumentException("字段"+ fieldName+ "在类"+beanClass+"中不存在");
 		}
 	}
 

--- a/hutool-core/src/test/java/com/xiaoleilu/hutool/core/util/ClassUtilTest.java
+++ b/hutool-core/src/test/java/com/xiaoleilu/hutool/core/util/ClassUtilTest.java
@@ -1,9 +1,12 @@
 package com.xiaoleilu.hutool.core.util;
 
+import com.xiaoleilu.hutool.util.ClassUtil;
+import com.xiaoleilu.hutool.util.CollectionUtil;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.xiaoleilu.hutool.util.ClassUtil;
 
 /**
  * {@link ClassUtil} 单元测试
@@ -19,5 +22,64 @@ public class ClassUtilTest {
 		
 		String simpleClassName = ClassUtil.getClassName(ClassUtil.class, true);
 		Assert.assertEquals("ClassUtil", simpleClassName);
+	}
+	class TestClass {
+		private String privateField;
+		protected String field;
+		private void privateMethod(){}
+		public void publicMethod(){}
+	}
+	class TestSubClass extends TestClass{
+		private String subField;
+		private void privateSubMethod(){}
+		public void publicSubMethod(){}
+	}
+	@Test
+	public void getPublicMethod(){
+		Method superPublicMethod = ClassUtil.getPublicMethod(TestSubClass.class, "publicMethod");
+		Assert.assertNotNull(superPublicMethod);
+		Method superPrivateMethod = ClassUtil.getPublicMethod(TestSubClass.class, "privateMethod");
+		Assert.assertNull(superPrivateMethod);
+
+		Method publicMethod = ClassUtil.getPublicMethod(TestSubClass.class, "publicSubMethod");
+		Assert.assertNotNull(publicMethod);
+		Method privateMethod = ClassUtil.getPublicMethod(TestSubClass.class, "privateSubMethod");
+		Assert.assertNull(privateMethod);
+	}
+
+	@Test
+	public void getDeclaredMethod() throws Exception {
+		Method noMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "noMethod");
+		Assert.assertNull(noMethod);
+
+		Method privateMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "privateMethod");
+		Assert.assertNotNull(privateMethod);
+		Method publicMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "publicMethod");
+		Assert.assertNotNull(publicMethod);
+
+		Method publicSubMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "publicSubMethod");
+		Assert.assertNotNull(publicSubMethod);
+		Method privateSubMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "privateSubMethod");
+		Assert.assertNotNull(privateSubMethod);
+
+	}
+
+	@Test
+	public void getDeclaredField()  {
+		System.out.println(CollectionUtil.newArrayList(TestSubClass.class.getDeclaredFields()));
+
+		Field noField = ClassUtil.getDeclaredField(TestSubClass.class, "noField");
+		Assert.assertNull(noField);
+
+		//能够获取到父类字段
+		Field privateField = ClassUtil.getField(TestSubClass.class, "privateField");
+		Assert.assertNotNull(privateField);
+
+		//获取不到父类字段
+		Field field = ClassUtil.getDeclaredField(TestSubClass.class, "field");
+		Assert.assertNull(field);
+
+		Field subField = ClassUtil.getDeclaredField(TestSubClass.class, "subField");
+		Assert.assertNotNull(subField);
 	}
 }


### PR DESCRIPTION
取消ClassUtil中会抛出的NoSuchFieldException改为出现异常时返回null.修改getDeclaredField方法说明和结果不一致(只会返回本类的字段).添加一个getField方法(返回本类和父类的字段)