### PR TITLE
V4 dev fixseason

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 target/
 dependency-reduced-pom.xml
 pom.xml.versionsBackup
+.factorypath
 
 # Gradle
 .gradle/

--- a/hutool-core/src/main/java/cn/hutool/core/date/DateTime.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateTime.java
@@ -258,7 +258,9 @@ public class DateTime extends Date {
 	 * 4：第四季度<br>
 	 * 
 	 * @return 第几个季度
+	 * @deprecated 请使用{@link quarter}代替
 	 */
+	@Deprecated
 	public int season() {
 		return monthStartFromOne() / 4 + 1;
 	}
@@ -267,9 +269,29 @@ public class DateTime extends Date {
 	 * 获得当前日期所属季度<br>
 	 * 
 	 * @return 第几个季度 {@link Season}
+	 * @deprecated 请使用{@link quarterEnum}代替
 	 */
+	@Deprecated
 	public Season seasonEnum() {
 		return Season.of(season());
+	}
+
+	/**
+	 * 获得当前日期所属季度<br>
+	 * 
+	 * @return 第几个季度 {@link Quarter}
+	 */
+	public int quarter() {
+		return month() / 3 + 1;
+	}
+
+	/**
+	 * 获得当前日期所属季度<br>
+	 * 
+	 * @return 第几个季度 {@link Quarter}
+	 */
+	public Quarter quarterEnum() {
+		return Quarter.of(quarter());
 	}
 
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -370,9 +370,23 @@ public class DateUtil {
 	 * 
 	 * @param date 日期
 	 * @return Season ，类似于 20132
+	 * @deprecated 请使用{@link yearAndQuarter} 代替
 	 */
+	@Deprecated
 	public static String yearAndSeason(Date date) {
 		return yearAndSeason(calendar(date));
+	}
+
+	/**
+	 * 获得指定日期年份和季节<br>
+	 * 格式：[20131]表示2013年第一季度
+	 * 
+	 * @param date 日期
+	 * @return Quarter ，类似于 20132
+	 * @deprecated 
+	 */
+	public static String yearAndQuarter(Date date) {
+		return yearAndQuarter(calendar(date));
 	}
 
 	/**
@@ -381,7 +395,9 @@ public class DateUtil {
 	 * @param startDate 起始日期（包含）
 	 * @param endDate 结束日期（包含）
 	 * @return Season列表 ，元素类似于 20132
+	 * @deprecated 请使用{@link yearAndQuarter} 代替
 	 */
+	@Deprecated
 	public static LinkedHashSet<String> yearAndSeasons(Date startDate, Date endDate) {
 		final LinkedHashSet<String> seasons = new LinkedHashSet<String>();
 		if (startDate == null || endDate == null) {
@@ -407,6 +423,40 @@ public class DateUtil {
 		}
 
 		return seasons;
+	}
+	
+	/**
+	 * 获得指定日期区间内的年份和季节<br>
+	 * 
+	 * @param startDate 起始日期（包含）
+	 * @param endDate 结束日期（包含）
+	 * @return Season列表 ，元素类似于 20132
+	 */
+	public static LinkedHashSet<String> yearAndQuarter(Date startDate, Date endDate) {
+		final LinkedHashSet<String> quarter = new LinkedHashSet<String>();
+		if (startDate == null || endDate == null) {
+			return quarter;
+		}
+
+		final Calendar cal = Calendar.getInstance();
+		cal.setTime(startDate);
+		while (true) {
+			// 如果开始时间超出结束时间，让结束时间为开始时间，处理完后结束循环
+			if (startDate.after(endDate)) {
+				startDate = endDate;
+			}
+
+			quarter.add(yearAndSeason(cal));
+
+			if (startDate.equals(endDate)) {
+				break;
+			}
+
+			cal.add(Calendar.MONTH, 3);
+			startDate = cal.getTime();
+		}
+
+		return quarter;
 	}
 
 	// ------------------------------------ Format start ----------------------------------------------
@@ -815,6 +865,50 @@ public class DateUtil {
 	 * @return {@link Calendar}
 	 */
 	public static Calendar endOfMonth(Calendar calendar) {
+		calendar.set(Calendar.DAY_OF_MONTH, calendar.getActualMaximum(Calendar.DAY_OF_MONTH));
+		return endOfDay(calendar);
+	}
+
+	/**
+	 * 获取某季度的开始时间
+	 * 
+	 * @param date 日期
+	 * @return {@link DateTime}
+	 */
+	public static DateTime beginOfQuarter(Date date) {
+		return new DateTime(beginOfQuarter(calendar(date)));
+	}
+
+	/**
+	 * 获取某季度的结束时间
+	 * 
+	 * @param date 日期
+	 * @return {@link DateTime}
+	 */
+	public static DateTime endOfQuarter(Date date) {
+		return new DateTime(endOfQuarter(calendar(date)));
+	}
+
+	/**
+	 * 获取某季度的开始时间
+	 * 
+	 * @param calendar 日期 {@link Calendar}
+	 * @return {@link Calendar}
+	 */
+	public static Calendar beginOfQuarter(Calendar calendar) {
+		calendar.set(Calendar.MONTH, calendar.get(DateField.MONTH.getValue()) /3 *3);
+		calendar.set(Calendar.DAY_OF_MONTH, 1);
+		return beginOfDay(calendar);
+	}
+
+	/**
+	 * 获取某季度的结束时间
+	 * 
+	 * @param calendar 日期 {@link Calendar}
+	 * @return {@link Calendar}
+	 */
+	public static Calendar endOfQuarter(Calendar calendar) {
+		calendar.set(Calendar.MONTH, calendar.get(DateField.MONTH.getValue()) /3 *3 +2);
 		calendar.set(Calendar.DAY_OF_MONTH, calendar.getActualMaximum(Calendar.DAY_OF_MONTH));
 		return endOfDay(calendar);
 	}
@@ -1392,8 +1486,19 @@ public class DateUtil {
 	 * 格式：[20131]表示2013年第一季度
 	 * 
 	 * @param cal 日期
+	 * @deprecated 请使用{@link yearAndQuarter}
 	 */
+	@Deprecated
 	private static String yearAndSeason(Calendar cal) {
+		return new StringBuilder().append(cal.get(Calendar.YEAR)).append(cal.get(Calendar.MONTH) / 3 + 1).toString();
+	}
+	/**
+	 * 获得指定日期年份和季节<br>
+	 * 格式：[20131]表示2013年第一季度
+	 * 
+	 * @param cal 日期
+	 */
+	private static String yearAndQuarter(Calendar cal) {
 		return new StringBuilder().append(cal.get(Calendar.YEAR)).append(cal.get(Calendar.MONTH) / 3 + 1).toString();
 	}
 	

--- a/hutool-core/src/main/java/cn/hutool/core/date/Quarter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/Quarter.java
@@ -1,0 +1,61 @@
+package cn.hutool.core.date;
+
+/**
+ * 季度枚举<br>
+ * 
+ * @see #Q1
+ * @see #Q2
+ * @see #Q3
+ * @see #Q4
+ * 
+ * @author zhfish
+ *
+ */
+public enum Quarter {
+
+	/** 第一季度 */
+	Q1(1),
+	/** 第二季度 */
+	Q2(2),
+	/** 第三季度 */
+	Q3(3),
+	/** 第四季度 */
+	Q4(4);
+	
+	// ---------------------------------------------------------------
+	private int value;
+
+	private Quarter(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return this.value;
+	}
+
+	/**
+	 * 将 季度int转换为Season枚举对象<br>
+	 * 
+	 * @see #Q1
+	 * @see #Q2
+	 * @see #Q3
+	 * @see #Q4
+	 * 
+	 * @param intValue 季度int表示
+	 * @return {@link Quarter}
+	 */
+	public static Quarter of(int intValue) {
+		switch (intValue) {
+			case 1:
+				return Q1;
+			case 2:
+				return Q2;
+			case 3:
+				return Q3;
+			case 4:
+				return Q4;
+			default:
+				return null;
+		}
+	}
+}

--- a/hutool-core/src/main/java/cn/hutool/core/date/Season.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/Season.java
@@ -43,7 +43,9 @@ public enum Season {
 	 * 
 	 * @param intValue 季度int表示
 	 * @return {@link Season}
+	 * @deprecated 使用@{@link Quarter} 替代
 	 */
+	@Deprecated
 	public static Season of(int intValue) {
 		switch (intValue) {
 			case 1:

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateTimeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateTimeTest.java
@@ -38,7 +38,11 @@ public class DateTimeTest {
 		Assert.assertEquals(5, day);
 	}
 	
-	@Test
+	/**
+	 * @deprecated season季节根据经纬变化，不适合做公共方法
+	 */
+	// @Test
+	@Deprecated
 	public void seasonTest(){
 		DateTime dateTime = new DateTime("2017-01-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		//季度（非季节）
@@ -50,17 +54,46 @@ public class DateTimeTest {
 		season = dateTime.seasonEnum();
 		Assert.assertEquals(Season.SUMMER, season);
 		
-		dateTime = new DateTime("2017-09-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
+		dateTime = new DateTime("2017-07-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		//季度（非季节）
 		season = dateTime.seasonEnum();
 		Assert.assertEquals(Season.AUTUMN, season);
 		
-		dateTime = new DateTime("2017-12-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
+		dateTime = new DateTime("2017-10-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		//季度（非季节）
 		season = dateTime.seasonEnum();
 		Assert.assertEquals(Season.WINTER, season);
 	}
 	
+		@Test
+		public void quarterTest() {
+			DateTime dateTime = new DateTime("2017-01-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
+			Quarter quarter = dateTime.quarterEnum();
+			Assert.assertEquals(Quarter.Q1, quarter);
+			
+			dateTime = new DateTime("2017-04-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
+			quarter = dateTime.quarterEnum();
+			Assert.assertEquals(Quarter.Q2, quarter);
+			
+			dateTime = new DateTime("2017-07-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
+			quarter = dateTime.quarterEnum();
+			Assert.assertEquals(Quarter.Q3, quarter);
+			
+			dateTime = new DateTime("2017-10-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
+			quarter = dateTime.quarterEnum();
+			Assert.assertEquals(Quarter.Q4, quarter);
+
+			// 精确到毫秒
+			DateTime beginTime = new DateTime("2017-10-01 00:00:00.000", DatePattern.NORM_DATETIME_MS_FORMAT);
+			dateTime = DateUtil.beginOfQuarter(dateTime);
+			Assert.assertEquals(beginTime, dateTime);
+
+			// 精确到毫秒
+			DateTime endTime = new DateTime("2017-12-31 23:59:59.999", DatePattern.NORM_DATETIME_MS_FORMAT);
+			dateTime = DateUtil.endOfQuarter(dateTime);
+			Assert.assertEquals(endTime, dateTime);
+		}
+
 	@Test
 	public void mutableTest(){
 		DateTime dateTime = new DateTime("2017-01-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);


### PR DESCRIPTION
- 增补gitignore
- datetime模块
- "季度"替代"季节"
- 修正季度算法
- 增加季度相关方法

原来的算法是错误的，但是测试用例选用的时间巧妙的避开了这个错误
修复了一下，顺便添加了方法（季度开始时间，季度结束时间）