### PR TITLE
[bug修复]替换Arrays.asList()

### DIFF
--- a/hutool-setting/src/main/java/cn/hutool/setting/GroupedSet.java
+++ b/hutool-setting/src/main/java/cn/hutool/setting/GroupedSet.java
@@ -278,8 +278,8 @@ public class GroupedSet extends HashMap<String, LinkedHashSet<String>> {
 	 */
 	public boolean contains(String group, String value, String... otherValues) {
 		if (ArrayUtil.isNotEmpty(otherValues)) {
-			// 需要测试多个值的情况
-			final List<String> valueList = Arrays.asList(otherValues);
+			// 需要测试多个值的情况		
+			final List<String> valueList = new ArrayList<>(Arrays.asList(otherValues));
 			valueList.add(value);
 			return contains(group, valueList);
 		} else {


### PR DESCRIPTION
说明：
Arrays.asList()返回的是Arrays的内部类，该类不支持add操作，会直接抛异常，应该用ArrayList替换。
