### PR TITLE
Update CsvWriter.java

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvWriter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvWriter.java
@@ -173,6 +173,7 @@ public final class CsvWriter implements Closeable, Flushable, Serializable {
 	 */
 	public CsvWriter write(String[]... lines) throws IORuntimeException {
 		if (ArrayUtil.isNotEmpty(lines)) {
+			appendBomInfo();
 			for (final String[] values : lines) {
 				appendLine(values);
 			}
@@ -190,12 +191,17 @@ public final class CsvWriter implements Closeable, Flushable, Serializable {
 	 */
 	public CsvWriter write(Collection<?> lines) throws IORuntimeException {
 		if (CollUtil.isNotEmpty(lines)) {
+			appendBomInfo();
 			for (Object values : lines) {
 				appendLine(Convert.toStrArray(values));
 			}
 			flush();
 		}
 		return this;
+	}
+	
+	private void appendBomInfo(){
+		appendLine(new String(new byte[] { (byte) 0xEF, (byte) 0xBB,(byte) 0xBF }));
 	}
 
 	/**


### PR DESCRIPTION
修复问题：CVS写入中文，用excel打开时，中文乱码
解决方案：添加bom头

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复还是新特性添加)

1. [bug修复] CVS写入中文，用excel打开时，中文乱码，将BOM头写入