### PR TITLE
修正节气判断逻辑，节气和节日一样，是一天而不是一段日期

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/chinese/SolarTerms.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/chinese/SolarTerms.java
@@ -4,6 +4,7 @@ import cn.hutool.core.date.ChineseDate;
 import cn.hutool.core.date.DateTime;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.util.NumberUtil;
+import cn.hutool.core.util.StrUtil;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -132,7 +133,7 @@ public class SolarTerms {
 	/**
 	 * 根据日期获取节气
 	 * @param date 日期
-	 * @return 返回指定日期所处的节气
+	 * @return 返回指定日期所处的节气，若不是一个节气则返回空字符串
 	 */
 	public static String getTerm(Date date) {
 		final DateTime dt = DateUtil.date(date);
@@ -143,7 +144,7 @@ public class SolarTerms {
 	/**
 	 * 根据农历日期获取节气
 	 * @param chineseDate 农历日期
-	 * @return 返回指定日期所处的节气
+	 * @return 返回指定农历日期所处的节气，若不是一个节气则返回空字符串
 	 */
 	public static String getTerm(ChineseDate chineseDate) {
 		return chineseDate.getTerm();
@@ -152,7 +153,7 @@ public class SolarTerms {
 	/**
 	 * 根据日期获取节气
 	 * @param date 日期
-	 * @return 返回指定日期所处的节气
+	 * @return 返回指定日期所处的节气，若不是一个节气则返回空字符串
 	 */
 	public static String getTerm(LocalDate date) {
 		return getTermInternal(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
@@ -163,7 +164,7 @@ public class SolarTerms {
 	 * @param year 公历年
 	 * @param mouth 公历月，从1开始
 	 * @param day 公历日，从1开始
-	 * @return 返回指定年月日所处的节气
+	 * @return 返回指定年月日所处的节气，若不是一个节气则返回空字符串
 	 */
 	public static String getTerm(int year, int mouth, int day) {
 		return getTerm(LocalDate.of(year, mouth, day));
@@ -171,10 +172,10 @@ public class SolarTerms {
 
 	/**
 	 * 根据年月日获取节气, 内部方法，不对月和日做有效校验
-	 * @param year 年
-	 * @param mouth 月，从1计数
-	 * @param day 日，从1计数
-	 * @return 返回指定年月日所处的节气
+	 * @param year 公历年
+	 * @param mouth 公历月，从1开始
+	 * @param day 公历日，从1开始
+	 * @return 返回指定年月日所处的节气，若不是一个节气则返回空字符串
 	 */
 	private static String getTermInternal(int year, int mouth, int day) {
 		if (year < 1900 || year > 2100) {
@@ -188,21 +189,21 @@ public class SolarTerms {
 		final int termInfo = Integer.parseInt(termTable.substring(segment * 5, (segment + 1) * 5), 16);
 		final String termInfoStr = String.valueOf(termInfo);
 
-		final String[] segmentTable = new String[24];
+		final String[] segmentTable = new String[4];
 		segmentTable[0] = termInfoStr.substring(0, 1);
 		segmentTable[1] = termInfoStr.substring(1, 3);
 		segmentTable[2] = termInfoStr.substring(3, 4);
 		segmentTable[3] = termInfoStr.substring(4, 6);
 
 		// 奇数月份的节气在前2个，偶数月份的节气在后两个
-		int segmentOffset = (mouth & 1) == 1 ? 0 : 2;
-		if (day < NumberUtil.parseInt(segmentTable[segmentOffset])) {
-			int idx = segment * 4 + segmentOffset - 1;
-			return TERMS[idx < 0 ? 23 : idx];
+		final int segmentOffset = (mouth & 1) == 1 ? 0 : 2;
+
+		if (day == Integer.parseInt(segmentTable[segmentOffset])) {
+			return TERMS[segment * 4 + segmentOffset];
 		}
-		if(day >= NumberUtil.parseInt(segmentTable[segmentOffset + 1])) {
+		if (day == Integer.parseInt(segmentTable[segmentOffset + 1])) {
 			return TERMS[segment * 4 + segmentOffset + 1];
 		}
-		return TERMS[segment * 4 + segmentOffset];
+		return StrUtil.EMPTY;
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/chinese/SolarTermsTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/chinese/SolarTermsTest.java
@@ -15,78 +15,52 @@ public class SolarTermsTest {
 
 	@Test
 	public void getTermTest() {
-		Assert.assertEquals("冬至", SolarTerms.getTerm(2021, 1, 4));
 
 		Assert.assertEquals("小寒", SolarTerms.getTerm(2021, 1, 5));
-		Assert.assertEquals("小寒", SolarTerms.getTerm(2021, 1, 19));
 
 		Assert.assertEquals("大寒", SolarTerms.getTerm(2021, 1, 20));
-		Assert.assertEquals("大寒", SolarTerms.getTerm(2021, 2, 2));
 
 		Assert.assertEquals("立春", SolarTerms.getTerm(2021, 2, 3));
-		Assert.assertEquals("立春", SolarTerms.getTerm(2021, 2, 17));
 
 		Assert.assertEquals("雨水", SolarTerms.getTerm(2021, 2, 18));
-		Assert.assertEquals("雨水", SolarTerms.getTerm(2021, 3, 4));
 
 		Assert.assertEquals("惊蛰", SolarTerms.getTerm(2021, 3, 5));
-		Assert.assertEquals("惊蛰", SolarTerms.getTerm(2021, 3, 19));
 
 		Assert.assertEquals("春分", SolarTerms.getTerm(2021, 3, 20));
-		Assert.assertEquals("春分", SolarTerms.getTerm(2021, 4, 3));
 
 		Assert.assertEquals("清明", SolarTerms.getTerm(2021, 4, 4));
-		Assert.assertEquals("清明", SolarTerms.getTerm(2021, 4, 10));
-		Assert.assertEquals("清明", SolarTerms.getTerm(2021, 4, 19));
 
 		Assert.assertEquals("谷雨", SolarTerms.getTerm(2021, 4, 20));
-		Assert.assertEquals("谷雨", SolarTerms.getTerm(2021, 4, 29));
-		Assert.assertEquals("谷雨", SolarTerms.getTerm(2021, 5, 4));
 
 		Assert.assertEquals("立夏", SolarTerms.getTerm(2021, 5, 5));
-		Assert.assertEquals("立夏", SolarTerms.getTerm(2021, 5, 9));
-		Assert.assertEquals("立夏", SolarTerms.getTerm(2021, 5, 20));
 
 		Assert.assertEquals("小满", SolarTerms.getTerm(2021, 5, 21));
-		Assert.assertEquals("小满", SolarTerms.getTerm(2021, 6, 4));
 
 		Assert.assertEquals("芒种", SolarTerms.getTerm(2021, 6, 5));
-		Assert.assertEquals("芒种", SolarTerms.getTerm(2021, 6, 20));
 
 		Assert.assertEquals("夏至", SolarTerms.getTerm(2021, 6, 21));
-		Assert.assertEquals("夏至", SolarTerms.getTerm(2021, 7, 6));
 
 		Assert.assertEquals("小暑", SolarTerms.getTerm(2021, 7, 7));
-		Assert.assertEquals("小暑", SolarTerms.getTerm(2021, 7, 21));
 
 		Assert.assertEquals("大暑", SolarTerms.getTerm(2021, 7, 22));
-		Assert.assertEquals("大暑", SolarTerms.getTerm(2021, 8, 6));
 
 		Assert.assertEquals("立秋", SolarTerms.getTerm(2021, 8, 7));
 
 		Assert.assertEquals("处暑", SolarTerms.getTerm(2021, 8, 23));
-		Assert.assertEquals("处暑", SolarTerms.getTerm(2021, 9, 6));
 
 		Assert.assertEquals("白露", SolarTerms.getTerm(2021, 9, 7));
-		Assert.assertEquals("白露", SolarTerms.getTerm(2021, 9, 22));
 
 		Assert.assertEquals("秋分", SolarTerms.getTerm(2021, 9, 23));
-		Assert.assertEquals("秋分", SolarTerms.getTerm(2021, 10, 7));
 
 		Assert.assertEquals("寒露", SolarTerms.getTerm(2021, 10, 8));
-		Assert.assertEquals("寒露", SolarTerms.getTerm(2021, 10, 22));
 
 		Assert.assertEquals("霜降", SolarTerms.getTerm(2021, 10, 23));
-		Assert.assertEquals("霜降", SolarTerms.getTerm(2021, 11, 6));
 
 		Assert.assertEquals("立冬", SolarTerms.getTerm(2021, 11, 7));
-		Assert.assertEquals("立冬", SolarTerms.getTerm(2021, 11, 21));
 
 		Assert.assertEquals("小雪", SolarTerms.getTerm(2021, 11, 22));
-		Assert.assertEquals("小雪", SolarTerms.getTerm(2021, 12, 6));
 
 		Assert.assertEquals("大雪", SolarTerms.getTerm(2021, 12, 7));
-		Assert.assertEquals("大雪", SolarTerms.getTerm(2021, 12, 20));
 
 		Assert.assertEquals("冬至", SolarTerms.getTerm(2021, 12, 21));
 	}
@@ -94,12 +68,14 @@ public class SolarTermsTest {
 
 	@Test
 	public void getTermByDateTest() {
-		Assert.assertEquals("春分", SolarTerms.getTerm(DateUtil.parseDate("2021-04-02")));
+		Assert.assertEquals("春分", SolarTerms.getTerm(DateUtil.parseDate("2021-03-20")));
+		Assert.assertEquals("处暑", SolarTerms.getTerm(DateUtil.parseDate("2022-08-23")));
 	}
 
 
 	@Test
 	public void getTermByChineseDateTest() {
-		Assert.assertEquals("清明", SolarTerms.getTerm(new ChineseDate(2021, 2, 25)));
+		Assert.assertEquals("清明", SolarTerms.getTerm(new ChineseDate(2021, 2, 23)));
+		Assert.assertEquals("秋分", SolarTerms.getTerm(new ChineseDate(2022, 8, 28)));
 	}
 }


### PR DESCRIPTION
1. [bug修复] 修正节气判断逻辑，节气和节日一样，是一天而不是一段日期
    根据查阅的资料得知节气是由太阳在黄道的角度来确定的，每15°一个节气（如：0°春分、15°清明 ... 345°惊蛰）。当太阳到达相应角度的那一个瞬间就是一个节气，因此节气可以精确到秒、毫秒乃至更小，但我们平常使用只精确到日就可以啦