### PR TITLE
[bug修复] Snowflake 循环等待下一个时间时避免长时间循环，加入对时钟倒退的判断

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/Snowflake.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Snowflake.java
@@ -177,8 +177,14 @@ public class Snowflake implements Serializable {
 	 */
 	private long tilNextMillis(long lastTimestamp) {
 		long timestamp = genTime();
-		while (timestamp <= lastTimestamp) {
+		// 循环直到操作系统时间戳变化
+		while (timestamp == lastTimestamp) {
 			timestamp = genTime();
+		}
+		if (timestamp < lastTimestamp) {
+			// 如果发现新的时间戳比上次记录的时间戳数值小，说明操作系统时间发生了倒退，报错
+			throw new IllegalStateException(
+					StrUtil.format("Clock moved backwards. Refusing to generate id for {}ms", lastTimestamp - timestamp));
 		}
 		return timestamp;
 	}


### PR DESCRIPTION
[bug修复] Snowflake 在循环等待下一个时间时，判断时间未发生变化的方式由<=改为==，避免了时钟突然倒退导致的长时间循环，同时加入时钟倒退检测，避免生成重复ID
