### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unused imports

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/PhoneUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/PhoneUtil.java
@@ -3,8 +3,6 @@ package cn.hutool.core.util;
 import cn.hutool.core.lang.PatternPool;
 import cn.hutool.core.lang.Validator;
 
-import java.util.regex.Pattern;
-
 
 /**
  * 手机号工具类

--- a/hutool-core/src/test/java/cn/hutool/core/codec/BCDTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/BCDTest.java
@@ -3,8 +3,6 @@ package cn.hutool.core.codec;
 import org.junit.Assert;
 import org.junit.Test;
 
-import cn.hutool.core.codec.BCD;
-
 public class BCDTest {
 	
 	@Test

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertOtherTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertOtherTest.java
@@ -5,7 +5,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Test;
 
-import cn.hutool.core.convert.Convert;
 import cn.hutool.core.util.CharsetUtil;
 
 /**

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConverterRegistryTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConverterRegistryTest.java
@@ -3,9 +3,6 @@ package cn.hutool.core.convert;
 import org.junit.Assert;
 import org.junit.Test;
 
-import cn.hutool.core.convert.Converter;
-import cn.hutool.core.convert.ConverterRegistry;
-
 /**
  * ConverterRegistry 单元测试
  * @author Looly

--- a/hutool-db/src/test/java/cn/hutool/db/EntityTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/EntityTest.java
@@ -3,7 +3,6 @@ package cn.hutool.db;
 import org.junit.Assert;
 import org.junit.Test;
 
-import cn.hutool.db.Entity;
 import cn.hutool.db.pojo.User;
 
 /**

--- a/hutool-db/src/test/java/cn/hutool/db/PostgreTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/PostgreTest.java
@@ -6,10 +6,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import cn.hutool.core.lang.Console;
-import cn.hutool.db.Db;
-import cn.hutool.db.Entity;
-import cn.hutool.db.Page;
-import cn.hutool.db.PageResult;
 
 /**
  * PostgreSQL 单元测试

--- a/hutool-db/src/test/java/cn/hutool/db/SqlServerTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/SqlServerTest.java
@@ -6,10 +6,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import cn.hutool.core.lang.Console;
-import cn.hutool.db.Db;
-import cn.hutool.db.Entity;
-import cn.hutool.db.Page;
-import cn.hutool.db.PageResult;
 
 /**
  * SQL Server操作单元测试

--- a/hutool-http/src/test/java/cn/hutool/http/DownloadTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/DownloadTest.java
@@ -4,8 +4,6 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IORuntimeException;
 import cn.hutool.core.io.StreamProgress;
 import cn.hutool.core.lang.Console;
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpUtil;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;

--- a/hutool-http/src/test/java/cn/hutool/http/HtmlUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HtmlUtilTest.java
@@ -3,8 +3,6 @@ package cn.hutool.http;
 import org.junit.Assert;
 import org.junit.Test;
 
-import cn.hutool.http.HtmlUtil;
-
 /**
  * Html单元测试
  * 

--- a/hutool-http/src/test/java/cn/hutool/http/HttpsTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpsTest.java
@@ -2,7 +2,6 @@ package cn.hutool.http;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ThreadUtil;
-import cn.hutool.http.HttpUtil;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/hutool-http/src/test/java/cn/hutool/http/RestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/RestTest.java
@@ -1,9 +1,6 @@
 package cn.hutool.http;
 
 import cn.hutool.core.lang.Console;
-import cn.hutool.http.Header;
-import cn.hutool.http.HttpRequest;
-import cn.hutool.http.HttpUtil;
 import cn.hutool.json.JSONUtil;
 import org.junit.Assert;
 import org.junit.Ignore;

--- a/hutool-poi/src/main/java/cn/hutool/poi/word/TableUtil.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/word/TableUtil.java
@@ -5,7 +5,6 @@ import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.IterUtil;
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.lang.Assert;
-import cn.hutool.core.lang.Console;
 import cn.hutool.core.map.MapUtil;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFTable;


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnusedImport' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.18/jdt.php
For erefactor see https://github.com/cal101/erefactor
