### PR TITLE
fix FileTypeUtil

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
@@ -5,7 +5,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import cn.hutool.core.util.StrUtil;
 
@@ -23,7 +23,15 @@ public class FileTypeUtil {
 	private static final Map<String, String> FILE_TYPE_MAP;
 
 	static {
-		FILE_TYPE_MAP = new ConcurrentHashMap<>();
+		FILE_TYPE_MAP = new ConcurrentSkipListMap<>((s1, s2) -> {
+			int len1 = s1.length();
+			int len2 = s2.length();
+			if (len1 == len2) {
+				return s1.compareTo(s2);
+			} else {
+				return len2 - len1;
+			}
+		});
 
 		FILE_TYPE_MAP.put("ffd8ff", "jpg"); // JPEG (jpg)
 		FILE_TYPE_MAP.put("89504e47", "png"); // PNG (png)
@@ -50,22 +58,23 @@ public class FileTypeUtil {
 		FILE_TYPE_MAP.put("52494646e27807005741", "wav"); // Wave (wav)
 		FILE_TYPE_MAP.put("52494646d07d60074156", "avi");
 		FILE_TYPE_MAP.put("4d546864000000060001", "mid"); // MIDI (mid)
-		FILE_TYPE_MAP.put("526172211a0700cf9073", "rar");// WinRAR
+		FILE_TYPE_MAP.put("526172211a0700cf9073", "rar"); // WinRAR
 		FILE_TYPE_MAP.put("235468697320636f6e66", "ini");
+		FILE_TYPE_MAP.put("504B0304140000000800", "odf"); // ofd文件 国标版式文件
 		FILE_TYPE_MAP.put("504B03040a0000000000", "jar");
 		FILE_TYPE_MAP.put("504B0304140008000800", "jar");
 		// MS Excel 注意：word、msi 和 excel的文件头一样
 		FILE_TYPE_MAP.put("d0cf11e0a1b11ae10", "xls");
 		FILE_TYPE_MAP.put("504B0304", "zip");
-		FILE_TYPE_MAP.put("4d5a9000030000000400", "exe");// 可执行文件
-		FILE_TYPE_MAP.put("3c25402070616765206c", "jsp");// jsp文件
-		FILE_TYPE_MAP.put("4d616e69666573742d56", "mf");// MF文件
-		FILE_TYPE_MAP.put("7061636b616765207765", "java");// java文件
-		FILE_TYPE_MAP.put("406563686f206f66660d", "bat");// bat文件
-		FILE_TYPE_MAP.put("1f8b0800000000000000", "gz");// gz文件
-		FILE_TYPE_MAP.put("cafebabe0000002e0041", "class");// bat文件
-		FILE_TYPE_MAP.put("49545346030000006000", "chm");// bat文件
-		FILE_TYPE_MAP.put("04000000010000001300", "mxp");// bat文件
+		FILE_TYPE_MAP.put("4d5a9000030000000400", "exe"); // 可执行文件
+		FILE_TYPE_MAP.put("3c25402070616765206c", "jsp"); // jsp文件
+		FILE_TYPE_MAP.put("4d616e69666573742d56", "mf"); // MF文件
+		FILE_TYPE_MAP.put("7061636b616765207765", "java"); // java文件
+		FILE_TYPE_MAP.put("406563686f206f66660d", "bat"); // bat文件
+		FILE_TYPE_MAP.put("1f8b0800000000000000", "gz"); // gz文件
+		FILE_TYPE_MAP.put("cafebabe0000002e0041", "class"); // class文件
+		FILE_TYPE_MAP.put("49545346030000006000", "chm"); // chm文件
+		FILE_TYPE_MAP.put("04000000010000001300", "mxp"); // mxp文件
 		FILE_TYPE_MAP.put("6431303a637265617465", "torrent");
 		FILE_TYPE_MAP.put("6D6F6F76", "mov"); // Quicktime (mov)
 		FILE_TYPE_MAP.put("FF575043", "wpd"); // WordPerfect (wpd)
@@ -85,7 +94,7 @@ public class FileTypeUtil {
 	 * @return 之前已经存在的文件扩展名
 	 */
 	public static String putFileType(String fileStreamHexHead, String extName) {
-		return FILE_TYPE_MAP.put(fileStreamHexHead.toLowerCase(), extName);
+		return FILE_TYPE_MAP.put(fileStreamHexHead, extName);
 	}
 
 	/**
@@ -95,7 +104,7 @@ public class FileTypeUtil {
 	 * @return 移除的文件扩展名
 	 */
 	public static String removeFileType(String fileStreamHexHead) {
-		return FILE_TYPE_MAP.remove(fileStreamHexHead.toLowerCase());
+		return FILE_TYPE_MAP.remove(fileStreamHexHead);
 	}
 
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
@@ -60,7 +60,7 @@ public class FileTypeUtil {
 		FILE_TYPE_MAP.put("4d546864000000060001", "mid"); // MIDI (mid)
 		FILE_TYPE_MAP.put("526172211a0700cf9073", "rar"); // WinRAR
 		FILE_TYPE_MAP.put("235468697320636f6e66", "ini");
-		FILE_TYPE_MAP.put("504B0304140000000800", "odf"); // ofd文件 国标版式文件
+		FILE_TYPE_MAP.put("504B0304140000000800", "ofd"); // ofd文件 国标版式文件
 		FILE_TYPE_MAP.put("504B03040a0000000000", "jar");
 		FILE_TYPE_MAP.put("504B0304140008000800", "jar");
 		// MS Excel 注意：word、msi 和 excel的文件头一样

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileTypeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileTypeUtilTest.java
@@ -53,7 +53,7 @@ public class FileTypeUtilTest {
 		Console.log(hex);
 		String type = FileTypeUtil.getType(file);
 		Console.log(type);
-		Assert.assertEquals("odf", type);
+		Assert.assertEquals("ofd", type);
 	}
 
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileTypeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileTypeUtilTest.java
@@ -6,6 +6,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 文件类型判断单元测试
@@ -13,19 +16,19 @@ import java.io.File;
  *
  */
 public class FileTypeUtilTest {
-	
+
 	@Test
 	@Ignore
 	public void fileTypeUtilTest() {
 		File file = FileUtil.file("hutool.jpg");
 		String type = FileTypeUtil.getType(file);
 		Assert.assertEquals("jpg", type);
-		
+
 		FileTypeUtil.putFileType("ffd8ffe000104a464946", "new_jpg");
 		String newType = FileTypeUtil.getType(file);
 		Assert.assertEquals("new_jpg", newType);
 	}
-	
+
 	@Test
 	@Ignore
 	public void emptyTest() {
@@ -41,4 +44,16 @@ public class FileTypeUtilTest {
 		String type = FileTypeUtil.getType(file);
 		Console.log(type);
 	}
+
+	@Test
+	@Ignore
+	public void ofdTest() {
+		File file = FileUtil.file("e:/test.ofd");
+		String hex = IoUtil.readHex28Upper(FileUtil.getInputStream(file));
+		Console.log(hex);
+		String type = FileTypeUtil.getType(file);
+		Console.log(type);
+		Assert.assertEquals("odf", type);
+	}
+
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)
1、修改了 FileTypeUtil 的私有属性 FILE_TYPE_MAP 的类型为 ConcurrentSkipListMap 并自定义了排序规则，先按长度排序若长度相等按 String,compareTo 排序，原因是 getType 方法应该按较长的前缀优先匹配
2、修改了 FileTypeUtil 的 putFileType、removeFileType 方法，去掉 toLowerCase，让使用者可以操作包含大写的内置文件类型
3、增加了 ofd 格式的文件类型判断
4、修改了部分错误注释
5、增加了 ofd 格式的单元测试