### PR TITLE
fix 线程不断创建OOM

### DIFF
--- a/hutool-cache/src/main/java/com/xiaoleilu/hutool/cache/GlobalPruneTimer.java
+++ b/hutool-cache/src/main/java/com/xiaoleilu/hutool/cache/GlobalPruneTimer.java
@@ -52,7 +52,7 @@ public enum GlobalPruneTimer {
 		if (null != pruneTimer) {
 			shutdownNow();
 		}
-		this.pruneTimer = new ScheduledThreadPoolExecutor(Integer.MAX_VALUE, new ThreadFactory() {
+		this.pruneTimer = new ScheduledThreadPoolExecutor(16, new ThreadFactory() {
 			@Override
 			public Thread newThread(Runnable r) {
 				return ThreadUtil.newThread(r, StrUtil.format("Pure-Timer-{}", cacheTaskNumber.getAndIncrement()));


### PR DESCRIPTION
设置较小的初始值,避免不断新建线程.

参考资料:
ThreadPoolExecutor线程池中的线程数量是可变的，其变化范围取决于下面两个变量：
1. corePoolSize：线程池维护线程的最少数量
2. maximumPoolSize：线程池维护线程的最大数量

具体线程的分配方式是，当一个任务被添加到线程池：
1. 如果此时线程池中的数量小于corePoolSize，即使线程池中的线程都处于空闲状态，也要创建新的线程来处理被添加的任务。
2. 如果此时线程池中的数量等于 corePoolSize，但是缓冲队列 workQueue未满，那么任务被放入缓冲队列。
3. 如果此时线程池中的数量大于corePoolSize，缓冲队列workQueue满，并且线程池中的数量小于maximumPoolSize，建新的线程来处理被添加的任务。
4. 如果此时线程池中的数量大于corePoolSize，缓冲队列workQueue满，并且线程池中的数量等于maximumPoolSize，那么通过 handler所指定的策略来处理此任务。也就是：处理任务的优先级为：核心线程corePoolSize、任务队列workQueue、最大线程maximumPoolSize，如果三者都满了，使用handler处理被拒绝的任务。
5. 当线程池中的线程数量大于 corePoolSize时，如果某线程空闲时间超过keepAliveTime，线程将被终止。

[Java线程池类ThreadPoolExecutor、ScheduledThreadPoolExecutor及Executors工厂类](http://blog.csdn.net/suifeng3051/article/details/49444177)