### PR TITLE
Fix (hutool-core): 修复是否空白符方法不认为 \u0000 为空格的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/CharUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/CharUtil.java
@@ -334,7 +334,8 @@ public class CharUtil {
 		return Character.isWhitespace(c)
 				|| Character.isSpaceChar(c)
 				|| c == '\ufeff'
-				|| c == '\u202a';
+				|| c == '\u202a'
+				|| c == '\u0000';
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/util/CharUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/CharUtilTest.java
@@ -37,6 +37,9 @@ public class CharUtilTest {
 
 		char a3 = '\u3000';
 		Assert.assertTrue(CharUtil.isBlankChar(a3));
+
+		char a4 = '\u0000';
+		Assert.assertTrue(CharUtil.isBlankChar(a4));
 	}
 
 	@Test


### PR DESCRIPTION
# 修改
1. 原有实现中没有将 \u0000 判断为空格，但这个是空格，因此补充
2. 同步增加测试方法

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复是否空白符方法不认为 \u0000 为空格的问题