### PR TITLE
NumberConverter Long类型增加日期转换

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/impl/NumberConverter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/impl/NumberConverter.java
@@ -1,12 +1,16 @@
 package cn.hutool.core.convert.impl;
 
 import cn.hutool.core.convert.AbstractConverter;
+import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.util.BooleanUtil;
 import cn.hutool.core.util.NumberUtil;
 import cn.hutool.core.util.StrUtil;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -93,6 +97,12 @@ public class NumberConverter extends AbstractConverter<Number> {
 				return ((Number) value).longValue();
 			} else if(value instanceof Boolean) {
 				return BooleanUtil.toLongObj((Boolean)value);
+			} else if (value instanceof Date) {
+				return ((Date) value).getTime();
+			} else if (value instanceof Calendar) {
+				return ((Calendar) value).getTimeInMillis();
+			} else if (value instanceof TemporalAccessor) {
+				return DateUtil.toInstant((TemporalAccessor) value).toEpochMilli();
 			}
 			final String valueStr = convertToStr(value);
 			return StrUtil.isBlank(valueStr) ? null : NumberUtil.parseLong(valueStr);


### PR DESCRIPTION
[bug修复] Long类型无法转换Date类型的数据

在使用的时候发现无法把Date类型的数据转换成Long类型的数据，但是却可以转换成基本数据类型long。看了一下代码发现`PrimitiveConverter`中long类型是有日期相关转换的功能的，所以移植到Long的转换中