### PR TITLE
issue[651]: URLUtil.normalize support ipv6

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/URLUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/URLUtil.java
@@ -637,7 +637,7 @@ public class URLUtil {
 	 * </pre>
 	 *
 	 * @param url URL字符串
-	 * @param isEncodeBody 是否对URL中body部分的中文和特殊字符做转义（不包括http:和/）
+	 * @param isEncodeBody 是否对URL中body部分的中文和特殊字符做转义（不包括 http:, /和域名部分）
 	 * @return 标准化后的URL字符串
 	 * @since 4.4.1
 	 */
@@ -667,9 +667,17 @@ public class URLUtil {
 		body = body.replaceAll("^[\\\\/]+", StrUtil.EMPTY);
 		// 替换多个\或/为单个/
 		body = body.replace("\\", "/").replaceAll("//+", "/");
-		if (isEncodeBody) {
-			body = encode(body);
+
+		final int pathSepIndex = StrUtil.indexOf(body, '/');
+		String domain = body;
+		String path = "";
+		if (pathSepIndex > 0) {
+			domain = StrUtil.subPre(body, pathSepIndex);
+			path = StrUtil.subSuf(body, pathSepIndex);
 		}
-		return pre + body + StrUtil.nullToEmpty(params);
+		if (isEncodeBody) {
+			path = encode(path);
+		}
+		return pre + domain + path + StrUtil.nullToEmpty(params);
 	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/test/HttpUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/test/HttpUtilTest.java
@@ -71,7 +71,7 @@ public class HttpUtilTest {
 		FileUtil.writeBytes(str, "f:/test/2D.jpg");
 		Console.log(str);
 	}
-	
+
 	@Test
 	@Ignore
 	public void get12306Test() {
@@ -273,5 +273,11 @@ public class HttpUtilTest {
 	public void getMimeTypeTest() {
 		String mimeType = HttpUtil.getMimeType("aaa.aaa");
 		Assert.assertNull(mimeType);
+	}
+
+	@Test
+	public void ipv6Test() {
+		String result = HttpUtil.get("http://[fe80::8f8:2022:a603:d180]:9439");
+		Console.log(result);
 	}
 }


### PR DESCRIPTION
**问题：**

URLUtil.normalize 方法将 url 的域名部分也 encode 了，
当域名部分是 ipv6 地址时：

```
http://[fe80::8f8:2022:a603:d180]:9439/index 被编码为 http://%5Bfe80::8f8:2022:a603:d180%5D:9439/index
```

导致后续HttpUtil.post/get 方法中解析 url 失败

**解决:**

URLUtil.normalize 方法对 body 编码时，不编码域名&端口部分