### PR TITLE
optimize: exclude all `pom.xml` from `hutool-all.jar`

### DIFF
--- a/hutool-all/pom.xml
+++ b/hutool-all/pom.xml
@@ -130,6 +130,14 @@
 									<include>${project.groupId}:*:*</include>
 								</includes>
 							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/maven/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [优化] 生成hutool-all.jar时，将各模块的pom.xml排除掉，减小jar包的大小。