### PR TITLE
fix-Strutil.brief substring logic

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
@@ -3312,11 +3312,11 @@ public class StrUtil {
 		if (null == str) {
 			return null;
 		}
-		if ((str.length() + 3) <= maxLength) {
+		if (str.length() <= maxLength) {
 			return str.toString();
 		}
 		int w = maxLength / 2;
-		int l = str.length();
+		int l = str.length() + 3;
 
 		final String str2 = str.toString();
 		return format("{}...{}", str2.substring(0, maxLength - w), str2.substring(l - w));


### PR DESCRIPTION
#### 说明
```
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;

    @Test
    public void test_str_brief() {
	 	String str = RandomStringUtils.random(1000);
	 	String brief = StrUtil.brief(str, 1000);
	 	assertEquals(brief.length(), 1003);
	}
```
shuould return length equals 1000,rather than 1003

### 修改描述(包括说明bug修复还是新特性添加)
1. [bug修复] brief(str,maxLength)  return a string with length greater then maxLength
