### PR TITLE
Cache.put()方法添加TimeUnit时间单位✒️

### DIFF
--- a/hutool-cache/src/main/java/cn/hutool/cache/Cache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/Cache.java
@@ -55,7 +55,7 @@ public interface Cache<K, V> extends Iterable<V>, Serializable {
 	 *
 	 * @param key     键
 	 * @param object  缓存的对象
-	 * @param timeout 失效时长，单位毫秒
+	 * @param timeout 失效时长
 	 * @param timeUnit 时长单位
 	 * @since 5.5.9
 	 */

--- a/hutool-cache/src/main/java/cn/hutool/cache/Cache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/Cache.java
@@ -5,6 +5,7 @@ import cn.hutool.core.lang.func.Func0;
 
 import java.io.Serializable;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 缓存接口
@@ -47,6 +48,20 @@ public interface Cache<K, V> extends Iterable<V>, Serializable {
 	 * @param timeout 失效时长，单位毫秒
 	 */
 	void put(K key, V object, long timeout);
+
+	/**
+	 * 将对象加入到缓存，使用指定失效时长<br>
+	 * 如果缓存空间满了，{@link #prune()} 将被调用以获得空间来存放新对象
+	 *
+	 * @param key     键
+	 * @param object  缓存的对象
+	 * @param timeout 失效时长，单位毫秒
+	 * @param timeUnit 时长单位
+	 * @since 5.5.9
+	 */
+	default void put(K key, V object, Number timeout, TimeUnit timeUnit){
+		put(key,object,timeUnit.toMillis(timeout.longValue()));
+	}
 
 	/**
 	 * 从缓存中获得对象，当对象不在缓存中或已经过期返回{@code null}

--- a/hutool-cache/src/main/java/cn/hutool/cache/CacheUtil.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/CacheUtil.java
@@ -7,16 +7,18 @@ import cn.hutool.cache.impl.NoCache;
 import cn.hutool.cache.impl.TimedCache;
 import cn.hutool.cache.impl.WeakCache;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * 缓存工具类
  * @author Looly
  *@since 3.0.1
  */
 public class CacheUtil {
-	
+
 	/**
 	 * 创建FIFO(first in first out) 先进先出缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param capacity 容量
@@ -26,10 +28,10 @@ public class CacheUtil {
 	public static <K, V> FIFOCache<K, V> newFIFOCache(int capacity, long timeout){
 		return new FIFOCache<>(capacity, timeout);
 	}
-	
+
 	/**
 	 * 创建FIFO(first in first out) 先进先出缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param capacity 容量
@@ -38,10 +40,10 @@ public class CacheUtil {
 	public static <K, V> FIFOCache<K, V> newFIFOCache(int capacity){
 		return new FIFOCache<>(capacity);
 	}
-	
+
 	/**
 	 * 创建LFU(least frequently used) 最少使用率缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param capacity 容量
@@ -51,10 +53,10 @@ public class CacheUtil {
 	public static <K, V> LFUCache<K, V> newLFUCache(int capacity, long timeout){
 		return new LFUCache<>(capacity, timeout);
 	}
-	
+
 	/**
 	 * 创建LFU(least frequently used) 最少使用率缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param capacity 容量
@@ -63,11 +65,11 @@ public class CacheUtil {
 	public static <K, V> LFUCache<K, V> newLFUCache(int capacity){
 		return new LFUCache<>(capacity);
 	}
-	
-	
+
+
 	/**
 	 * 创建LRU (least recently used)最近最久未使用缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param capacity 容量
@@ -77,10 +79,10 @@ public class CacheUtil {
 	public static <K, V> LRUCache<K, V> newLRUCache(int capacity, long timeout){
 		return new LRUCache<>(capacity, timeout);
 	}
-	
+
 	/**
 	 * 创建LRU (least recently used)最近最久未使用缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param capacity 容量
@@ -89,10 +91,10 @@ public class CacheUtil {
 	public static <K, V> LRUCache<K, V> newLRUCache(int capacity){
 		return new LRUCache<>(capacity);
 	}
-	
+
 	/**
 	 * 创建定时缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param timeout 过期时长，单位：毫秒
@@ -101,10 +103,24 @@ public class CacheUtil {
 	public static <K, V> TimedCache<K, V> newTimedCache(long timeout){
 		return new TimedCache<>(timeout);
 	}
-	
+
+	/**
+	 * 创建定时缓存.
+	 *
+	 * @param <K> Key类型
+	 * @param <V> Value类型
+	 * @param timeout 过期时长
+	 * @param timeUnit 时长单位
+	 * @since 5.5.9
+	 * @return {@link TimedCache}
+	 */
+	public static <K, V> TimedCache<K, V> newTimedCache(Number timeout, TimeUnit timeUnit){
+		return new TimedCache<>(timeUnit.toMillis(timeout.longValue()));
+	}
+
 	/**
 	 * 创建弱引用缓存.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @param timeout 过期时长，单位：毫秒
@@ -114,10 +130,10 @@ public class CacheUtil {
 	public static <K, V> WeakCache<K, V> newWeakCache(long timeout){
 		return new WeakCache<>(timeout);
 	}
-	
+
 	/**
 	 * 创建无缓存实现.
-	 * 
+	 *
 	 * @param <K> Key类型
 	 * @param <V> Value类型
 	 * @return {@link NoCache}

--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/TimedCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/TimedCache.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 定时缓存<br>
@@ -29,6 +30,17 @@ public class TimedCache<K, V> extends AbstractCache<K, V> {
 	 */
 	public TimedCache(long timeout) {
 		this(timeout, new HashMap<>());
+	}
+
+	/**
+	 * 构造
+	 *
+	 * @param timeout 超时（过期）时长
+	 * @param timeUnit 时长单位
+	 * @since 5.5.9
+	 */
+	public TimedCache(Number timeout, TimeUnit timeUnit) {
+		this(timeUnit.toMillis(timeout.longValue()), new HashMap<>());
 	}
 
 	/**

--- a/hutool-cache/src/test/java/cn/hutool/cache/test/CacheTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/test/CacheTest.java
@@ -8,13 +8,15 @@ import cn.hutool.core.thread.ThreadUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * 缓存测试用例
  * @author Looly
  *
  */
 public class CacheTest {
-	
+
 	@Test
 	public void fifoCacheTest(){
 		Cache<String,String> fifoCache = CacheUtil.newFIFOCache(3);
@@ -28,22 +30,22 @@ public class CacheTest {
 		fifoCache.put("key2", "value2", DateUnit.SECOND.getMillis() * 3);
 		fifoCache.put("key3", "value3", DateUnit.SECOND.getMillis() * 3);
 		fifoCache.put("key4", "value4", DateUnit.SECOND.getMillis() * 3);
-		
+
 		//由于缓存容量只有3，当加入第四个元素的时候，根据FIFO规则，最先放入的对象将被移除
 		String value1 = fifoCache.get("key1");
 		Assert.assertNull(value1);
 	}
-	
+
 	@Test
 	public void lfuCacheTest(){
 		Cache<String, String> lfuCache = CacheUtil.newLFUCache(3);
 		lfuCache.put("key1", "value1", DateUnit.SECOND.getMillis() * 3);
 		//使用次数+1
-		lfuCache.get("key1"); 
+		lfuCache.get("key1");
 		lfuCache.put("key2", "value2", DateUnit.SECOND.getMillis() * 3);
 		lfuCache.put("key3", "value3", DateUnit.SECOND.getMillis() * 3);
 		lfuCache.put("key4", "value4", DateUnit.SECOND.getMillis() * 3);
-		
+
 		//由于缓存容量只有3，当加入第四个元素的时候，根据LFU规则，最少使用的将被移除（2,3被移除）
 		String value1 = lfuCache.get("key1");
 		String value2 = lfuCache.get("key2");
@@ -52,7 +54,7 @@ public class CacheTest {
 		Assert.assertNull(value2);
 		Assert.assertNull(value3);
 	}
-	
+
 	@Test
 	public void lruCacheTest(){
 		Cache<String, String> lruCache = CacheUtil.newLRUCache(3);
@@ -71,7 +73,7 @@ public class CacheTest {
 		String value2 = lruCache.get("key2");
 		Assert.assertNull(value2);
 	}
-	
+
 	@Test
 	public void timedCacheTest(){
 		TimedCache<String, String> timedCache = CacheUtil.newTimedCache(4);
@@ -80,30 +82,45 @@ public class CacheTest {
 		timedCache.put("key2", "value2", DateUnit.SECOND.getMillis() * 5);//5秒过期
 		timedCache.put("key3", "value3");//默认过期(4毫秒)
 		timedCache.put("key4", "value4", Long.MAX_VALUE);//永不过期
-		
+
 		//启动定时任务，每5毫秒秒检查一次过期
 		timedCache.schedulePrune(5);
 		//等待5毫秒
 		ThreadUtil.sleep(5);
-		
+
 		//5毫秒后由于value2设置了5毫秒过期，因此只有value2被保留下来
 		String value1 = timedCache.get("key1");
 		Assert.assertNull(value1);
 		String value2 = timedCache.get("key2");
 		Assert.assertEquals("value2", value2);
-		
+
 		//5毫秒后，由于设置了默认过期，key3只被保留4毫秒，因此为null
 		String value3 = timedCache.get("key3");
 		Assert.assertNull(value3);
-		
+
 		String value3Supplier = timedCache.get("key3", () -> "Default supplier");
 		Assert.assertEquals("Default supplier", value3Supplier);
-		
+
 		// 永不过期
 		String value4 = timedCache.get("key4");
 		Assert.assertEquals("value4", value4);
-		
+
 		//取消定时清理
 		timedCache.cancelPruneSchedule();
 	}
+
+	@Test
+	public void cacheTimeUnitTest(){
+		//默认过期(5毫秒)
+		TimedCache<String, String> timedCache = CacheUtil.newTimedCache(5);
+
+		//设置有效期为1毫秒
+		timedCache.put("key1", "value1",1, TimeUnit.MILLISECONDS);
+
+		//等待2毫秒
+		ThreadUtil.sleep(2, TimeUnit.MILLISECONDS);
+
+		Assert.assertNull(timedCache.get("key1"));
+	}
+
 }

--- a/hutool-cache/src/test/java/cn/hutool/cache/test/CacheTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/test/CacheTest.java
@@ -112,7 +112,21 @@ public class CacheTest {
 	@Test
 	public void cacheTimeUnitTest(){
 		//默认过期(5毫秒)
-		TimedCache<String, String> timedCache = CacheUtil.newTimedCache(5);
+		TimedCache<String, String> timedCache = CacheUtil.newTimedCache(5,TimeUnit.MILLISECONDS);
+
+		//设置有效期为1毫秒
+		timedCache.put("key1", "value1",1, TimeUnit.MILLISECONDS);
+
+		//等待2毫秒
+		ThreadUtil.sleep(2, TimeUnit.MILLISECONDS);
+
+		Assert.assertNull(timedCache.get("key1"));
+	}
+
+	@Test
+	public void timeCacheTimeUnitTest(){
+		//默认过期(5毫秒)
+		TimedCache<String, String> timedCache = new TimedCache<>(5,TimeUnit.MILLISECONDS);
 
 		//设置有效期为1毫秒
 		timedCache.put("key1", "value1",1, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
Cache.Java
```java
        /**
	 * 将对象加入到缓存，使用指定失效时长<br>
	 * 如果缓存空间满了，{@link #prune()} 将被调用以获得空间来存放新对象
	 *
	 * @param key     键
	 * @param object  缓存的对象
	 * @param timeout 失效时长，单位毫秒
	 * @param timeUnit 时长单位
	 * @since 5.5.9
	 */
	default void put(K key, V object, Number timeout, TimeUnit timeUnit){
		put(key,object,timeUnit.toMillis(timeout.longValue()));
	}
```
CacheTest.Java
```java
	@Test
	public void cacheTimeUnitTest(){
		//默认过期(5毫秒)
		TimedCache<String, String> timedCache = CacheUtil.newTimedCache(5);

		//设置有效期为1毫秒
		timedCache.put("key1", "value1",1, TimeUnit.MILLISECONDS);

		//等待2毫秒
		ThreadUtil.sleep(2, TimeUnit.MILLISECONDS);

		Assert.assertNull(timedCache.get("key1"));
	}
```