### PR TITLE
已经判断isEmpty(string)为true字符串为空时,直接复用全局的静态final EMPTY字段，而不需要调用toString方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
@@ -1840,7 +1840,7 @@ public class StrUtil {
 	 */
 	public static String subBefore(CharSequence string, char separator, boolean isLastSeparator) {
 		if (isEmpty(string)) {
-			return null == string ? null : string.toString();
+			return null == string ? null : EMPTY;
 		}
 
 		final String str = string.toString();
@@ -1878,7 +1878,7 @@ public class StrUtil {
 	 */
 	public static String subAfter(CharSequence string, CharSequence separator, boolean isLastSeparator) {
 		if (isEmpty(string)) {
-			return null == string ? null : string.toString();
+			return null == string ? null : EMPTY;
 		}
 		if (separator == null) {
 			return EMPTY;
@@ -1914,7 +1914,7 @@ public class StrUtil {
 	 */
 	public static String subAfter(CharSequence string, char separator, boolean isLastSeparator) {
 		if (isEmpty(string)) {
-			return null == string ? null : string.toString();
+			return null == string ? null : EMPTY;
 		}
 		final String str = string.toString();
 		final int pos = isLastSeparator ? str.lastIndexOf(separator) : str.indexOf(separator);


### PR DESCRIPTION
```java
if (isEmpty(string)) {
    return null == string ? null : string.toString();
}
```
部分API中已经判断isEmpty(string)为true字符串为空时,直接复用全局的静态final EMPTY字段，而不需要调用toString方法。
