### PR TITLE
导出word时，增加表格StackOverFlowError问题

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/word/TableUtil.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/word/TableUtil.java
@@ -69,19 +69,14 @@ public class TableUtil {
 	public static void writeRow(XWPFTableRow row, Object rowBean, boolean isWriteKeyAsHead) {
 		if (rowBean instanceof Iterable) {
 			writeRow(row, (Iterable<?>) rowBean);
-		}
-		
-		Map rowMap = null;
-		if(rowBean instanceof Map) {
-			rowMap = (Map) rowBean;
-		} else if (BeanUtil.isBean(rowBean.getClass())) {
-			rowMap = BeanUtil.beanToMap(rowBean, new LinkedHashMap<>(), false, false);
-		} else {
+		}else if(rowBean instanceof Map){
+			writeRow(row, (Map)rowBean, isWriteKeyAsHead);
+		}else if(BeanUtil.isBean(rowBean.getClass())){
+			writeRow(row, BeanUtil.beanToMap(rowBean, new LinkedHashMap<>(), false, false), isWriteKeyAsHead);
+		}else if (BeanUtil.isBean(rowBean.getClass())) {
 			// 其它转为字符串默认输出
 			writeRow(row, CollUtil.newArrayList(rowBean), isWriteKeyAsHead);
 		}
-		
-		writeRow(row, rowMap, isWriteKeyAsHead);
 	}
 	
 	/**


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复还是新特性添加)

[bug修复] 在使用wod导出时，word中使用createTable增加表格时，存在递归调用死循环问题