### PR TITLE
修改 Validator.isCitizenId() 方法，通过调用 IdcardUtil.isValidCard() 来进行身份证号码校验

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/PatternPool.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/PatternPool.java
@@ -57,10 +57,6 @@ public class PatternPool {
 	 */
 	public final static Pattern MOBILE = Pattern.compile("(?:0|86|\\+86)?1[3-9]\\d{9}");
 	/**
-	 * 18位身份证号码
-	 */
-	public final static Pattern CITIZEN_ID = Pattern.compile("[1-9]\\d{5}[1-2]\\d{3}((0\\d)|(1[0-2]))(([012]\\d)|3[0-1])\\d{3}(\\d|X|x)");
-	/**
 	 * 邮编
 	 */
 	public final static Pattern ZIP_CODE = Pattern.compile("[1-9]\\d{5}(?!\\d)");

--- a/hutool-core/src/main/java/cn/hutool/core/lang/Validator.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Validator.java
@@ -7,6 +7,7 @@ import cn.hutool.core.util.NumberUtil;
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.ReUtil;
 import cn.hutool.core.util.StrUtil;
+import cn.hutool.core.util.IdcardUtil;
 
 import java.net.MalformedURLException;
 import java.util.regex.Matcher;
@@ -51,10 +52,6 @@ public class Validator {
 	 * 移动电话
 	 */
 	public final static Pattern MOBILE = PatternPool.MOBILE;
-	/**
-	 * 身份证号码
-	 */
-	public final static Pattern CITIZEN_ID = PatternPool.CITIZEN_ID;
 	/**
 	 * 邮编
 	 */
@@ -724,19 +721,17 @@ public class Validator {
 	}
 
 	/**
-	 * 验证是否为身份证号码（18位中国）<br>
-	 * 出生日期只支持到到2999年
+	 * 验证是否为身份证号码（支持18位、15位和港澳台的10位）
 	 *
-	 * @param value 值
-	 * @return 是否为身份证号码（18位中国）
+	 * @param value 身份证号，支持18位、15位和港澳台的10位
+	 * @return 是否为有效身份证号码
 	 */
 	public static boolean isCitizenId(CharSequence value) {
-		return isMatchRegex(CITIZEN_ID, value);
+		return IdcardUtil.isValidCard(String.valueOf(value));
 	}
 
 	/**
-	 * 验证是否为身份证号码（18位中国）<br>
-	 * 出生日期只支持到到2999年
+	 * 验证是否为身份证号码（支持18位、15位和港澳台的10位）
 	 *
 	 * @param <T>      字符串类型
 	 * @param value    值

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
@@ -71,8 +71,17 @@ public class ValidatorTest {
 
 	@Test
 	public void isCitizenIdTest() {
-		boolean b = Validator.isCitizenId("150218199012123389");
+		// 18为身份证号码验证
+		boolean b = Validator.isCitizenId("110101199003074477");
 		Assert.assertTrue(b);
+
+		// 15位身份证号码验证
+		boolean b1 = Validator.isCitizenId("410001910101123");
+		Assert.assertTrue(b1);
+
+		// 10位身份证号码验证
+		boolean b2 = Validator.isCitizenId("U193683453");
+		Assert.assertTrue(b2);
 	}
 
 	@Test(expected = ValidateException.class)


### PR DESCRIPTION
[新特性]  让 Validator.isCitizenId() 支持18位、15位和港澳台的10位身份证号码校验