### PR TITLE
fix(hutool-http): user-agent 增加企业微信和钉钉. 去除 Browser 中的行尾注释

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
@@ -22,31 +22,36 @@ public class Browser extends UserAgentInfo {
 	/**
 	 * 支持的浏览器类型
 	 */
-	public static final List<Browser> browers = CollUtil.newArrayList(//
-			new Browser("MSEdge", "Edge|Edg", "(?:edge|Edg)\\/([\\d\\w\\.\\-]+)"), //
-			new Browser("Chrome", "chrome", "chrome\\/([\\d\\w\\.\\-]+)"), //
-			new Browser("Firefox", "firefox", Other_Version), //
-			new Browser("IEMobile", "iemobile", Other_Version), //
-			new Browser("Android Browser", "android", "version\\/([\\d\\w\\.\\-]+)"), //
-			new Browser("Safari", "safari", "version\\/([\\d\\w\\.\\-]+)"), //
-			new Browser("Opera", "opera", Other_Version), //
-			new Browser("Konqueror", "konqueror", Other_Version), //
-			new Browser("PS3", "playstation 3", "([\\d\\w\\.\\-]+)\\)\\s*$"), //
-			new Browser("PSP", "playstation portable", "([\\d\\w\\.\\-]+)\\)?\\s*$"), //
-			new Browser("Lotus", "lotus.notes", "Lotus-Notes\\/([\\w.]+)"), //
-			new Browser("Thunderbird", "thunderbird", Other_Version), //
-			new Browser("Netscape", "netscape", Other_Version), //
-			new Browser("Seamonkey", "seamonkey", Other_Version), //
-			new Browser("Outlook", "microsoft.outlook", Other_Version), //
-			new Browser("Evolution", "evolution", Other_Version), //
-			new Browser("MSIE", "msie", "msie ([\\d\\w\\.\\-]+)"), //
-			new Browser("MSIE11", "rv:11", "rv:([\\d\\w\\.\\-]+)"), //
-			new Browser("Gabble", "Gabble", "Gabble\\/([\\d\\w\\.\\-]+)"), //
-			new Browser("Yammer Desktop", "AdobeAir", "([\\d\\w\\.\\-]+)\\/Yammer"), //
-			new Browser("Yammer Mobile", "Yammer[\\s]+([\\d\\w\\.\\-]+)", "Yammer[\\s]+([\\d\\w\\.\\-]+)"), //
-			new Browser("Apache HTTP Client", "Apache\\\\-HttpClient", "Apache\\-HttpClient\\/([\\d\\w\\.\\-]+)"), //
-			new Browser("BlackBerry", "BlackBerry", "BlackBerry[\\d]+\\/([\\d\\w\\.\\-]+)"),//
-			new Browser("MicroMessenger", "MicroMessenger", "MicroMessenger\\/([\\d\\w\\.\\-]+)")//
+	public static final List<Browser> browers = CollUtil.newArrayList(
+			new Browser("MSEdge", "Edge|Edg", "(?:edge|Edg)\\/([\\d\\w\\.\\-]+)"),
+			new Browser("Chrome", "chrome", "chrome\\/([\\d\\w\\.\\-]+)"),
+			new Browser("Firefox", "firefox", Other_Version),
+			new Browser("IEMobile", "iemobile", Other_Version),
+			new Browser("Android Browser", "android", "version\\/([\\d\\w\\.\\-]+)"),
+			new Browser("Safari", "safari", "version\\/([\\d\\w\\.\\-]+)"),
+			new Browser("Opera", "opera", Other_Version),
+			new Browser("Konqueror", "konqueror", Other_Version),
+			new Browser("PS3", "playstation 3", "([\\d\\w\\.\\-]+)\\)\\s*$"),
+			new Browser("PSP", "playstation portable", "([\\d\\w\\.\\-]+)\\)?\\s*$"),
+			new Browser("Lotus", "lotus.notes", "Lotus-Notes\\/([\\w.]+)"),
+			new Browser("Thunderbird", "thunderbird", Other_Version),
+			new Browser("Netscape", "netscape", Other_Version),
+			new Browser("Seamonkey", "seamonkey", Other_Version),
+			new Browser("Outlook", "microsoft.outlook", Other_Version),
+			new Browser("Evolution", "evolution", Other_Version),
+			new Browser("MSIE", "msie", "msie ([\\d\\w\\.\\-]+)"),
+			new Browser("MSIE11", "rv:11", "rv:([\\d\\w\\.\\-]+)"),
+			new Browser("Gabble", "Gabble", "Gabble\\/([\\d\\w\\.\\-]+)"),
+			new Browser("Yammer Desktop", "AdobeAir", "([\\d\\w\\.\\-]+)\\/Yammer"),
+			new Browser("Yammer Mobile", "Yammer[\\s]+([\\d\\w\\.\\-]+)", "Yammer[\\s]+([\\d\\w\\.\\-]+)"),
+			new Browser("Apache HTTP Client", "Apache\\\\-HttpClient", "Apache\\-HttpClient\\/([\\d\\w\\.\\-]+)"),
+			new Browser("BlackBerry", "BlackBerry", "BlackBerry[\\d]+\\/([\\d\\w\\.\\-]+)"),
+			// 企业微信 企业微信使用微信浏览器内核,会包含 MicroMessenger 所以要放在前面
+			new Browser("wxwork", "wxwork", "wxwork\\/([\\d\\w\\.\\-]+)"),
+			// 微信
+			new Browser("MicroMessenger", "MicroMessenger", "MicroMessenger\\/([\\d\\w\\.\\-]+)"),
+			// 钉钉
+			new Browser("DingTalk", "DingTalk", "AliApp\\(DingTalk\\/([\\d\\w\\.\\-]+)\\)")
 	);
 
 	private Pattern versionPattern;

--- a/hutool-http/src/test/java/cn/hutool/http/test/HttpUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/test/HttpUtilTest.java
@@ -4,19 +4,30 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.ReUtil;
+import cn.hutool.core.util.ZipUtil;
 import cn.hutool.http.Header;
 import cn.hutool.http.HttpRequest;
 import cn.hutool.http.HttpUtil;
+import lombok.SneakyThrows;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public class HttpUtilTest {
+	@Test
+	public void utlTest() {
+		File file = new File("/Users/Downloads/test");
+		File zipFile = new File(file, "demo.zip");
+		HttpUtil.downloadFile("http://192.168.6.106:8000/demo.zip", file);
+		ZipUtil.unzip(zipFile);
+	}
 
 	@Test
 	@Ignore

--- a/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
@@ -204,4 +204,30 @@ public class UserAgentUtilTest {
 		Assert.assertEquals("iPhone", ua.getPlatform().toString());
 		Assert.assertTrue(ua.isMobile());
 	}
+
+	@Test
+	public void parseWorkWxTest() {
+		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 wxwork/3.0.31 MicroMessenger/7.0.1 Language/zh";
+		UserAgent ua = UserAgentUtil.parse(uaString);
+		Assert.assertEquals("wxwork", ua.getBrowser().toString());
+		Assert.assertEquals("3.0.31", ua.getVersion());
+		Assert.assertEquals("Webkit", ua.getEngine().toString());
+		Assert.assertEquals("605.1.15", ua.getEngineVersion());
+		Assert.assertEquals("iPhone", ua.getOs().toString());
+		Assert.assertEquals("iPhone", ua.getPlatform().toString());
+		Assert.assertTrue(ua.isMobile());
+	}
+
+	@Test
+	public void parseDingTalkTest() {
+		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/18A373 AliApp(DingTalk/5.1.33) com.laiwang.DingTalk/13976299 Channel/201200 language/zh-Hans-CN WK";
+		UserAgent ua = UserAgentUtil.parse(uaString);
+		Assert.assertEquals("DingTalk", ua.getBrowser().toString());
+		Assert.assertEquals("5.1.33", ua.getVersion());
+		Assert.assertEquals("Webkit", ua.getEngine().toString());
+		Assert.assertEquals("605.1.15", ua.getEngineVersion());
+		Assert.assertEquals("iPhone", ua.getOs().toString());
+		Assert.assertEquals("iPhone", ua.getPlatform().toString());
+		Assert.assertTrue(ua.isMobile());
+	}
 }


### PR DESCRIPTION
1. [bug修复] user-agent 增加企业微信和钉钉支持，用于判断是否可以 OAuth2 自动执行操作
2. [代码格式]  去除 Browser 中的行尾注释