### PR TITLE
[cleanup] erefactor/EclipseJdt - Use diamond operator

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/builder/HashCodeBuilder.java
+++ b/hutool-core/src/main/java/cn/hutool/core/builder/HashCodeBuilder.java
@@ -103,7 +103,7 @@ public class HashCodeBuilder implements Builder<Integer> {
      *
      * @since 2.3
      */
-    private static final ThreadLocal<Set<IDKey>> REGISTRY = new ThreadLocal<Set<IDKey>>();
+    private static final ThreadLocal<Set<IDKey>> REGISTRY = new ThreadLocal<>();
 
     /*
      * NOTE: we cannot store the actual objects in a HashSet, as that would use the very hashCode()

--- a/hutool-json/src/test/java/cn/hutool/json/test/bean/report/CaseReport.java
+++ b/hutool-json/src/test/java/cn/hutool/json/test/bean/report/CaseReport.java
@@ -14,7 +14,7 @@ public class CaseReport {
 	/**
 	 * 包含的测试步骤报告
 	 */
-	private List<StepReport> stepReports = new ArrayList<StepReport>();
+	private List<StepReport> stepReports = new ArrayList<>();
 	
 	public List<StepReport> getStepReports() {
 		return stepReports;

--- a/hutool-json/src/test/java/cn/hutool/json/test/bean/report/SuiteReport.java
+++ b/hutool-json/src/test/java/cn/hutool/json/test/bean/report/SuiteReport.java
@@ -14,7 +14,7 @@ public class SuiteReport {
 	/**
 	 * 包含的用例测试报告
 	 */
-	private List<CaseReport> caseReports = new ArrayList<CaseReport>();
+	private List<CaseReport> caseReports = new ArrayList<>();
 	
 	public List<CaseReport> getCaseReports() {
 		return caseReports;


### PR DESCRIPTION
Looking for some challenges for the erefactor continuous maintenance pipeline
I found  your interesting hutool project.
You may be interested in some of the results of applying the pipeline.

It would be nice if the hutool build script would set up the environment needed for executing the tests.
I found out that TZ="Asia/Shanghai" was needed for some tests but could not find out how to make CollUtilTest pass.

So I had to disable it with -Dtest=\!CollUtilTest*.


EclipseJdt cleanup 'UseDiamondOperator' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.18/jdt.php
For erefactor see https://github.com/cal101/erefactor
