### PR TITLE
补充Math.ceilDiv()除法运算向上取整

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -752,6 +752,18 @@ public class NumberUtil {
 		return v1.divide(v2, scale, roundingMode);
 	}
 
+	/**
+	 * 补充Math.ceilDiv() JDK8中添加了和Math.floorDiv()但却没有ceilDiv()
+	 *
+	 * @param v1           被除数
+	 * @param v2           除数
+	 * @return 两个参数的商
+	 * @since 5.3.3
+	 */
+	public static int ceilDiv(int v1, int v2) {
+		return (int)Math.ceil((double)v1 / v2);
+	}
+
 	// ------------------------------------------------------------------------------------------- round
 
 	/**


### PR DESCRIPTION
#### 说明

JDK1.8添加了
Math.floorDiv()
但缺没有
Math.ceilDiv()

举个常用的栗子

页码 = 文本长度 / 每页长度

但是由于div不是int类型
此时的需求是两个数相除并向上取整
方法一：取余数判断是否整除
page = (line%size==0)? (line/size) : (line/size+1);
方法二：使用Math.ceil()
page =Math.ceil(line/size);//理想情况下10/3 page =4 但是返回的却是3
只有先把line和size转换成double才行。

思考？
为啥JDK提供了Math.floorDiv()而没提供Math.ceilDiv()？
难道是为了先向下取整再+1？那也不对啊。如果能整除的话再+1不太合适

此方法主要作用
Math.floorDiv(10/3)           //返回整形3    (向下取整)
NumberUtil.ceilDiv(10,3)    //返回整形4    (向上取整)

如Math和NumberUtil容易混淆，可在NumberUtil中完善相关的floorDiv和ceilDiv相应重载方法
NumberUtil.floorDiv(10,3)   //返回整形3    (向下取整)






