### PR TITLE
在MapUtil中添加集合转map的static方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/map/MapUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/MapUtil.java
@@ -11,23 +11,10 @@ import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.ReflectUtil;
 import cn.hutool.core.util.StrUtil;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 /**
  * Map相关工具类
@@ -1347,5 +1334,35 @@ public class MapUtil {
 				map.clear();
 			}
 		}
+	}
+
+	/**
+	 * 将一个集合对象按照 {@code function}, 转换为map对象
+	 * <pre>
+	 *     使用示例:
+	 *     class User {
+	 *         private Integer id;
+	 *         private String nickname;
+	 *         ...
+	 *         public Integer getId(){...}
+	 *         public Integer getNickName(){...}
+	 *     }
+	 *     List<User> userList = ... ;
+	 *     Map<Integer, User> idTOUserMap = MapUtil.collectionToMap(userList, User::getId);
+	 *     ...
+	 * </pre>
+	 *
+	 * @param collection 待转换的集合对象, eg: {@code List<User>}
+	 * @param function 给定的转换方法, eg: User.getId
+	 * @param <M> {@code function}对应的返回值类型
+	 * @param <T> 集合对应的泛型
+	 * @return 集合转换后的map对象
+	 */
+	public static <M, T> Map<M, T> collectionToMap(Collection<T> collection, Function<T, M> function) {
+		Map<M, T> map = new HashMap<>(collection.size(), 1);
+		for (T t : collection) {
+			map.put(function.apply(t), t);
+		}
+		return map;
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/MapUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/MapUtilTest.java
@@ -7,12 +7,14 @@ import cn.hutool.core.util.StrUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 public class MapUtilTest {
-	
+
 	@Test
 	public void filterTest() {
 		Map<String, String> map = MapUtil.newHashMap();
@@ -74,7 +76,7 @@ public class MapUtilTest {
 		map.put("b", "2");
 		map.put("c", "3");
 		map.put("d", "4");
-		
+
 		Object[][] objectArray = MapUtil.toObjectArray(map);
 		Assert.assertEquals("a", objectArray[0][0]);
 		Assert.assertEquals("1", objectArray[0][1]);
@@ -101,5 +103,35 @@ public class MapUtilTest {
 
 		String join3 = MapUtil.sortJoin(build, StrUtil.EMPTY, StrUtil.EMPTY, false, "123", "abc");
 		Assert.assertEquals("key1value1key2value2key3value3123abc", join3);
+	}
+
+	@Test
+	public void collectionToMap() {
+		List<TestUser> list = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			list.add(new TestUser(i, "name" + i));
+		}
+		Map<Integer, TestUser> id2UserMap = MapUtil.collectionToMap(list, TestUser::getId);
+		for (TestUser testUser : list) {
+			Assert.assertEquals(testUser.getNickname(), id2UserMap.get(testUser.getId()).getNickname());
+		}
+	}
+
+	private static class TestUser {
+		private final Integer id;
+		private final String nickname;
+
+		public TestUser(Integer id, String nickname) {
+			this.id = id;
+			this.nickname = nickname;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getNickname() {
+			return nickname;
+		}
 	}
 }


### PR DESCRIPTION
#### 说明
在guava 库中，可以通过Maps.uniqueIndex，将一个list集合按照自己选定的属性，生成map对象，我在Hutool中没有找到类似的方式。
在JDK8中，通过stream可以完成类似的操作，例如: 
`users.stream().collect( Collectors.toMap(User::getId, (user) -> user))`
但该操作在执行效率上并不高效。

1. [新特性] 添加从集合转为map的方法