### PR TITLE
Test improvement: removed assertion roulette (test smell)

### DIFF
--- a/hutool-extra/src/test/java/cn/hutool/extra/template/BeetlUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/template/BeetlUtilTest.java
@@ -21,15 +21,16 @@ import java.io.IOException;
 public class BeetlUtilTest {
 
 	@Test
-	public void renderStrTest() throws IOException {
+	public void renderTest() throws IOException {
 		GroupTemplate groupTemplate = BeetlUtil.createGroupTemplate(new StringTemplateResourceLoader(), Configuration.defaultConfiguration());
 		Template template = BeetlUtil.getTemplate(groupTemplate, "hello,${name}");
 		String result = BeetlUtil.render(template, Dict.create().set("name", "hutool"));
-
 		Assert.assertEquals("hello,hutool", result);
+	}
 
+	@Test
+	public void renderFromStrTest() {
 		String renderFromStr = BeetlUtil.renderFromStr("hello,${name}", Dict.create().set("name", "hutool"));
 		Assert.assertEquals("hello,hutool", renderFromStr);
-
 	}
 }


### PR DESCRIPTION
This is a test refactoring.

Problem:
The assertion roulette test smell occurs when a test method has multiple non-documented assertions. Various assertion statements in a test method without a descriptive message impacts readability/understandability/maintainability as it is not possible to understand the reason for the failure of the test nor executing all the test assertions.

Solution:
The refactoring consisted of splitting the multiple assertion method into single assertion ones, indicating the test specificity in its name.

No assertion from the original test was changed.