### PR TITLE
RGB随机颜色的上限值不对且API重复

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/img/ImgUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/img/ImgUtil.java
@@ -61,6 +61,12 @@ public class ImgUtil {
 	public static final String IMAGE_TYPE_BMP = "bmp";// 英文Bitmap（位图）的简写，它是Windows操作系统中的标准图像文件格式
 	public static final String IMAGE_TYPE_PNG = "png";// 可移植网络图形
 	public static final String IMAGE_TYPE_PSD = "psd";// Photoshop的专用格式Photoshop
+	
+	/**
+	 * RGB颜色范围上限
+	 */
+	private static final int RGB_COLOR_BOUND = 256;
+	
 
 	// ---------------------------------------------------------------------------------------------------------------------- scale
 
@@ -1952,7 +1958,7 @@ public class ImgUtil {
 		if (null == random) {
 			random = RandomUtil.getRandom();
 		}
-		return new Color(random.nextInt(255), random.nextInt(255), random.nextInt(255));
+		return new Color(random.nextInt(RGB_COLOR_BOUND), random.nextInt(RGB_COLOR_BOUND), random.nextInt(RGB_COLOR_BOUND));
 	}
 
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/util/RandomUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/RandomUtil.java
@@ -522,10 +522,11 @@ public class RandomUtil {
 	 *
 	 * @return 随机颜色
 	 * @since 4.1.5
+	 * @deprecated 使用{@link ImagUtil#randomColor()}
 	 */
 	public static Color randomColor() {
 		final Random random = getRandom();
-		return new Color(random.nextInt(255), random.nextInt(255), random.nextInt(255));
+		return new Color(random.nextInt(256), random.nextInt(2565), random.nextInt(256));
 	}
 
 	/**


### PR DESCRIPTION
1. RGB中的红绿蓝每种颜色取值范围都是[0,255],代码中都用的`random.nextInt(255)`会导致255一直取拿不到
2. `ImagUtil`和`RandomUtil`中都有`randomColor`方法， 检查了下,`RandomUtil#randomColor`没有使用，而`ImagUtil#randomColor`使用较多，将`RandomUtil#randomColor`标注为废弃,link到`ImagUtil#randomColor`