### PR TITLE
1. 在使用阻塞等待获取锁的方式中，必须在try代码块之外，并且在加锁方法与try代码块之间没有任何可能抛出异常的方法调用，避免加锁成功后…

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/ConcurrentHashSet.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/ConcurrentHashSet.java
@@ -105,7 +105,7 @@ public class ConcurrentHashSet<E> extends AbstractSet<E> implements java.io.Seri
 
 	@Override
 	public boolean remove(Object o) {
-		return map.remove(o) == PRESENT;
+		return PRESENT.equals(map.remove(o));
 	}
 
 	@Override

--- a/hutool-core/src/main/java/cn/hutool/core/thread/DelegatedExecutorService.java
+++ b/hutool-core/src/main/java/cn/hutool/core/thread/DelegatedExecutorService.java
@@ -16,73 +16,86 @@ import java.util.concurrent.TimeoutException;
  * @author loolly
  */
 public class DelegatedExecutorService extends AbstractExecutorService {
-	private final ExecutorService e;
+    private final ExecutorService e;
 
-	DelegatedExecutorService(ExecutorService executor) {
-		e = executor;
-	}
+    DelegatedExecutorService(ExecutorService executor) {
+        e = executor;
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public void execute(Runnable command) {
-		e.execute(command);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public void execute(Runnable command) {
+        e.execute(command);
+    }
 
-	public void shutdown() {
-		e.shutdown();
-	}
+    @Override
+    public void shutdown() {
+        e.shutdown();
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public List<Runnable> shutdownNow() {
-		return e.shutdownNow();
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public List<Runnable> shutdownNow() {
+        return e.shutdownNow();
+    }
 
-	public boolean isShutdown() {
-		return e.isShutdown();
-	}
+    @Override
+    public boolean isShutdown() {
+        return e.isShutdown();
+    }
 
-	public boolean isTerminated() {
-		return e.isTerminated();
-	}
+    @Override
+    public boolean isTerminated() {
+        return e.isTerminated();
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-		return e.awaitTermination(timeout, unit);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return e.awaitTermination(timeout, unit);
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public Future<?> submit(Runnable task) {
-		return e.submit(task);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public Future<?> submit(Runnable task) {
+        return e.submit(task);
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public <T> Future<T> submit(Callable<T> task) {
-		return e.submit(task);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public <T> Future<T> submit(Callable<T> task) {
+        return e.submit(task);
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public <T> Future<T> submit(Runnable task, T result) {
-		return e.submit(task, result);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public <T> Future<T> submit(Runnable task, T result) {
+        return e.submit(task, result);
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-		return e.invokeAll(tasks);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return e.invokeAll(tasks);
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-			throws InterruptedException {
-		return e.invokeAll(tasks, timeout, unit);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return e.invokeAll(tasks, timeout, unit);
+    }
 
-	@SuppressWarnings("NullableProblems")
-	public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
-			throws InterruptedException, ExecutionException {
-		return e.invokeAny(tasks);
-	}
+    @Override
+    @SuppressWarnings("NullableProblems")
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+            throws InterruptedException, ExecutionException {
+        return e.invokeAny(tasks);
+    }
 
-	public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-			throws InterruptedException, ExecutionException, TimeoutException {
-		return e.invokeAny(tasks, timeout, unit);
-	}
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return e.invokeAny(tasks, timeout, unit);
+    }
 }

--- a/hutool-cron/src/main/java/cn/hutool/cron/TaskTable.java
+++ b/hutool-cron/src/main/java/cn/hutool/cron/TaskTable.java
@@ -20,255 +20,255 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * @author Looly
  */
 public class TaskTable implements Serializable {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-	private final Scheduler scheduler;
-	private final TimeZone timezone;
+    private final Scheduler scheduler;
+    private final TimeZone timezone;
 
-	private final List<String> ids = new ArrayList<>();
-	private final List<CronPattern> patterns = new ArrayList<>();
-	private final List<Task> tasks = new ArrayList<>();
-	private int size;
+    private final List<String> ids = new ArrayList<>();
+    private final List<CronPattern> patterns = new ArrayList<>();
+    private final List<Task> tasks = new ArrayList<>();
+    private int size;
 
-	/**
-	 * 构造
-	 *
-	 * @param scheduler {@link Scheduler}
-	 */
-	public TaskTable(Scheduler scheduler) {
-		this.scheduler = scheduler;
-		this.timezone = scheduler.getTimeZone();
-	}
+    /**
+     * 构造
+     *
+     * @param scheduler {@link Scheduler}
+     */
+    public TaskTable(Scheduler scheduler) {
+        this.scheduler = scheduler;
+        this.timezone = scheduler.getTimeZone();
+    }
 
-	/**
-	 * 新增Task
-	 *
-	 * @param id      ID
-	 * @param pattern {@link CronPattern}
-	 * @param task    {@link Task}
-	 * @return this
-	 */
-	public TaskTable add(String id, CronPattern pattern, Task task) {
-		final Lock writeLock = lock.writeLock();
-		try {
-			writeLock.lock();
-			if (ids.contains(id)) {
-				throw new CronException("Id [{}] has been existed!", id);
-			}
-			ids.add(id);
-			patterns.add(pattern);
-			tasks.add(task);
-			size++;
-		} finally {
-			writeLock.unlock();
-		}
-		return this;
-	}
+    /**
+     * 新增Task
+     *
+     * @param id      ID
+     * @param pattern {@link CronPattern}
+     * @param task    {@link Task}
+     * @return this
+     */
+    public TaskTable add(String id, CronPattern pattern, Task task) {
+        final Lock writeLock = lock.writeLock();
+        writeLock.lock();
+        try {
+            if (ids.contains(id)) {
+                throw new CronException("Id [{}] has been existed!", id);
+            }
+            ids.add(id);
+            patterns.add(pattern);
+            tasks.add(task);
+            size++;
+        } finally {
+            writeLock.unlock();
+        }
+        return this;
+    }
 
-	/**
-	 * 获取所有ID，返回不可变列表，即列表不可修改
-	 *
-	 * @return ID列表
-	 * @since 4.6.7
-	 */
-	public List<String> getIds() {
-		final Lock readLock = lock.readLock();
-		try {
-			readLock.lock();
-			return Collections.unmodifiableList(this.ids);
-		} finally {
-			readLock.unlock();
-		}
-	}
+    /**
+     * 获取所有ID，返回不可变列表，即列表不可修改
+     *
+     * @return ID列表
+     * @since 4.6.7
+     */
+    public List<String> getIds() {
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+        try {
+            return Collections.unmodifiableList(this.ids);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
-	/**
-	 * 获取所有定时任务表达式，返回不可变列表，即列表不可修改
-	 *
-	 * @return 定时任务表达式列表
-	 * @since 4.6.7
-	 */
-	public List<CronPattern> getPatterns() {
-		final Lock readLock = lock.readLock();
-		try {
-			readLock.lock();
-			return Collections.unmodifiableList(this.patterns);
-		} finally {
-			readLock.unlock();
-		}
-	}
+    /**
+     * 获取所有定时任务表达式，返回不可变列表，即列表不可修改
+     *
+     * @return 定时任务表达式列表
+     * @since 4.6.7
+     */
+    public List<CronPattern> getPatterns() {
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+        try {
+            return Collections.unmodifiableList(this.patterns);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
-	/**
-	 * 获取所有定时任务，返回不可变列表，即列表不可修改
-	 *
-	 * @return 定时任务列表
-	 * @since 4.6.7
-	 */
-	public List<Task> getTasks() {
-		final Lock readLock = lock.readLock();
-		try {
-			readLock.lock();
-			return Collections.unmodifiableList(this.tasks);
-		} finally {
-			readLock.unlock();
-		}
-	}
+    /**
+     * 获取所有定时任务，返回不可变列表，即列表不可修改
+     *
+     * @return 定时任务列表
+     * @since 4.6.7
+     */
+    public List<Task> getTasks() {
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+        try {
+            return Collections.unmodifiableList(this.tasks);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
-	/**
-	 * 移除Task
-	 *
-	 * @param id Task的ID
-	 */
-	public void remove(String id) {
-		final Lock writeLock = lock.writeLock();
-		try {
-			writeLock.lock();
-			final int index = ids.indexOf(id);
-			if (index > -1) {
-				tasks.remove(index);
-				patterns.remove(index);
-				ids.remove(index);
-				size--;
-			}
-		} finally {
-			writeLock.unlock();
-		}
-	}
+    /**
+     * 移除Task
+     *
+     * @param id Task的ID
+     */
+    public void remove(String id) {
+        final Lock writeLock = lock.writeLock();
+        writeLock.lock();
+        try {
+            final int index = ids.indexOf(id);
+            if (index > -1) {
+                tasks.remove(index);
+                patterns.remove(index);
+                ids.remove(index);
+                size--;
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
 
-	/**
-	 * 更新某个Task的定时规则
-	 *
-	 * @param id      Task的ID
-	 * @param pattern 新的表达式
-	 * @return 是否更新成功，如果id对应的规则不存在则不更新
-	 * @since 4.0.10
-	 */
-	public boolean updatePattern(String id, CronPattern pattern) {
-		final Lock writeLock = lock.writeLock();
-		try {
-			writeLock.lock();
-			final int index = ids.indexOf(id);
-			if (index > -1) {
-				patterns.set(index, pattern);
-				return true;
-			}
-		} finally {
-			writeLock.unlock();
-		}
-		return false;
-	}
+    /**
+     * 更新某个Task的定时规则
+     *
+     * @param id      Task的ID
+     * @param pattern 新的表达式
+     * @return 是否更新成功，如果id对应的规则不存在则不更新
+     * @since 4.0.10
+     */
+    public boolean updatePattern(String id, CronPattern pattern) {
+        final Lock writeLock = lock.writeLock();
+        writeLock.lock();
+        try {
+            final int index = ids.indexOf(id);
+            if (index > -1) {
+                patterns.set(index, pattern);
+                return true;
+            }
+        } finally {
+            writeLock.unlock();
+        }
+        return false;
+    }
 
-	/**
-	 * 获得指定位置的{@link Task}
-	 *
-	 * @param index 位置
-	 * @return {@link Task}
-	 * @since 3.1.1
-	 */
-	public Task getTask(int index) {
-		final Lock readLock = lock.readLock();
-		try {
-			readLock.lock();
-			return tasks.get(index);
-		} finally {
-			readLock.unlock();
-		}
-	}
+    /**
+     * 获得指定位置的{@link Task}
+     *
+     * @param index 位置
+     * @return {@link Task}
+     * @since 3.1.1
+     */
+    public Task getTask(int index) {
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+        try {
+            return tasks.get(index);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
-	/**
-	 * 获得指定id的{@link Task}
-	 *
-	 * @param id ID
-	 * @return {@link Task}
-	 * @since 3.1.1
-	 */
-	public Task getTask(String id) {
-		final int index = ids.indexOf(id);
-		if (index > -1) {
-			return getTask(index);
-		}
-		return null;
-	}
+    /**
+     * 获得指定id的{@link Task}
+     *
+     * @param id ID
+     * @return {@link Task}
+     * @since 3.1.1
+     */
+    public Task getTask(String id) {
+        final int index = ids.indexOf(id);
+        if (index > -1) {
+            return getTask(index);
+        }
+        return null;
+    }
 
-	/**
-	 * 获得指定位置的{@link CronPattern}
-	 *
-	 * @param index 位置
-	 * @return {@link CronPattern}
-	 * @since 3.1.1
-	 */
-	public CronPattern getPattern(int index) {
-		final Lock readLock = lock.readLock();
-		try {
-			readLock.lock();
-			return patterns.get(index);
-		} finally {
-			readLock.unlock();
-		}
-	}
+    /**
+     * 获得指定位置的{@link CronPattern}
+     *
+     * @param index 位置
+     * @return {@link CronPattern}
+     * @since 3.1.1
+     */
+    public CronPattern getPattern(int index) {
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+        try {
+            return patterns.get(index);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
-	/**
-	 * 任务表大小，加入的任务数
-	 *
-	 * @return 任务表大小，加入的任务数
-	 * @since 4.0.2
-	 */
-	public int size() {
-		return this.size;
-	}
+    /**
+     * 任务表大小，加入的任务数
+     *
+     * @return 任务表大小，加入的任务数
+     * @since 4.0.2
+     */
+    public int size() {
+        return this.size;
+    }
 
-	/**
-	 * 任务表是否为空
-	 *
-	 * @return true为空
-	 * @since 4.0.2
-	 */
-	public boolean isEmpty() {
-		return this.size < 1;
-	}
+    /**
+     * 任务表是否为空
+     *
+     * @return true为空
+     * @since 4.0.2
+     */
+    public boolean isEmpty() {
+        return this.size < 1;
+    }
 
-	/**
-	 * 获得指定id的{@link CronPattern}
-	 *
-	 * @param id ID
-	 * @return {@link CronPattern}
-	 * @since 3.1.1
-	 */
-	public CronPattern getPattern(String id) {
-		final int index = ids.indexOf(id);
-		if (index > -1) {
-			return getPattern(index);
-		}
-		return null;
-	}
+    /**
+     * 获得指定id的{@link CronPattern}
+     *
+     * @param id ID
+     * @return {@link CronPattern}
+     * @since 3.1.1
+     */
+    public CronPattern getPattern(String id) {
+        final int index = ids.indexOf(id);
+        if (index > -1) {
+            return getPattern(index);
+        }
+        return null;
+    }
 
-	/**
-	 * 如果时间匹配则执行相应的Task，带读锁
-	 *
-	 * @param millis 时间毫秒
-	 */
-	public void executeTaskIfMatch(long millis) {
-		final Lock readLock = lock.readLock();
-		try {
-			readLock.lock();
-			executeTaskIfMatchInternal(millis);
-		} finally {
-			readLock.unlock();
-		}
-	}
+    /**
+     * 如果时间匹配则执行相应的Task，带读锁
+     *
+     * @param millis 时间毫秒
+     */
+    public void executeTaskIfMatch(long millis) {
+        final Lock readLock = lock.readLock();
+        readLock.lock();
+        try {
+            executeTaskIfMatchInternal(millis);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
-	/**
-	 * 如果时间匹配则执行相应的Task，无锁
-	 *
-	 * @param millis 时间毫秒
-	 * @since 3.1.1
-	 */
-	protected void executeTaskIfMatchInternal(long millis) {
-		for (int i = 0; i < size; i++) {
-			if (patterns.get(i).match(timezone, millis, this.scheduler.matchSecond)) {
-				this.scheduler.taskExecutorManager.spawnExecutor(tasks.get(i));
-			}
-		}
-	}
+    /**
+     * 如果时间匹配则执行相应的Task，无锁
+     *
+     * @param millis 时间毫秒
+     * @since 3.1.1
+     */
+    protected void executeTaskIfMatchInternal(long millis) {
+        for (int i = 0; i < size; i++) {
+            if (patterns.get(i).match(timezone, millis, this.scheduler.matchSecond)) {
+                this.scheduler.taskExecutorManager.spawnExecutor(tasks.get(i));
+            }
+        }
+    }
 }

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/RC4.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/RC4.java
@@ -140,8 +140,8 @@ public class RC4 implements Serializable {
 	 */
 	public byte[] crypt(final byte[] msg) {
 		final ReadLock readLock = this.lock.readLock();
-		readLock.lock();
 		byte[] code;
+		readLock.lock();
 		try {
 			final int[] sbox = this.sbox.clone();
 			code = new byte[msg.length];


### PR DESCRIPTION
…，在finally中无法解锁。

说明一：如果在lock方法与try代码块之间的方法调用抛出异常，那么无法解锁，造成其它线程无法成功获取锁。
说明二：如果lock方法在try代码块之内，可能由于其它方法抛出异常，导致在finally代码块中，unlock对未加锁的对象解锁，它会调用AQS的tryRelease方法（取决于具体实现类），抛出IllegalMonitorStateException异常。
说明三：在Lock对象的lock方法实现中可能抛出unchecked异常，产生的后果与说明二相同。 java.concurrent.LockShouldWithTryFinallyRule.rule.desc

2. 补上遗漏的Override注解

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复还是新特性添加)

1. [bug修复] balabala……
2. [新特性]  balabala……