### PR TITLE
FIX:#1173 修复子类使用同名属性覆盖了父类的transient属性导致属性transient检测而被忽略

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanDesc.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanDesc.java
@@ -146,7 +146,9 @@ public class BeanDesc implements Serializable {
 			if (false == ModifierUtil.isStatic(field)) {
 				//只针对非static属性
 				prop = createProp(field, methods);
-				this.propMap.put(prop.getFieldName(), prop);
+				PropDesc finalProp = prop;
+				// 只有不存在时才放入，防止父类属性覆盖子类属性
+				this.propMap.putIfAbsent(prop.getFieldName(), finalProp);
 			}
 		}
 		return this;

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
@@ -364,12 +364,26 @@ public class BeanUtilTest {
 
 	@Getter
 	@Setter
-	public static class Person {
+	public static class SubPersonWithOverlayTransientField extends PersonWithTransientField {
+		// 覆盖父类中 transient 属性
 		private String name;
+	}
+
+	@Getter
+	@Setter
+	public static class Person {
+		private  String name;
 		private int age;
 		private String openid;
 	}
 
+	@Getter
+	@Setter
+	public static class PersonWithTransientField {
+		private transient String name;
+		private int age;
+		private String openid;
+	}
 	public static class Person2 {
 
 		public Person2(String name, int age, String openid) {
@@ -381,6 +395,23 @@ public class BeanUtilTest {
 		public String name;
 		public int age;
 		public String openid;
+	}
+
+	/**
+	 * <a href="https://github.com/looly/hutool/issues/1173">#1173</a>
+	 */
+	@Test
+	public void beanToBeanOverlayFieldTest() {
+		SubPersonWithOverlayTransientField source = new SubPersonWithOverlayTransientField();
+		source.setName("zhangsan");
+		source.setAge(20);
+		source.setOpenid("1");
+		SubPersonWithOverlayTransientField dest = new SubPersonWithOverlayTransientField();
+		BeanUtil.copyProperties(source, dest);
+
+		Assert.assertEquals(source.getName(), dest.getName());
+		Assert.assertEquals(source.getAge(), dest.getAge());
+		Assert.assertEquals(source.getOpenid(), dest.getOpenid());
 	}
 
 	@Test


### PR DESCRIPTION
1. [bug修复] #1173 更改获取 class 属性缓存时将 put 方法改为putIfAbsent 防止父类字段覆盖子类字段