### PR TITLE
# 修复CSV 使用在使用UTF8-BOM编码导致字符解析错误

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvParser.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvParser.java
@@ -240,7 +240,11 @@ public final class CsvParser implements Closeable, Serializable {
 					}
 					localCopyStart = localBufPos;
 				} else {
-					copyLen++;
+					if (c == CharUtil.U_FEFF && localBufPos == 1) {
+						++localCopyStart;
+					} else {
+						copyLen++;
+					}
 				}
 			}
 

--- a/hutool-core/src/main/java/cn/hutool/core/util/CharUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/CharUtil.java
@@ -49,6 +49,10 @@ public class CharUtil {
 	public static final char COLON = ':';
 	/** 字符常量：艾特 @ */
 	public static final char AT = '@';
+	/**
+	 * with Bom 前缀
+	 */
+	public static final char U_FEFF = '\uFEFF';
 
 	/**
 	 * 是否为ASCII字符，ASCII字符位于0~127之间

--- a/hutool-core/src/test/resources/test_bean.csv
+++ b/hutool-core/src/test/resources/test_bean.csv
@@ -1,4 +1,4 @@
-姓名,gender,focus,age
+﻿姓名,gender,focus,age
 张三,男,无,33
 李四,男,好对象,23
 王妹妹,女,特别关注,22


### PR DESCRIPTION
 
1. [bug修复] 
CSV mac下使用 UTF8  中文乱码，使用UTF8-BOM ，以\ufff字符开头 导致 字符串对比失败

Corretto-OpenJDK8 MAC
![image](https://user-images.githubusercontent.com/46640269/95673774-6af4b780-0bde-11eb-81ef-4e55b005a129.png)

Corretto-OpenJDK11 MAC
![image](https://user-images.githubusercontent.com/46640269/95673780-721bc580-0bde-11eb-86aa-154ade857707.png)
