### PR TITLE
修改使用xml.setXmlStandalone(true)设定属性后，父节点格式化位置不对。

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/XmlUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/XmlUtil.java
@@ -587,6 +587,7 @@ public class XmlUtil {
 			final Transformer xformer = factory.newTransformer();
 			if (indent > 0) {
 				xformer.setOutputProperty(OutputKeys.INDENT, "yes");
+				xformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "yes");
 				xformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", String.valueOf(indent));
 			}
 			if (StrUtil.isNotBlank(charset)) {


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复还是新特性添加)

1. [bug修复] 修改使用xml.setXmlStandalone(true)设定属性后，父节点格式化位置不对。
[关于XmlUtil.toStr(xml,"GBK",true)方法格式化美化不完美问题 #1232](https://github.com/looly/hutool/issues/1232)
