### PR TITLE
Rc4 API enhanced

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/RC4.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/RC4.java
@@ -11,6 +11,7 @@ import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.HexUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.CryptoException;
+import cn.hutool.crypto.SecureUtil;
 
 /**
  * RC4加密解密算法实现<br>
@@ -98,6 +99,16 @@ public class RC4 implements Serializable {
 	}
 
 	/**
+	 * 加密，使用UTF-8编码
+	 *
+	 * @param data 被加密的字符串
+	 * @return 加密后的Hex
+	 */
+	public String encryptHex(String data) {
+		return HexUtil.encodeHexStr(encrypt(data));
+	}
+
+	/**
 	 * 加密
 	 * 
 	 * @param data 被加密的字符串
@@ -107,6 +118,17 @@ public class RC4 implements Serializable {
 	 */
 	public String encryptBase64(String data, Charset charset) {
 		return Base64.encode(encrypt(data, charset));
+	}
+
+
+	/**
+	 * 加密，使用UTF-8编码
+	 *
+	 * @param data 被加密的字符串
+	 * @return 加密后的Base64
+	 */
+	public String encryptBase64(String data) {
+		return Base64.encode(encrypt(data));
 	}
 
 	/**
@@ -131,6 +153,28 @@ public class RC4 implements Serializable {
 	public String decrypt(byte[] message) throws CryptoException {
 		return decrypt(message, CharsetUtil.CHARSET_UTF_8);
 	}
+
+	/**
+	 * 解密Hex（16进制）或Base64表示的字符串，使用默认编码UTF-8
+	 *
+	 * @param message 消息
+	 * @return 明文
+	 */
+	public String decrypt(String message) {
+		return decrypt(SecureUtil.decode(message));
+	}
+
+	/**
+	 * 解密Hex（16进制）或Base64表示的字符串
+	 *
+	 * @param message    明文
+	 * @param charset 解密后的charset
+	 * @return 明文
+	 */
+	public String decrypt(String message, Charset charset) {
+		return StrUtil.str(decrypt(message), charset);
+	}
+
 
 	/**
 	 * 加密或解密指定值，调用此方法前需初始化密钥

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/RC4Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/RC4Test.java
@@ -1,9 +1,13 @@
 package cn.hutool.crypto.test.symmetric;
 
+import cn.hutool.core.util.CharsetUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
 import cn.hutool.crypto.symmetric.RC4;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class RC4Test {
 	
@@ -34,6 +38,37 @@ public class RC4Test {
 		String message2 = "这是第二个中文消息！";
 		byte[] crypt2 = rc4.encrypt(message2);
 		String msg2 = rc4.decrypt(crypt2);
+		Assert.assertEquals(message2, msg2);
+	}
+
+	@Test
+	public void testDecryptWithHexMessage() {
+		String message = "这是第一个用来测试密文为十六进制字符串的消息！";
+		String key = "生成一个密钥";
+		RC4 rc4 = new RC4(key);
+		String encryptHex = rc4.encryptHex(message, CharsetUtil.CHARSET_UTF_8);
+		String msg = rc4.decrypt(encryptHex);
+		Assert.assertEquals(message, msg);
+
+		String message2 = "这是第二个用来测试密文为十六进制字符串的消息！";
+		String encryptHex2 = rc4.encryptHex(message2);
+		String msg2 = rc4.decrypt(encryptHex2);
+		Assert.assertEquals(message2, msg2);
+	}
+
+
+	@Test
+	public void testDecryptWithBase64Message() {
+		String message = "这是第一个用来测试密文为Base64编码的消息！";
+		String key = "生成一个密钥";
+		RC4 rc4 = new RC4(key);
+		String encryptHex = rc4.encryptBase64(message, CharsetUtil.CHARSET_UTF_8);
+		String msg = rc4.decrypt(encryptHex);
+		Assert.assertEquals(message, msg);
+
+		String message2 = "这是第一个用来测试密文为Base64编码的消息！";
+		String encryptHex2 = rc4.encryptBase64(message2);
+		String msg2 = rc4.decrypt(encryptHex2);
 		Assert.assertEquals(message2, msg2);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/RC4Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/RC4Test.java
@@ -6,9 +6,6 @@ import org.junit.Test;
 
 import cn.hutool.crypto.symmetric.RC4;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-
 public class RC4Test {
 	
 	@Test


### PR DESCRIPTION
#### 说明

我们打算使用hutool中的RC4工具类做一些数据的加密和解密工作，但是使用过程中发现解密方法不是很方便，加密的API提供了`RC4().encryptHex`,`RC4().encryptBase64()`方法都很方便,但是解密的API相对单一，以`encryptHex()`方法为例，该方法生成了十六进制的字符串，但是RC4工具类并没有提供直接解密十六进制字符串的API，导致解密的时候还需要先将十六进制字符串解析成byte[]数组，较为繁琐。
#### 改动
补齐了默认按UTF-8编码进行加密的方法，也补齐了HEX/Base64形式的密文的解密方法，也补齐了对应的测试用例
请帮忙检视，非常感谢