### PR TITLE
[bug修复]修复ArrayUtil中isEmpty带来的异常

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/ArrayUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ArrayUtil.java
@@ -66,12 +66,13 @@ public class ArrayUtil {
 	 * @return 是否为空
 	 */
 	public static boolean isEmpty(Object array) {
-		if (null == array) {
-			return true;
-		} else if (isArray(array)) {
-			return 0 == Array.getLength(array);
+		if (array != null) {
+			if (isArray(array)) {
+				return 0 == Array.getLength(array);
+			}
+			return false;
 		}
-		throw new UtilException("Object to provide is not a Array !");
+		return true;		
 	}
 
 	/**


### PR DESCRIPTION
说明：方法注释有一条
        /**
	 * 如果此对象为非数组，理解为此对象为数组的第一个元素，则返回false<br>	
	 */

按理来说：如果是ArrayUtil.isEmpty(new Object()),应该返回false，而实际却会抛出异常，且有影响到下面的isNotEmpty(Object array)方法：

        // isNotEmpty(new Object());         throw  UtilException
        public static boolean isNotEmpty(Object array) {
		return false == isEmpty(array);    
	}