### PR TITLE
fix: LinKedMap特性丢失

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/map/CamelCaseLinkedMap.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/CamelCaseLinkedMap.java
@@ -1,19 +1,21 @@
 package cn.hutool.core.map;
 
+import cn.hutool.core.util.StrUtil;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * 驼峰Key风格的LinkedHashMap<br>
  * 对KEY转换为驼峰，get("int_value")和get("intValue")获得的值相同，put进入的值也会被覆盖
- * 
+ *
  * @author Looly
  *
  * @param <K> 键类型
  * @param <V> 值类型
  * @since 4.0.7
  */
-public class CamelCaseLinkedMap<K, V> extends CamelCaseMap<K, V> {
+public class CamelCaseLinkedMap<K, V> extends CustomKeyMap<K, V> {
 	private static final long serialVersionUID = 4043263744224569870L;
 
 	// ------------------------------------------------------------------------- Constructor start
@@ -26,7 +28,7 @@ public class CamelCaseLinkedMap<K, V> extends CamelCaseMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param initialCapacity 初始大小
 	 */
 	public CamelCaseLinkedMap(int initialCapacity) {
@@ -35,7 +37,7 @@ public class CamelCaseLinkedMap<K, V> extends CamelCaseMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param m Map
 	 */
 	public CamelCaseLinkedMap(Map<? extends K, ? extends V> m) {
@@ -44,7 +46,7 @@ public class CamelCaseLinkedMap<K, V> extends CamelCaseMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param loadFactor 加载因子
 	 * @param m Map
 	 */
@@ -55,7 +57,7 @@ public class CamelCaseLinkedMap<K, V> extends CamelCaseMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param initialCapacity 初始大小
 	 * @param loadFactor 加载因子
 	 */
@@ -63,4 +65,18 @@ public class CamelCaseLinkedMap<K, V> extends CamelCaseMap<K, V> {
 		super(new LinkedHashMap<>(initialCapacity, loadFactor));
 	}
 	// ------------------------------------------------------------------------- Constructor end
+
+	/**
+	 * 将Key转为驼峰风格，如果key为字符串的话
+	 *
+	 * @param key KEY
+	 * @return 驼峰Key
+	 */
+	@Override
+	protected Object customKey(Object key) {
+		if (key instanceof CharSequence) {
+			key = StrUtil.toCamelCase(key.toString());
+		}
+		return key;
+	}
 }

--- a/hutool-core/src/main/java/cn/hutool/core/map/CaseInsensitiveLinkedMap.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/CaseInsensitiveLinkedMap.java
@@ -6,14 +6,14 @@ import java.util.Map;
 /**
  * 忽略大小写的LinkedHashMap<br>
  * 对KEY忽略大小写，get("Value")和get("value")获得的值相同，put进入的值也会被覆盖
- * 
+ *
  * @author Looly
  *
  * @param <K> 键类型
  * @param <V> 值类型
  * @since 3.3.1
  */
-public class CaseInsensitiveLinkedMap<K, V> extends CaseInsensitiveMap<K, V> {
+public class CaseInsensitiveLinkedMap<K, V> extends CustomKeyMap<K, V> {
 	private static final long serialVersionUID = 4043263744224569870L;
 
 	// ------------------------------------------------------------------------- Constructor start
@@ -26,7 +26,7 @@ public class CaseInsensitiveLinkedMap<K, V> extends CaseInsensitiveMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param initialCapacity 初始大小
 	 */
 	public CaseInsensitiveLinkedMap(int initialCapacity) {
@@ -35,7 +35,7 @@ public class CaseInsensitiveLinkedMap<K, V> extends CaseInsensitiveMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param m Map
 	 */
 	public CaseInsensitiveLinkedMap(Map<? extends K, ? extends V> m) {
@@ -44,7 +44,7 @@ public class CaseInsensitiveLinkedMap<K, V> extends CaseInsensitiveMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param loadFactor 加载因子
 	 * @param m Map
 	 * @since 3.1.2
@@ -56,7 +56,7 @@ public class CaseInsensitiveLinkedMap<K, V> extends CaseInsensitiveMap<K, V> {
 
 	/**
 	 * 构造
-	 * 
+	 *
 	 * @param initialCapacity 初始大小
 	 * @param loadFactor 加载因子
 	 */
@@ -64,4 +64,18 @@ public class CaseInsensitiveLinkedMap<K, V> extends CaseInsensitiveMap<K, V> {
 		super(new LinkedHashMap<>(initialCapacity, loadFactor));
 	}
 	// ------------------------------------------------------------------------- Constructor end
+
+	/**
+	 * 将Key转为小写
+	 *
+	 * @param key KEY
+	 * @return 小写KEY
+	 */
+	@Override
+	protected Object customKey(Object key) {
+		if (key instanceof CharSequence) {
+			key = key.toString().toLowerCase();
+		}
+		return key;
+	}
 }


### PR DESCRIPTION
[bug修复] 原始CamelCaseLinkedMap和CaseInsensitiveLinkedMap中的LinkedHashMap会被各自继承的父类中的HashMap覆盖，导致失去LinkedHashMap的特性。