### PR TITLE
MapUtil增加toMap方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/map/MapUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/MapUtil.java
@@ -22,6 +22,8 @@ import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.ReflectUtil;
 import cn.hutool.core.util.StrUtil;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
 
 /**
  * Map相关工具类
@@ -846,5 +848,41 @@ public class MapUtil {
 	 */
 	public static <T> T get(Map<?, ?> map, Object key, Class<T> type) {
 		return null == map ? null : Convert.convert(type, map.get(key));
+	}
+
+	/**
+	 * List转成Map，并按指定的策略去重.
+	 *
+	 * @param elements 源
+	 * @param keyMapper key生成策略
+	 * @param valueMapper value生成策略
+	 * @param mergeFunction 当key重复时，解决策略
+	 * @param <T> 源数据类型
+	 * @param <K> key数据类型
+	 * @param <U> value数据类型
+	 * @return 转换后的Map
+	 */
+	public static <T, K, U> Map<K, U> toMap(List<T> elements,
+		Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper,
+		BinaryOperator<T> mergeFunction) {
+
+		Map<K, U> result = new HashMap<>();
+		if (null == elements || elements.size() == 0) {
+			return result;
+		}
+
+		Map<K, T> temp = new HashMap<>();
+		elements.forEach(e -> {
+			K key = keyMapper.apply(e);
+			T finalReult = e;
+			if (result.containsKey(key) && null != mergeFunction) {
+				finalReult = mergeFunction.apply(temp.get(key), e);
+			}
+			result.put(key, valueMapper.apply(finalReult));
+			temp.put(key, finalReult);
+		});
+
+		temp.clear();
+		return result;
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/MapUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/MapUtilTest.java
@@ -1,5 +1,6 @@
 package cn.hutool.core.map;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -96,5 +97,41 @@ public class MapUtilTest {
 		Assert.assertEquals("3", objectArray[2][1]);
 		Assert.assertEquals("d", objectArray[3][0]);
 		Assert.assertEquals("4", objectArray[3][1]);
+	}
+
+	@Test
+	public void toMap() {
+		ArrayList<User> objects = new ArrayList<>();
+		objects.add(new User(1L, 1));
+		objects.add(new User(2L, 0));
+		objects.add(new User(4L, 2));
+		objects.add(new User(4L, 1));
+		objects.add(new User(5L, 3));
+
+		Map<Long, Integer> map = MapUtil.toMap(objects, User::getId, User::getScore,
+			(a, b) -> {
+				return a.getScore() < b.getScore() ? a : b;
+			});
+
+		Assert.assertEquals(4, map.size());
+		Assert.assertEquals(1, (int) map.get(4L));
+	}
+
+	static class User {
+		private long id;
+		private int score;
+
+		public User(long id, int score) {
+			this.id = id;
+			this.score = score;
+		}
+
+		public long getId() {
+			return id;
+		}
+
+		public int getScore() {
+			return score;
+		}
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.0</version>
 				<configuration>
-					<source>7</source>
-					<target>7</target>
+					<source>8</source>
+					<target>8</target>
 				</configuration>
 			</plugin>
 			<!-- Javadoc -->


### PR DESCRIPTION
- **toMap** 
List对象转Map，支持自定义key和value，以及key重复时，value的选择策略，例如传入的数据是：
```
class User {
    private long id;
    private int score;
}

objects.add(new User(1L, 1));
objects.add(new User(2L, 0));
objects.add(new User(4L, 2));
objects.add(new User(4L, 1));
objects.add(new User(5L, 3));
```
    id作为key，score作为value，当id重复时，取score相对小的对象，结果为：
```
{1=1, 2=0, 4=1, 5=3}
```