### PR TITLE
优化全局邮箱账户初始化逻辑

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/mail/GlobalMailAccount.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/mail/GlobalMailAccount.java
@@ -3,7 +3,7 @@ package cn.hutool.extra.mail;
 import cn.hutool.core.io.IORuntimeException;
 
 /**
- * 全局邮件帐户，依赖于邮件配置文件{@link MailAccount#MAIL_SETTING_PATH}或{@link MailAccount#MAIL_SETTING_PATH2}
+ * 全局邮件帐户，依赖于邮件配置文件{@link MailAccount#MAIL_SETTING_PATHS}
  * 
  * @author looly
  *
@@ -35,31 +35,13 @@ public enum GlobalMailAccount {
 	 * @return MailAccount
 	 */
 	private MailAccount createDefaultAccount() {
-		MailAccount mailAccount = null;
-		try {
-			mailAccount = new MailAccount(MailAccount.MAIL_SETTING_PATH);
-		} catch (IORuntimeException e) {
-			//ignore
-		}
-		
-		// 寻找config/mailAccount.setting
-		if(null == mailAccount) {
+		for (String mailSettingPath : MailAccount.MAIL_SETTING_PATHS) {
 			try {
-				mailAccount = new MailAccount(MailAccount.MAIL_SETTING_PATH2);
+				return new MailAccount(mailSettingPath);
 			} catch (IORuntimeException e) {
 				//ignore
 			}
 		}
-		
-		// 寻找mail.setting
-		if(null == mailAccount) {
-			try {
-				mailAccount = new MailAccount(MailAccount.MAIL_SETTING_PATH3);
-			} catch (IORuntimeException e) {
-				//ignore
-			}
-		}
-		
-		return mailAccount;
+		return null;
 	}
 }

--- a/hutool-extra/src/main/java/cn/hutool/extra/mail/MailAccount.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/mail/MailAccount.java
@@ -32,9 +32,7 @@ public class MailAccount implements Serializable {
 	private static final String MAIL_DEBUG = "mail.debug";
 	private static final String SPLIT_LONG_PARAMS = "mail.mime.splitlongparameters";
 
-	public static final String MAIL_SETTING_PATH = "config/mail.setting";
-	public static final String MAIL_SETTING_PATH2 = "config/mailAccount.setting";
-	public static final String MAIL_SETTING_PATH3 = "mail.setting";
+	public static final String[] MAIL_SETTING_PATHS = new String[]{"config/mail.setting", "config/mailAccount.setting", "mail.setting"};
 
 	/**
 	 * SMTP服务器域名


### PR DESCRIPTION
#### 说明
全局邮箱账户的初始化分别对三个路径做完全相同的逻辑处理，重复代码较多，如果有新增的配置路径还要原样写一遍初始化逻辑