### PR TITLE
创建LinkedHashMap的初始容量值在FIFOCache的容量过大时,效率低,且容易造成内存溢出.

### DIFF
--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/FIFOCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/FIFOCache.java
@@ -1,5 +1,6 @@
 package cn.hutool.cache.impl;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 
@@ -36,13 +37,10 @@ public class FIFOCache<K, V> extends AbstractCache<K, V> {
 	 * @param timeout 过期时长
 	 */
 	public FIFOCache(int capacity, long timeout) {
-		if(Integer.MAX_VALUE == capacity) {
-			capacity -= 1;
-		}
-		
 		this.capacity = capacity;
 		this.timeout = timeout;
-		cacheMap = new LinkedHashMap<>(capacity + 1, 1.0f, false);
+		int initialCapacity = Integer.max(1 << 4, capacity>>> 7);
+		cacheMap = new LinkedHashMap<>(initialCapacity, 1.0f, false);
 	}
 
 	/**


### PR DESCRIPTION
创建LinkedHashMap的初始容量值在FIFOCache的容量过大时,效率低,且容易造成内存溢出.

如果直接传入integer.MAX_VALUE,则.hashMap的table.size()=1 << 30,首次分配内部数组table即需要4G(每个指针4字节)内存,效率极低,内存小的的虚拟机会出现内存溢出.(不可接受).

使用FIFOCache容量的128分之一和16的较大值为初始容量值, table控制在1700万以内.
integer.MAX_VALUE>>>7=16777215, hashMap的table.size()=16777216. 分配table数组,需要62M内存.(可接受).