### PR TITLE
Browser 中添加一个新的 Android Browser ，表示 Android 系统原生的浏览器。Fixed #974

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
@@ -27,6 +27,7 @@ public class Browser extends UserAgentInfo {
 			new Browser("Chrome", "chrome", "chrome\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Firefox", "firefox", Other_Version), //
 			new Browser("IEMobile", "iemobile", Other_Version), //
+			new Browser("Android Browser", "android", "version\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Safari", "safari", "version\\/([\\d\\w\\.\\-]+)"), //
 			new Browser("Opera", "opera", Other_Version), //
 			new Browser("Konqueror", "konqueror", Other_Version), //

--- a/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
@@ -47,6 +47,32 @@ public class UserAgentUtilTest {
 	}
 
 	@Test
+	public void parseHuaweiPhoneWithNativeBrowserTest() {
+		String uaString = "Mozilla/5.0 (Linux; Android 10; EML-AL00 Build/HUAWEIEML-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36";
+		UserAgent ua = UserAgentUtil.parse(uaString);
+		Assert.assertEquals("Android Browser", ua.getBrowser().toString());
+		Assert.assertEquals("4.0", ua.getVersion());
+		Assert.assertEquals("Webkit", ua.getEngine().toString());
+		Assert.assertEquals("537.36", ua.getEngineVersion());
+		Assert.assertEquals("Android", ua.getOs().toString());
+		Assert.assertEquals("Android", ua.getPlatform().toString());
+		Assert.assertTrue(ua.isMobile());
+	}
+
+	@Test
+	public void parseSamsungPhoneWithNativeBrowserTest() {
+		String uaString = "Dalvik/2.1.0 (Linux; U; Android 9; SM-G950U Build/PPR1.180610.011)";
+		UserAgent ua = UserAgentUtil.parse(uaString);
+		Assert.assertEquals("Android Browser", ua.getBrowser().toString());
+		Assert.assertNull(ua.getVersion());
+		Assert.assertEquals("Unknown", ua.getEngine().toString());
+		Assert.assertNull(ua.getEngineVersion());
+		Assert.assertEquals("Android", ua.getOs().toString());
+		Assert.assertEquals("Android", ua.getPlatform().toString());
+		Assert.assertTrue(ua.isMobile());
+	}
+
+	@Test
 	public void parseWindows10WithChromeTest() {
 		String uaStr = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36";
 		UserAgent ua = UserAgentUtil.parse(uaStr);


### PR DESCRIPTION
修复原生浏览器被错误的解析成 Safari 了。并添加两个手机的测试用例。 fixed #974


1. [bug修复] #974 