### PR TITLE
Compatible with other development language use BCrypt may cause "$2y$","$2b$"  Ciphertext prefix

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/digest/BCrypt.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/digest/BCrypt.java
@@ -424,7 +424,7 @@ public class BCrypt {
 			off = 3;
 		else {
 			minor = salt.charAt(2);
-			if (minor != 'a' || salt.charAt(3) != '$')
+			if ((minor != 'a' && minor != 'x' && minor != 'y' && minor != 'b') || salt.charAt(3) != '$')
 				throw new IllegalArgumentException("Invalid salt revision");
 			off = 4;
 		}


### PR DESCRIPTION
 PHP 5.3.7 之前只支持 "$2a$" 作为盐值的前缀，PHP 5.3.7 开始引入了新的前缀来修正一个在Blowfish实现上的安全风险。。总而言之，开发者如果仅针对 PHP 5.3.7及之后版本进行开发，那应该使用 "$2y$" 而非 "$2a$"