### PR TITLE
缓存降低锁的粒度，提高并发能力

### DIFF
--- a/hutool-cache/src/test/java/cn/hutool/cache/test/CacheConcurrentTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/test/CacheConcurrentTest.java
@@ -3,14 +3,19 @@ package cn.hutool.cache.test;
 import cn.hutool.cache.Cache;
 import cn.hutool.cache.impl.FIFOCache;
 import cn.hutool.cache.impl.LRUCache;
+import cn.hutool.cache.impl.WeakCache;
 import cn.hutool.core.lang.Console;
+import cn.hutool.core.thread.ConcurrencyTester;
 import cn.hutool.core.thread.ThreadUtil;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * 缓存单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -46,7 +51,7 @@ public class CacheConcurrentTest {
 		System.out.println("==============================");
 		ThreadUtil.sleep(10000);
 	}
-	
+
 	@Test
 	@Ignore
 	public void lruCacheTest() {
@@ -72,7 +77,7 @@ public class CacheConcurrentTest {
 				}
 			});
 		}
-		
+
 		ThreadUtil.sleep(5000);
 	}
 
@@ -81,5 +86,23 @@ public class CacheConcurrentTest {
 		for (Object tt : cache) {
 			Console.log(tt);
 		}
+	}
+
+	@Test
+	public void effectiveTest() {
+		// 模拟耗时操作消耗时间
+		int delay = 2000;
+		AtomicInteger ai = new AtomicInteger(0);
+		WeakCache<Integer, Integer> weakCache = new WeakCache<>(60 * 1000);
+		ConcurrencyTester concurrencyTester = ThreadUtil.concurrencyTest(32, () -> {
+			int i = ai.incrementAndGet() % 4;
+			weakCache.get(i, () -> {
+				ThreadUtil.sleep(delay);
+				return i;
+			});
+		});
+		long interval = concurrencyTester.getInterval();
+		// 总耗时应与单词操作耗时在同一个数量级
+		Assert.assertTrue(interval < delay * 2);
 	}
 }

--- a/hutool-cache/src/test/java/cn/hutool/cache/test/CacheConcurrentTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/test/CacheConcurrentTest.java
@@ -102,7 +102,7 @@ public class CacheConcurrentTest {
 			});
 		});
 		long interval = concurrencyTester.getInterval();
-		// 总耗时应与单词操作耗时在同一个数量级
+		// 总耗时应与单次操作耗时在同一个数量级
 		Assert.assertTrue(interval < delay * 2);
 	}
 }


### PR DESCRIPTION
### 说明
1. [问题] 缓存的get并传入supplier参数方法，一般来说supplier为耗时方法，若不耗时也没什么必要做缓存，原本在写的时候将supplier一起锁在了里面，并发效率极低。
2. [解决]  现在为每个key获取一个lock，不同key进来的时候可以并发执行supplier.call()，提高并发效率