### PR TITLE
feat(captcha): 新增获取验证码带文件格式的 Base64 编码

### DIFF
--- a/hutool-captcha/src/main/java/cn/hutool/captcha/AbstractCaptcha.java
+++ b/hutool-captcha/src/main/java/cn/hutool/captcha/AbstractCaptcha.java
@@ -195,6 +195,15 @@ public abstract class AbstractCaptcha implements ICaptcha {
 	}
 
 	/**
+	 * 获取图片带文件格式的 Base64
+	 *
+	 * @return 图片带文件格式的 Base64
+	 */
+	public String getImageBase64Full(){
+		return "data:image/png;base64," + Base64.encode(getImageBytes());
+	}
+
+	/**
 	 * 自定义字体
 	 *
 	 * @param font 字体


### PR DESCRIPTION
## 修改描述

### 新特性
1. 增加一个获取验证码带文件格式的 Base64 的方法，格式如下：
```
data:image/png;base64,wqewsdasdwd.........
```

虽然标准的 Base64 并无此文件头，但在后端将图片验证码通过 Base64 返回给前端时，在 css 中显示仍需添加此文件头。
所以为了方便起见，添加一个该方法直接返回此格式的 Base64