### PR TITLE
增加crc16循环冗余校验算法工具类Crc16Util

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/Crc16Util.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/Crc16Util.java
@@ -1,0 +1,50 @@
+package cn.hutool.core.util;
+
+/**
+ * crc16校验码工具类
+ *
+ * @author wangjian
+ */
+public class Crc16Util {
+
+    /**
+     * 生成crc 十六进制整数 4位固定长度 返回大写
+     * 
+     * @param str 要生成crc的字符串
+     * @return
+     */
+    public static String crc16(String str) {
+        int len = 4;
+        String getHexStr = "";
+        byte[] buf = str.getBytes();
+        int size = 8;
+        int r = 0xffff;
+
+        for (int j = 0; j < buf.length; j++) {
+            int hi = r >> size;
+            hi ^= buf[j];
+            r = hi;
+
+            for (int i = 0; i < size; i++) {
+                int flag = r & 0x0001;
+                r = r >> 1;
+                if (flag == 1) {
+                    r ^= 0xa001;
+                }
+            }
+        }
+
+        getHexStr = Integer.toHexString(r);
+        if (getHexStr.length() < len) {
+            int loop = len - getHexStr.length();
+            for (int i = 0; i < loop; i++) {
+                getHexStr += "0";
+            }
+        }
+        if (r == 0) {
+            getHexStr = "0000";
+        }
+        
+        return getHexStr.toUpperCase();
+    }
+}

--- a/hutool-core/src/test/java/cn/hutool/core/util/Crc16UtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/Crc16UtilTest.java
@@ -1,0 +1,25 @@
+package cn.hutool.core.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * {@link Crc16Util}单元测试
+ * @author wangjian
+ *
+ */
+public class Crc16UtilTest {
+	
+	
+	@Test
+	public void crc16Test() {
+	    String str = "QN=20160801085857223;ST=23;CN=2011;PW=123456;MN=010000A8900016F000169DC0;Flag=5;CP=&&DataTime=20160801085857; LA-Rtd=50.1&&";
+		String crc16 = Crc16Util.crc16(str);
+		Assert.assertEquals("1E00", crc16);
+		
+        String str2 = "QN=20160801085857223;ST=32;CN=1062;PW=100000;MN=010000A8900016F000169DC0;Flag=5;CP=&&RtdInterval=30&&";
+        String crc16String = Crc16Util.crc16(str2);
+        Assert.assertEquals("1C80", crc16String);		
+	}
+	
+}


### PR DESCRIPTION
1. [新特性]  增加crc16循环冗余校验算法工具类Crc16Util 项目中有用到
测试类Crc16UtilTest

循环冗余校验（CRC）算法
CRC 校验（Cyclic Redundancy Check）是一种数据传输错误检查方法。本标准采用 ANSI CRC16，
简称 CRC16。
CRC16 码由传输设备计算后加入到数据包中。接收设备重新计算接收数据包的 CRC16 码，并与接
收到的 CRC16 码比较，如果两值不同，则有误。
CRC16 校验字节的生成步骤如下：
1) CRC16 校验寄存器赋值为 0xFFFF；
2) 取被校验串的第一个字节赋值给临时寄存器；
3) 临时寄存器与 CRC16 校验寄存器的高位字节进行“异或”运算，赋值给 CRC16 校验寄存器；
4) 取 CRC16 校验寄存器最后一位赋值给检测寄存器；
5) 把 CRC16 校验寄存器右移一位；
6) 若检测寄存器值为 1，CRC16 校验寄存器与多项式 0xA001 进行“异或”运算，赋值给 CRC16
校验寄存器；
7) 重复步骤 4~6，直至移出 8 位；
8) 取被校验串的下一个字节赋值给临时寄存器；
9) 重复步骤 3~8，直至被校验串的所有字节均被校验；
10) 返回 CRC16 校验寄存器的值。
校验码按照先高字节后低字节的顺序存放。