### PR TITLE
bugfix: implicit conversion loses integer precision.

### DIFF
--- a/hutool-bloomFilter/src/main/java/cn/hutool/bloomfilter/bitMap/LongMap.java
+++ b/hutool-bloomFilter/src/main/java/cn/hutool/bloomfilter/bitMap/LongMap.java
@@ -33,7 +33,7 @@ public class LongMap implements BitMap, Serializable {
 	public void add(long i) {
 		int r = (int) (i / BitMap.MACHINE64);
 		long c = i % BitMap.MACHINE64;
-		longs[r] = longs[r] | (1 << c);
+		longs[r] = longs[r] | (1L << c);
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public class LongMap implements BitMap, Serializable {
 	public void remove(long i) {
 		int r = (int) (i / BitMap.MACHINE64);
 		long c = i % BitMap.MACHINE64;
-		longs[r] &= ~(1 << c);
+		longs[r] &= ~(1L << c);
 	}
 
 }


### PR DESCRIPTION
1. [bug修复] 1默认为int类型,左移超过32位后,高位丢失.
