### PR TITLE
modify BaseAsymmetric.java

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/asymmetric/BaseAsymmetric.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/asymmetric/BaseAsymmetric.java
@@ -143,7 +143,8 @@ public class BaseAsymmetric<T extends BaseAsymmetric<T>> {
 	 * @return 获得私钥
 	 */
 	public String getPrivateKeyBase64() {
-		return Base64.encode(getPrivateKey().getEncoded());
+		final PrivateKey privateKey = getPrivateKey();
+		return (null == privateKey) ? null : Base64.encode(privateKey.getEncoded());
 	}
 
 	/**


### PR DESCRIPTION
[bug修复]修改了BaseAsymmetric中的getPrivateKeyBase64()方法，防止因未传入私钥而带来的空指针异常。