### PR TITLE
使用sm2p256v1曲线生成SM2秘钥对

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/KeyUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/KeyUtil.java
@@ -15,6 +15,7 @@ import java.security.SecureRandom;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -56,6 +57,15 @@ public class KeyUtil {
 	 * </pre>
 	 */
 	public static final int DEFAULT_KEY_SIZE = 1024;
+	
+	/**
+	 * SM2默认曲线
+	 * 
+	 * <pre>
+	 * Default SM2 curve
+	 * </pre>
+	 */
+	public static final String SM2_DEFAULT_CURVE = "sm2p256v1";
 
 	/**
 	 * 生成 {@link SecretKey}，仅用于对称加密和摘要算法密钥生成
@@ -298,13 +308,13 @@ public class KeyUtil {
 	 * 生成用于非对称加密的公钥和私钥<br>
 	 * 密钥对生成算法见：https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#KeyPairGenerator
 	 * 
-	 * @param algorithm 非对称加密算法
+	 * @param realAlgorithm 非对称加密算法
 	 * @param keySize 密钥模（modulus ）长度
 	 * @param seed 种子
 	 * @return {@link KeyPair}
 	 */
-	public static KeyPair generateKeyPair(String algorithm, int keySize, byte[] seed) {
-		algorithm = getAlgorithmAfterWith(algorithm);
+	public static KeyPair generateKeyPair(String realAlgorithm, int keySize, byte[] seed) {
+		String algorithm = getAlgorithmAfterWith(realAlgorithm);
 		if ("EC".equalsIgnoreCase(algorithm) && (keySize <= 0 || keySize > 256)) {
 			// 对于EC算法，密钥长度有限制，在此使用默认256
 			keySize = 256;
@@ -325,6 +335,15 @@ public class KeyUtil {
 			keyPairGen.initialize(keySize, random);
 		} else {
 			keyPairGen.initialize(keySize);
+		}
+		
+		if ("SM2".equalsIgnoreCase(realAlgorithm)) {
+			ECGenParameterSpec sm2p256v1 = new ECGenParameterSpec(SM2_DEFAULT_CURVE);
+			try {
+				keyPairGen.initialize(sm2p256v1);
+			} catch (InvalidAlgorithmParameterException e) {
+				throw new CryptoException(e);
+			}
 		}
 		return keyPairGen.generateKeyPair();
 	}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/KeyUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/KeyUtil.java
@@ -38,7 +38,7 @@ import cn.hutool.core.util.StrUtil;
 /**
  * 密钥工具类
  * 
- * @author looly
+ * @author looly, Gsealy
  * @since 4.4.1
  */
 public class KeyUtil {

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/SecureUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/SecureUtil.java
@@ -44,7 +44,7 @@ import cn.hutool.crypto.symmetric.SymmetricCrypto;
  * 2、非对称加密（asymmetric），例如：RSA、DSA等<br>
  * 3、摘要加密（digest），例如：MD5、SHA-1、SHA-256、HMAC等<br>
  * 
- * @author xiaoleilu
+ * @author xiaoleilu, Gsealy
  *
  */
 public final class SecureUtil {

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/SecureUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/SecureUtil.java
@@ -934,17 +934,17 @@ public final class SecureUtil {
 	}
 
 	/**
-	 * 增加加密解密的算法提供者，例如：
+	 * 增加加密解密的算法提供者，默认优先使用，例如：
 	 * 
 	 * <pre>
-	 * addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
+	 * insertProviderAt(new org.bouncycastle.jce.provider.BouncyCastleProvider(), 1);
 	 * </pre>
 	 * 
 	 * @param provider 算法提供者
 	 * @since 4.1.22
 	 */
 	public static void addProvider(Provider provider) {
-		Security.addProvider(provider);
+		Security.insertProviderAt(provider, 1);
 	}
 
 	/**

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/SM2Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/SM2Test.java
@@ -16,7 +16,7 @@ import cn.hutool.crypto.asymmetric.SM2;
 /**
  * SM2算法单元测试
  * 
- * @author Looly
+ * @author Looly, Gsealy
  *
  */
 public class SM2Test {

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/SM2Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/SM2Test.java
@@ -27,6 +27,15 @@ public class SM2Test {
 		Assert.assertNotNull(pair.getPrivate());
 		Assert.assertNotNull(pair.getPublic());
 	}
+	
+	@Test
+	public void KeyPairOIDTest() {
+		// OBJECT IDENTIFIER 1.2.156.10197.1.301
+		String OID = "06082A811CCF5501822D";
+		KeyPair pair = SecureUtil.generateKeyPair("SM2");
+		Assert.assertTrue(HexUtil.encodeHexStr(pair.getPrivate().getEncoded()).toUpperCase().contains(OID));
+		Assert.assertTrue(HexUtil.encodeHexStr(pair.getPublic().getEncoded()).toUpperCase().contains(OID));
+	}
 
 	@Test
 	public void sm2CustomKeyTest() {


### PR DESCRIPTION
原先使用默认 `1.2.840.10045.3.1.7` prime256v1 (ANSI X9.62 named elliptic curve) 生成秘钥对，SM2添加国密曲线` 1.2.156.10197.1.301` sm2ECC (China GM Standards Committee)
issues：#250 