### PR TITLE
FileUtil重载方法,添加getSuffix方法✒️

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
@@ -1848,6 +1848,46 @@ public class FileUtil {
 	}
 
 	/**
+	 * 获取文件后缀名，扩展名不带“.”
+	 *
+	 * @param file 文件
+	 * @return 扩展名
+	 */
+	public static String getSuffix(File file) {
+		return extName(file);
+	}
+
+	/**
+	 * 获得文件后缀名，扩展名不带“.”
+	 *
+	 * @param fileName 文件名
+	 * @return 扩展名
+	 */
+	public static String getSuffix(String fileName) {
+		return extName(fileName);
+	}
+
+	/**
+	 * 返回主文件名
+	 *
+	 * @param file 文件
+	 * @return 主文件名
+	 */
+	public static String getPrefix(File file) {
+		return mainName(file);
+	}
+
+	/**
+	 * 返回主文件名
+	 *
+	 * @param fileName 完整文件名
+	 * @return 主文件名
+	 */
+	public static String getPrefix(String fileName) {
+		return mainName(fileName);
+	}
+	
+	/**
 	 * 返回主文件名
 	 *
 	 * @param file 文件


### PR DESCRIPTION
FileUtil工具类中虽然已经提供了类似,extName和mainName的方法。

但是在编写代码时，写出FileUtil后会自动提示getName而不会提示extName和mainName方法。
在手动输入get后，发现也只有getType和getName方法。

![1592319883(1)](https://user-images.githubusercontent.com/29905445/84792467-75cf7f00-b026-11ea-9807-e4081ca3b673.jpg)


并且在Hutool项目的源代码中搜索  "文件后缀名称",居然没有类似的注释

此提交主要有一下两方面意义
1.多提供一种获取文件后缀的方式.getSuffix和getPrefix
2.多提供一种注释 包含"文件后缀"字样,方便快速全局搜索
![image](https://user-images.githubusercontent.com/29905445/84792658-b7f8c080-b026-11ea-99c7-dcaa770ca7b9.png)


