### PR TITLE
[新特性]反射调用支持传递参数的值为null

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/NullWrapperBean.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/NullWrapperBean.java
@@ -1,0 +1,20 @@
+package cn.hutool.core.bean;
+
+/**
+ * 为了解决反射过程中,需要传递null参数,但是会丢失参数类型而设立的包装类
+ */
+public class NullWrapperBean {
+
+    private final Class<?> mClasses;
+
+    /**
+     * @param classes null的类型
+     */
+    public NullWrapperBean(Class<?> classes) {
+        this.mClasses = classes;
+    }
+
+    public Class<?> getClasses() {
+        return mClasses;
+    }
+}

--- a/hutool-core/src/main/java/cn/hutool/core/util/ClassUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ClassUtil.java
@@ -1,5 +1,6 @@
 package cn.hutool.core.util;
 
+import cn.hutool.core.bean.NullWrapperBean;
 import cn.hutool.core.convert.BasicType;
 import cn.hutool.core.exceptions.UtilException;
 import cn.hutool.core.io.FileUtil;
@@ -139,15 +140,21 @@ public class ClassUtil {
 	 * @param objects 对象数组，如果数组中存在{@code null}元素，则此元素被认为是Object类型
 	 * @return 类数组
 	 */
-	public static Class<?>[] getClasses(Object... objects) {
-		Class<?>[] classes = new Class<?>[objects.length];
-		Object obj;
-		for (int i = 0; i < objects.length; i++) {
-			obj = objects[i];
-			classes[i] = (null == obj) ? Object.class : obj.getClass();
-		}
-		return classes;
-	}
+    public static Class<?>[] getClasses(Object... objects) {
+        Class<?>[] classes = new Class<?>[objects.length];
+        Object obj;
+        for (int i = 0; i < objects.length; i++) {
+            obj = objects[i];
+            if (obj instanceof NullWrapperBean) {
+                classes[i] = ((NullWrapperBean) obj).getClasses();
+            } else if (null == obj) {
+                classes[i] = Object.class;
+            } else {
+                classes[i] = obj.getClass();
+            }
+        }
+        return classes;
+    }
 
 	/**
 	 * 指定类是否与给定的类名相同


### PR DESCRIPTION
增加对null参数传递的支持,在传递null参数保持类型信息不丢失

PR之前通过methodName反射调用时，如果需要传null的参数，会被转为Object，造成方法找不到。
通过NullWrapperBean对null参数进行包装，保留了参数的类型信息。