### PR TITLE
MaskBit增加掩码反向转换的方法，完善Ipv4Util掩码相关方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/net/Ipv4Util.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/Ipv4Util.java
@@ -194,28 +194,18 @@ public class Ipv4Util {
 	/**
 	 * 根据子网掩码转换为掩码位
 	 *
-	 * @param mask 掩码，例如xxx.xxx.xxx.xxx
-	 * @return 掩码位，例如32
+	 * @param mask 掩码的点分十进制表示，例如 255.255.255.0
+	 *
+	 * @return 掩码位，例如 24
+	 *
+	 * @throws IllegalArgumentException 子网掩码非法
 	 */
 	public static int getMaskBitByMask(String mask) {
-		StringBuffer sbf;
-		String str;
-		int inetmask = 0;
-		int count;
-		for (String part : StrUtil.split(mask, CharUtil.DOT)) {
-			sbf = toBin(Integer.parseInt(part));
-			str = sbf.reverse().toString();
-			count = 0;
-			for (int i = 0; i < str.length(); i++) {
-				i = str.indexOf('1', i);
-				if (i == -1) {
-					break;
-				}
-				count++;
-			}
-			inetmask += count;
+		Integer maskBit = MaskBit.getMaskBit(mask);
+		if (maskBit == null) {
+			throw new IllegalArgumentException("Invalid netmask " + mask);
 		}
-		return inetmask;
+		return maskBit;
 	}
 
 	/**
@@ -287,6 +277,29 @@ public class Ipv4Util {
 		}
 		return count;
 	}
+
+	/**
+	 * 判断掩码是否合法
+	 *
+	 * @param mask 掩码的点分十进制表示，例如 255.255.255.0
+	 *
+	 * @return true：掩码合法；false：掩码不合法
+	 */
+	public static boolean isMaskValid(String mask) {
+		return MaskBit.getMaskBit(mask) != null;
+	}
+
+	/**
+	 * 判断掩码位是否合法
+	 *
+	 * @param maskBit 掩码位，例如 24
+	 *
+	 * @return true：掩码位合法；false：掩码位不合法
+	 */
+	public static boolean isMaskBitValid(int maskBit) {
+		return MaskBit.get(maskBit) != null;
+	}
+
 
 	//-------------------------------------------------------------------------------- Private method start
 

--- a/hutool-core/src/main/java/cn/hutool/core/net/MaskBit.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/MaskBit.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.net;
 
+import cn.hutool.core.map.BiMap;
 import java.util.HashMap;
-import java.util.Map;
 
 /**
  * 掩码位和掩码之间的Map对应
@@ -11,9 +11,12 @@ import java.util.Map;
  */
 public class MaskBit {
 
-	private static final Map<Integer, String> MASK_BIT_MAP;
+	/**
+	 * 掩码位与掩码的点分十进制的双向对应关系
+	 */
+	private static final BiMap<Integer, String> MASK_BIT_MAP;
 	static {
-		MASK_BIT_MAP = new HashMap<>(32);
+		MASK_BIT_MAP = new BiMap<>(new HashMap<>(32));
 		MASK_BIT_MAP.put(1, "128.0.0.0");
 		MASK_BIT_MAP.put(2, "192.0.0.0");
 		MASK_BIT_MAP.put(3, "224.0.0.0");
@@ -57,4 +60,16 @@ public class MaskBit {
 	public static String get(int maskBit) {
 		return MASK_BIT_MAP.get(maskBit);
 	}
+
+	/**
+	 * 根据掩码获取掩码位
+	 *
+	 * @param mask 掩码的点分十进制表示，如 255.255.255.0
+	 *
+	 * @return 掩码位，如 24；如果掩码不合法，则返回null
+	 */
+	public static Integer getMaskBit(String mask) {
+		return MASK_BIT_MAP.getKey(mask);
+	}
+
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/Ipv4UtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/Ipv4UtilTest.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
+import org.junit.function.ThrowingRunnable;
 
 public class Ipv4UtilTest {
 
@@ -12,6 +13,12 @@ public class Ipv4UtilTest {
 	public void getMaskBitByMaskTest(){
 		final int maskBitByMask = Ipv4Util.getMaskBitByMask("255.255.255.0");
 		Assert.assertEquals(24, maskBitByMask);
+	}
+
+	@Test
+	public void getMaskBitByIllegalMaskTest() {
+		ThrowingRunnable getMaskBitByMaskRunnable = () -> Ipv4Util.getMaskBitByMask("255.255.0.255");
+		Assert.assertThrows("非法掩码测试", IllegalArgumentException.class, getMaskBitByMaskRunnable);
 	}
 
 	@Test
@@ -41,5 +48,31 @@ public class Ipv4UtilTest {
 		int maskBit = Ipv4Util.getMaskBitByMask("255.255.255.0");
 		final List<String> list = Ipv4Util.list("192.168.100.2", maskBit, false);
 		Assert.assertEquals(254, list.size());
+	}
+
+	@Test
+	public void isMaskValidTest() {
+		boolean maskValid = Ipv4Util.isMaskValid("255.255.255.0");
+		Assert.assertTrue("掩码合法检验", maskValid);
+	}
+
+	@Test
+	public void isMaskInvalidTest() {
+		Assert.assertFalse("掩码非法检验 - 255.255.0.255", Ipv4Util.isMaskValid("255.255.0.255"));
+		Assert.assertFalse("掩码非法检验 - null值", Ipv4Util.isMaskValid(null));
+		Assert.assertFalse("掩码非法检验 - 空字符串", Ipv4Util.isMaskValid(""));
+		Assert.assertFalse("掩码非法检验 - 空白字符串", Ipv4Util.isMaskValid(" "));
+	}
+
+	@Test
+	public void isMaskBitValidTest() {
+		boolean maskBitValid = Ipv4Util.isMaskBitValid(32);
+		Assert.assertTrue("掩码位合法检验", maskBitValid);
+	}
+
+	@Test
+	public void isMaskBitInvalidTest() {
+		boolean maskBitValid = Ipv4Util.isMaskBitValid(33);
+		Assert.assertFalse("掩码位非法检验", maskBitValid);
 	}
 }


### PR DESCRIPTION
### 修改描述

1. [新特性]  MaskBit增加掩码反向转换的方法getMaskBit()
2. [新特性]  Ipv4Util增加子网掩码是否合法的判断方法isMaskValid()和掩码位是否合法的判断方法isMaskBitValid()
3. [新特性]  Ipv4Util.getMaskBitByMask()方法直接从MaskBit中获取，不再逐位解析字符串，提升了速度并加入了掩码的合法性校验
