### PR TITLE
简化CreditCode逻辑

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/CreditCodeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/CreditCodeUtil.java
@@ -98,11 +98,11 @@ public class CreditCodeUtil {
 		}
 		for (int i = 2; i < 8; i++) {
 			int num = RandomUtil.randomInt(10);
-			buf.append(Character.toUpperCase(BASE_CODE_ARRAY[num]));
+			buf.append(BASE_CODE_ARRAY[num]);
 		}
 		for (int i = 8; i < 17; i++) {
 			int num = RandomUtil.randomInt(BASE_CODE_ARRAY.length - 1);
-			buf.append(Character.toUpperCase(BASE_CODE_ARRAY[num]));
+			buf.append(BASE_CODE_ARRAY[num]);
 		}
 
 		final String code = buf.toString();


### PR DESCRIPTION
生成CreditCode的过程中 BASE_CODE_ARRAY中除了数字就只有大写的字符，不需要继续调用`Character.toUpperCase`