### PR TITLE
[新特性] SpringUtil.getBean(TypeReference<T>)

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
@@ -1,6 +1,5 @@
 package cn.hutool.extra.spring;
 
-import cn.hutool.core.lang.ParameterizedTypeImpl;
 import cn.hutool.core.lang.TypeReference;
 import cn.hutool.core.util.ArrayUtil;
 import org.springframework.context.ApplicationContext;
@@ -9,7 +8,6 @@ import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -92,7 +90,7 @@ public class SpringUtil implements ApplicationContextAware {
 		Class<T> rawType = (Class<T>) parameterizedType.getRawType();
 		Class<?>[] genericTypes = Arrays.stream(parameterizedType.getActualTypeArguments()).map(type -> (Class<?>) type).toArray(Class[]::new);
 		String[] beanNames = applicationContext.getBeanNamesForType(ResolvableType.forClassWithGenerics(rawType, genericTypes));
-		return applicationContext.getBean(beanNames[0], rawType);
+		return getBean(beanNames[0], rawType);
 	}
 
 	/**

--- a/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
@@ -1,10 +1,16 @@
 package cn.hutool.extra.spring;
 
+import cn.hutool.core.lang.ParameterizedTypeImpl;
+import cn.hutool.core.lang.TypeReference;
 import cn.hutool.core.util.ArrayUtil;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.ResolvableType;
 import org.springframework.stereotype.Component;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -71,6 +77,22 @@ public class SpringUtil implements ApplicationContextAware {
 	 */
 	public static <T> T getBean(String name, Class<T> clazz) {
 		return applicationContext.getBean(name, clazz);
+	}
+
+    /**
+     * 通过类型参考返回带泛型参数的Bean
+     *
+     * @param reference 类型参考，用于持有转换后的泛型类型
+     * @param <T> Bean类型
+     * @return 带泛型参数的Bean
+     */
+	@SuppressWarnings("unchecked")
+	public static <T> T getBean(TypeReference<T> reference) {
+		ParameterizedType parameterizedType = (ParameterizedType) reference.getType();
+		Class<T> rawType = (Class<T>) parameterizedType.getRawType();
+		Class<?>[] genericTypes = Arrays.stream(parameterizedType.getActualTypeArguments()).map(type -> (Class<?>) type).toArray(Class[]::new);
+		String[] beanNames = applicationContext.getBeanNamesForType(ResolvableType.forClassWithGenerics(rawType, genericTypes));
+		return applicationContext.getBean(beanNames[0], rawType);
 	}
 
 	/**

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
@@ -10,9 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.lang.reflect.Type;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RunWith(SpringJUnit4ClassRunner.class)

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
@@ -1,5 +1,7 @@
 package cn.hutool.extra.spring;
 
+import cn.hutool.core.lang.TypeReference;
+import cn.hutool.core.map.MapUtil;
 import lombok.Data;
 import org.junit.Assert;
 import org.junit.Test;
@@ -7,6 +9,11 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {SpringUtil.class, SpringUtilTest.Demo2.class})
@@ -20,6 +27,14 @@ public class SpringUtilTest {
 		Assert.assertEquals("test", testDemo.getName());
 	}
 
+	@Test
+	public void getBeanWithTypeReferenceTest() {
+		Map<String, Object> mapBean = SpringUtil.getBean(new TypeReference<Map<String, Object>>() {});
+		Assert.assertNotNull(mapBean);
+		Assert.assertEquals("value1", mapBean.get("key1"));
+		Assert.assertEquals("value2", mapBean.get("key2"));
+	}
+
 	@Data
 	public static class Demo2{
 		private long id;
@@ -31,6 +46,14 @@ public class SpringUtilTest {
 			demo.setId(12345);
 			demo.setName("test");
 			return demo;
+		}
+
+		@Bean(name="mapDemo")
+		public Map<String, Object> generateMap() {
+			HashMap<String, Object> map = MapUtil.newHashMap();
+			map.put("key1", "value1");
+			map.put("key2", "value2");
+			return map;
 		}
 	}
 }


### PR DESCRIPTION
添加Spring工具类静态方法，通过类型参考（TypeReference）获取带泛型参数的Bean，同时添加了一个小的单元测试

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复还是新特性添加)

1. [bug修复] balabala……
2. [新特性]  balabala……