### PR TITLE
修复UA部分的一些问题，添加了新版Windows和一些非主流WindowsPhone设备的识别准确性问题

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
@@ -23,8 +23,10 @@ public class Browser extends UserAgentInfo {
 	 * 支持的浏览器类型
 	 */
 	public static final List<Browser> browers = CollUtil.newArrayList(//
+			new Browser("MSEdge", "Edge", "edge\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Chrome", "chrome", "chrome\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Firefox", "firefox", Other_Version), //
+			new Browser("IEMobile", "iemobile", Other_Version), //
 			new Browser("Safari", "safari", "version\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Opera", "opera", Other_Version), //
 			new Browser("Konqueror", "konqueror", Other_Version), //
@@ -36,8 +38,8 @@ public class Browser extends UserAgentInfo {
 			new Browser("Seamonkey", "seamonkey", Other_Version), //
 			new Browser("Outlook", "microsoft.outlook", Other_Version), //
 			new Browser("Evolution", "evolution", Other_Version), //
-			new Browser("MSIE", "msie", Other_Version), //
-			new Browser("IEMobile", "emobile|windows phone", Other_Version), //
+			new Browser("MSIE", "msie", "msie ([\\d\\w\\.\\-]+)"), //
+			new Browser("MSIE11", "trident", "rv:([\\d\\w\\.\\-]+)"), //
 			new Browser("Gabble", "Gabble", "Gabble\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Yammer Desktop", "AdobeAir", "([\\d\\w\\.\\-]+)\\/Yammer"), //
 			new Browser("Yammer Mobile", "Yammer[\\s]+([\\d\\w\\.\\-]+)", "Yammer[\\s]+([\\d\\w\\.\\-]+)"), //
@@ -46,6 +48,7 @@ public class Browser extends UserAgentInfo {
 	);
 
 	private Pattern versionPattern;
+
 
 	/**
 	 * 构造

--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
@@ -39,7 +39,7 @@ public class Browser extends UserAgentInfo {
 			new Browser("Outlook", "microsoft.outlook", Other_Version), //
 			new Browser("Evolution", "evolution", Other_Version), //
 			new Browser("MSIE", "msie", "msie ([\\d\\w\\.\\-]+)"), //
-			new Browser("MSIE11", "trident", "rv:([\\d\\w\\.\\-]+)"), //
+			new Browser("MSIE11", "rv:11", "rv:([\\d\\w\\.\\-]+)"), //
 			new Browser("Gabble", "Gabble", "Gabble\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Yammer Desktop", "AdobeAir", "([\\d\\w\\.\\-]+)\\/Yammer"), //
 			new Browser("Yammer Mobile", "Yammer[\\s]+([\\d\\w\\.\\-]+)", "Yammer[\\s]+([\\d\\w\\.\\-]+)"), //

--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Engine.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Engine.java
@@ -19,9 +19,9 @@ public class Engine extends UserAgentInfo {
 	 * 支持的引擎类型
 	 */
 	public static final List<Engine> engines = CollUtil.newArrayList(//
+			new Engine("Trident", "trident"), //
 			new Engine("Webkit", "webkit"), //
 			new Engine("Chrome", "chrome"), //
-			new Engine("MSIE", "msie"), //
 			new Engine("Opera", "opera"), //
 			new Engine("Presto", "presto"), //
 			new Engine("Gecko", "gecko"), //

--- a/hutool-http/src/main/java/cn/hutool/http/useragent/OS.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/OS.java
@@ -19,9 +19,11 @@ public class OS extends UserAgentInfo {
 	 * 支持的引擎类型
 	 */
 	public static final List<OS> oses = CollUtil.newArrayList(//
-			new OS("Windows 10","windows nt 10\\.0"),//
+			new OS("Windows 10 or Windows Server 2016","windows nt 10\\.0"),//
+			new OS("Windows 8.1 or Winsows Server 2012R2","windows nt 6\\.3"),//
+			new OS("Windows 8 or Winsows Server 2012","windows nt 6\\.2"),//
 			new OS("Windows Vista", "windows nt 6\\.0"), //
-			new OS("Windows 7", "windows nt 6\\.\\d+"), //
+			new OS("Windows 7 or Windows Server 2008R2", "windows nt 6\\.1"), //
 			new OS("Windows 2003", "windows nt 5\\.2"), //
 			new OS("Windows XP", "windows nt 5\\.1"), //
 			new OS("Windows 2000", "windows nt 5\\.0"), //

--- a/hutool-http/src/main/java/cn/hutool/http/useragent/OS.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/OS.java
@@ -19,6 +19,7 @@ public class OS extends UserAgentInfo {
 	 * 支持的引擎类型
 	 */
 	public static final List<OS> oses = CollUtil.newArrayList(//
+			new OS("Windows 10","windows nt 10\\.0"),//
 			new OS("Windows Vista", "windows nt 6\\.0"), //
 			new OS("Windows 7", "windows nt 6\\.\\d+"), //
 			new OS("Windows 2003", "windows nt 5\\.2"), //
@@ -27,6 +28,7 @@ public class OS extends UserAgentInfo {
 			new OS("Windows Phone", "windows (ce|phone|mobile)( os)?"), //
 			new OS("Windows", "windows"), //
 			new OS("OSX", "os x (\\d+)[._](\\d+)"), //
+			new OS("Android","Android"),//
 			new OS("Linux", "linux"), //
 			new OS("Wii", "wii"), //
 			new OS("PS3", "playstation 3"), //

--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Platform.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Platform.java
@@ -1,5 +1,6 @@
 package cn.hutool.http.useragent;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import cn.hutool.core.collection.CollUtil;
@@ -19,13 +20,25 @@ public class Platform extends UserAgentInfo {
 	 * 支持的移动平台类型
 	 */
 	public static final List<Platform> mobilePlatforms = CollUtil.newArrayList(//
+			new Platform("Windows Phone", "windows (ce|phone|mobile)( os)?"), //
 			new Platform("iPad", "ipad"), //
 			new Platform("iPod", "ipod"), //
 			new Platform("iPhone", "iphone"), //
 			new Platform("Android", "android"), //
-			new Platform("Windows Phone", "windows (ce|phone|mobile)( os)?"), //
 			new Platform("Symbian", "symbian(os)?"), //
 			new Platform("Blackberry", "blackberry") //
+	);
+
+	/**
+	 * 支持的桌面平台类型
+	 */
+	public static final List<Platform> desktopPlatforms=CollUtil.newArrayList(//
+			new Platform("Windows", "windows"), //
+			new Platform("Mac", "(macintosh|darwin)"), //
+			new Platform("Linux", "linux"), //
+			new Platform("Wii", "wii"), //
+			new Platform("Playstation", "playstation"), //
+			new Platform("Java", "java") //
 	);
 	
 	/**
@@ -33,16 +46,9 @@ public class Platform extends UserAgentInfo {
 	 */
 	public static final List<Platform> platforms;
 	static {
-		platforms = CollUtil.newArrayList(//
-				// 移动平台
-				new Platform("Windows", "windows"), //
-				new Platform("Mac", "(macintosh|darwin)"), //
-				new Platform("Linux", "linux"), //
-				new Platform("Wii", "wii"), //
-				new Platform("Playstation", "playstation"), //
-				new Platform("Java", "java") //
-		);
+		platforms=new ArrayList<Platform>(13);
 		platforms.addAll(mobilePlatforms);
+		platforms.addAll(desktopPlatforms);
 	}
 
 	/**

--- a/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
@@ -54,7 +54,7 @@ public class UserAgentUtilTest {
 		Assert.assertEquals("70.0.3538.102", ua.getVersion());
 		Assert.assertEquals("Webkit", ua.getEngine().toString());
 		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 10", ua.getOs().toString());
+		Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
 		Assert.assertEquals("Windows", ua.getPlatform().toString());
 		Assert.assertFalse(ua.isMobile());
 	}
@@ -67,7 +67,7 @@ public class UserAgentUtilTest {
         Assert.assertEquals("11.0", ua.getVersion());
         Assert.assertEquals("Trident", ua.getEngine().toString());
         Assert.assertEquals("7.0", ua.getEngineVersion());
-        Assert.assertEquals("Windows 10", ua.getOs().toString());
+        Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
         Assert.assertEquals("Windows", ua.getPlatform().toString());
         Assert.assertFalse(ua.isMobile());
     }
@@ -106,7 +106,7 @@ public class UserAgentUtilTest {
         Assert.assertEquals("18.17763", ua.getVersion());
         Assert.assertEquals("Webkit", ua.getEngine().toString());
         Assert.assertEquals("537.36", ua.getEngineVersion());
-        Assert.assertEquals("Windows 10", ua.getOs().toString());
+        Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
         Assert.assertEquals("Windows", ua.getPlatform().toString());
         Assert.assertFalse(ua.isMobile());
     }
@@ -121,5 +121,31 @@ public class UserAgentUtilTest {
         Assert.assertEquals("Windows Phone", ua.getOs().toString());
         Assert.assertEquals("Windows Phone", ua.getPlatform().toString());
         Assert.assertTrue(ua.isMobile());
+    }
+    
+    @Test
+    public void parseChromeOnWindowsServer2012R2(){
+	    String uaStr="Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36";
+        UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("Chrome", ua.getBrowser().toString());
+        Assert.assertEquals("63.0.3239.132", ua.getVersion());
+        Assert.assertEquals("Webkit", ua.getEngine().toString());
+        Assert.assertEquals("537.36", ua.getEngineVersion());
+        Assert.assertEquals("Windows 8.1 or Winsows Server 2012R2", ua.getOs().toString());
+        Assert.assertEquals("Windows", ua.getPlatform().toString());
+        Assert.assertFalse(ua.isMobile());
+    }
+
+    @Test
+    public void parseIE11OnWindowsServer2008R2(){
+	    String uaStr="Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko";
+        UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("MSIE11", ua.getBrowser().toString());
+        Assert.assertEquals("11.0", ua.getVersion());
+        Assert.assertEquals("Trident", ua.getEngine().toString());
+        Assert.assertEquals("7.0", ua.getEngineVersion());
+        Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
+        Assert.assertEquals("Windows", ua.getPlatform().toString());
+        Assert.assertFalse(ua.isMobile());
     }
 }

--- a/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
@@ -32,4 +32,94 @@ public class UserAgentUtilTest {
 		Assert.assertEquals("iPhone", ua.getPlatform().toString());
 		Assert.assertTrue(ua.isMobile());
 	}
+
+	@Test
+	public void parseMiui10WithChromeTest(){
+		String uaStr="Mozilla/5.0 (Linux; Android 9; MIX 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36";
+		UserAgent ua=UserAgentUtil.parse(uaStr);
+		Assert.assertEquals("Chrome", ua.getBrowser().toString());
+		Assert.assertEquals("70.0.3538.80", ua.getVersion());
+		Assert.assertEquals("Webkit", ua.getEngine().toString());
+		Assert.assertEquals("537.36", ua.getEngineVersion());
+		Assert.assertEquals("Android", ua.getOs().toString());
+		Assert.assertEquals("Android", ua.getPlatform().toString());
+		Assert.assertTrue(ua.isMobile());
+	}
+
+	@Test
+	public void parseWindows10WithChromeTest(){
+		String uaStr="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36";
+		UserAgent ua=UserAgentUtil.parse(uaStr);
+		Assert.assertEquals("Chrome", ua.getBrowser().toString());
+		Assert.assertEquals("70.0.3538.102", ua.getVersion());
+		Assert.assertEquals("Webkit", ua.getEngine().toString());
+		Assert.assertEquals("537.36", ua.getEngineVersion());
+		Assert.assertEquals("Windows 10", ua.getOs().toString());
+		Assert.assertEquals("Windows", ua.getPlatform().toString());
+		Assert.assertFalse(ua.isMobile());
+	}
+
+	@Test
+    public void parseWindows10WithIe11Test(){
+	    String uaStr="Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko";
+        UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("MSIE11", ua.getBrowser().toString());
+        Assert.assertEquals("11.0", ua.getVersion());
+        Assert.assertEquals("Trident", ua.getEngine().toString());
+        Assert.assertEquals("7.0", ua.getEngineVersion());
+        Assert.assertEquals("Windows 10", ua.getOs().toString());
+        Assert.assertEquals("Windows", ua.getPlatform().toString());
+        Assert.assertFalse(ua.isMobile());
+    }
+
+    @Test
+    public void parseWindows10WithIeMobileLumia520Test(){
+	    String uaStr="Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537 ";
+	    UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("IEMobile", ua.getBrowser().toString());
+        Assert.assertEquals("11.0", ua.getVersion());
+        Assert.assertEquals("Trident", ua.getEngine().toString());
+        Assert.assertEquals("7.0", ua.getEngineVersion());
+        Assert.assertEquals("Windows Phone", ua.getOs().toString());
+        Assert.assertEquals("Windows Phone", ua.getPlatform().toString());
+        Assert.assertTrue(ua.isMobile());
+    }
+
+    @Test
+    public void parseWindows10WithIe8EmulatorTest(){
+	    String uaStr="Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)";
+        UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("MSIE", ua.getBrowser().toString());
+        Assert.assertEquals("8.0", ua.getVersion());
+        Assert.assertEquals("Trident", ua.getEngine().toString());
+        Assert.assertEquals("4.0", ua.getEngineVersion());
+        Assert.assertEquals("Windows 7", ua.getOs().toString());
+        Assert.assertEquals("Windows", ua.getPlatform().toString());
+        Assert.assertFalse(ua.isMobile());
+    }
+
+    @Test
+    public void parseWindows10WithEdgeTest(){
+	    String uaStr="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17763";
+        UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("MSEdge", ua.getBrowser().toString());
+        Assert.assertEquals("18.17763", ua.getVersion());
+        Assert.assertEquals("Webkit", ua.getEngine().toString());
+        Assert.assertEquals("537.36", ua.getEngineVersion());
+        Assert.assertEquals("Windows 10", ua.getOs().toString());
+        Assert.assertEquals("Windows", ua.getPlatform().toString());
+        Assert.assertFalse(ua.isMobile());
+    }
+    @Test
+    public void parseEdgeOnLumia950XLTest(){
+	    String uaStr="Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Mobile Safari/537.36 Edge/15.14900";
+        UserAgent ua=UserAgentUtil.parse(uaStr);
+        Assert.assertEquals("MSEdge", ua.getBrowser().toString());
+        Assert.assertEquals("15.14900", ua.getVersion());
+        Assert.assertEquals("Webkit", ua.getEngine().toString());
+        Assert.assertEquals("537.36", ua.getEngineVersion());
+        Assert.assertEquals("Windows Phone", ua.getOs().toString());
+        Assert.assertEquals("Windows Phone", ua.getPlatform().toString());
+        Assert.assertTrue(ua.isMobile());
+    }
 }

--- a/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
@@ -14,7 +14,7 @@ public class UserAgentUtilTest {
 		Assert.assertEquals("14.0.835.163", ua.getVersion());
 		Assert.assertEquals("Webkit", ua.getEngine().toString());
 		Assert.assertEquals("535.1", ua.getEngineVersion());
-		Assert.assertEquals("Windows 7", ua.getOs().toString());
+		Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
 		Assert.assertEquals("Windows", ua.getPlatform().toString());
 		Assert.assertFalse(ua.isMobile());
 	}
@@ -93,7 +93,7 @@ public class UserAgentUtilTest {
         Assert.assertEquals("8.0", ua.getVersion());
         Assert.assertEquals("Trident", ua.getEngine().toString());
         Assert.assertEquals("4.0", ua.getEngineVersion());
-        Assert.assertEquals("Windows 7", ua.getOs().toString());
+        Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
         Assert.assertEquals("Windows", ua.getPlatform().toString());
         Assert.assertFalse(ua.isMobile());
     }
@@ -124,7 +124,7 @@ public class UserAgentUtilTest {
     }
     
     @Test
-    public void parseChromeOnWindowsServer2012R2(){
+    public void parseChromeOnWindowsServer2012R2Test(){
 	    String uaStr="Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36";
         UserAgent ua=UserAgentUtil.parse(uaStr);
         Assert.assertEquals("Chrome", ua.getBrowser().toString());
@@ -137,7 +137,7 @@ public class UserAgentUtilTest {
     }
 
     @Test
-    public void parseIE11OnWindowsServer2008R2(){
+    public void parseIE11OnWindowsServer2008R2Test(){
 	    String uaStr="Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko";
         UserAgent ua=UserAgentUtil.parse(uaStr);
         Assert.assertEquals("MSIE11", ua.getBrowser().toString());


### PR DESCRIPTION
浏览器添加Edge支持（现在将被识别为MSEdge），修正识别顺序带来的IEMobile识别不准确的问题，修正IE11的特殊UA格式带来识别不准确的问题（现在将被识别为MSIE11）
引擎精确性修正，IE统一修改为其引擎名，修改了识别参数（现在将被识别为Trident）
系统版本追加Windows 10与Android的支持
修正由于顺序带来的WindowsPhone被识别为Iphone的问题，修正Android与Linux被混淆识别的问题
添加一些测试用例