### PR TITLE
StrUtil添加subBetweenAll()方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/Console.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Console.java
@@ -179,4 +179,32 @@ public class Console {
 	public static String input() {
 		return scanner().next();
 	}
+
+	// --------------------------------------------------------------------------------- console lineNumber
+	/**
+	 * 返回当前位置+行号 (不支持Lambda、内部类、递归内使用)
+	 *
+	 * @return 返回当前行号
+	 * @author dahuoyzs
+	 * @since 5.2.5
+	 */
+	public static String where() {
+		StackTraceElement stackTraceElement = new Throwable().getStackTrace()[1];
+		final String className = stackTraceElement.getClassName();
+		final String methodName = stackTraceElement.getMethodName();
+		final String fileName = stackTraceElement.getFileName();
+		final Integer lineNumber = stackTraceElement.getLineNumber();
+		return String.format("%s.%s(%s:%s)", className,methodName,fileName,lineNumber);
+	}
+
+	/**
+	 * 返回当前行号 (不支持Lambda、内部类、递归内使用)
+	 *
+	 * @return 返回当前行号
+	 * @since 5.2.5
+	 */
+	public static Integer lineNumber() {
+		return new Throwable().getStackTrace()[1].getLineNumber();
+	}
+
 }

--- a/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
@@ -5,12 +5,8 @@ import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import cn.hutool.core.comparator.VersionComparator;
@@ -1950,6 +1946,73 @@ public class StrUtil {
 	 */
 	public static String subBetween(CharSequence str, CharSequence beforeAndAfter) {
 		return subBetween(str, beforeAndAfter, beforeAndAfter);
+	}
+
+	/**
+	 * 截取指定字符串多段中间部分，不包括标识字符串<br>
+	 *
+	 * 栗子：
+	 *
+	 * <pre>
+	 * StrUtil.subBetweenAll("wx[b]y[z]", "[", "]") 		= ["b","z"]
+	 * StrUtil.subBetweenAll(null, *, *)          			= []
+	 * StrUtil.subBetweenAll(*, null, *)          			= []
+	 * StrUtil.subBetweenAll(*, *, null)          			= []
+	 * StrUtil.subBetweenAll("", "", "")          			= []
+	 * StrUtil.subBetweenAll("", "", "]")         			= []
+	 * StrUtil.subBetweenAll("", "[", "]")        			= []
+	 * StrUtil.subBetweenAll("yabcz", "", "")     			= []
+	 * StrUtil.subBetweenAll("yabcz", "y", "z")   			= ["abc"]
+	 * StrUtil.subBetweenAll("yabczyabcz", "y", "z")   		= ["abc","abc"]
+	 * StrUtil.subBetweenAll("[yabc[zy]abcz]", "[", "]");   = ["zy"]           重叠时只截取内部，
+	 * </pre>
+	 *
+	 * @param str 被切割的字符串
+	 * @param regexBefore 截取开始的字符串标识
+	 * @param regexAfter 截取到的字符串标识
+	 * @return 截取后的字符串
+	 * @author dahuoyzs
+	 * @since 5.2.5
+	 */
+	public static String[] subBetweenAll(CharSequence str, CharSequence regexBefore, CharSequence regexAfter) {
+		if (str == null || regexBefore == null || regexAfter == null || str.length() < 1 || regexBefore.length() < 1 || regexAfter.length() < 1) {
+			return new String[0];
+		}
+
+		final String before = regexBefore.toString().replace("\\", "");
+		final String after = regexAfter.toString().replace("\\", "");
+		final Integer beforeNumber = StrUtil.count(str, before);
+		final Integer afterNumber = StrUtil.count(str, after);
+		if (beforeNumber<1||afterNumber<1){
+			return new String[0];
+		}
+
+		LinkedList<String> betweenList = new LinkedList<>();
+		if (beforeNumber.compareTo(afterNumber) > 0) {
+			String[] fragments = str.toString().split(regexAfter.toString());
+			for (int i = 0; i < fragments.length - 1; i++) {
+				String fragment = fragments[i];
+				if (fragment.contains(before)) {
+					int beforeIndex = StrUtil.lastIndexOf(fragment, before, 0, false);
+					String between = fragment.substring(beforeIndex);
+					if (between.length()>0)
+						betweenList.add(between);
+				}
+			}
+		} else {
+			String[] fragments = str.toString().split(regexBefore.toString());
+			for (int i = 1; i < fragments.length; i++) {
+				String fragment = fragments[i];
+				if (fragment.contains(after)) {
+					int afterIndex = StrUtil.indexOf(fragment, after, 0, false);
+					String between = fragment.substring(0, afterIndex);
+					if (between.length()>0)
+						betweenList.add(between);
+				}
+			}
+		}
+
+		return betweenList.toArray(new String[0]);
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTest.java
@@ -3,7 +3,6 @@ package cn.hutool.core.lang;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ThreadUtil;
 
 /**
@@ -57,4 +56,5 @@ public class ConsoleTest {
 			ThreadUtil.sleep(200);
 		}
 	}
+
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
@@ -421,5 +421,11 @@ public class StrUtilTest {
 		Assert.assertEquals("1AB", StrUtil.padAfter("1", 3, "ABC"));
 		Assert.assertEquals("23", StrUtil.padAfter("123", 2, "ABC"));
 	}
+
+	@Test
+	public void subBetweenAllTest() {
+		Assert.assertArrayEquals(new String[]{"yz","abc"},StrUtil.subBetweenAll("saho[yz]fdsadp[abc]a","\\[","\\]"));
+		Assert.assertArrayEquals(new String[]{"abc"}, StrUtil.subBetweenAll("saho[yzfdsadp[abc]a]","\\[","\\]"));
+	}
 	
 }


### PR DESCRIPTION
[新特性]
StrUtil增加subBetweenAll方法截取文本中的多段文本

栗子：
StrUtil.subBetweenAll("wx[b]y[z]", "[", "]") = ["b","z"]
StrUtil.subBetweenAll("yabcz", "y", "z") = ["abc"]
StrUtil.subBetweenAll("yabczyabcz", "y", "z") = ["abc","abc"]
StrUtil.subBetweenAll("[yabc[zy]abcz]", "[", "]"); = ["zy"] 重叠时只截取内部，
Console增加lineNumber()方法 用于调试时，快速定位行号
Console增加where()方法 用于调试时，快速定位行号