### PR TITLE
Fix flaky test in EnumUtilTest

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
@@ -30,7 +30,8 @@ public class EnumUtilTest {
 	@Test
 	public void getFieldNamesTest() {
 		List<String> names = EnumUtil.getFieldNames(TestEnum.class);
-		Assert.assertEquals(CollUtil.newArrayList("type", "name"), names);
+		Assert.assertTrue(names.contains("type"));
+		Assert.assertTrue(names.contains("name"));
 	}
 	
 	@Test


### PR DESCRIPTION
#### 修改描述
1. [bug修复] 

- 修复EnumUtilTest.java内存在的Flaky test (Fixed flaky test that caused by EnumUtilTest.java under hutool-core)

- `getFieldNamesTest`这个测试的问题在于: 它最终调用了[`java.lang.Class.getDeclaredFields`](https://github.com/looly/hutool/blob/v5-master/hutool-core/src/main/java/cn/hutool/core/util/ReflectUtil.java#L206)。该方法所返回的数组的顺序是[不确定的(Non-Deterministic)](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/lang/Class.java#l1870)，因此每次运行的测试结果可能不一致。

- 这一flaky test是由工具[NonDex](https://github.com/TestingResearchIllinois/NonDex)检测到的。