### PR TITLE
修复testcase中sqllite没有指定隔离级别，导致初始化SqlLite连接池时的潜在异常

### DIFF
--- a/hutool-db/src/test/resources/config/db.setting
+++ b/hutool-db/src/test/resources/config/db.setting
@@ -25,6 +25,7 @@ remarks = true
 [test]
 url = jdbc:sqlite:test.db
 remarks = true
+defaultTransactionIsolation = READ_UNCOMMITTED
 
 # 测试用HSQLDB数据库
 [hsqldb]


### PR DESCRIPTION
bug修复

复现步骤:
拉取最新的v5-dev分支的代码
进入代码目录， 执行命令 `mvn test`, 过程中发现异常信息:
```java
[SQL] -> SELECT
        *
    FROM
        [user]
[main] DEBUG cn.hutool.setting.SettingLoader - Load setting file [file:/E:/workspaces/hutool/hutool-db/target/test-classes/config/db.setting]
[main] DEBUG cn.hutool.db.DbUtil - Show sql: [true], format sql: [true], show params: [true], level: [DEBUG]
[main] DEBUG cn.hutool.db.ds.GlobalDSFactory - Custom use [BeeCP] DataSource.
[main] INFO cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1)starting....
[main] DEBUG cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1))begin to create new pooled connection,state:1
[main] WARN cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1))failed to set default on executing to 'setTransactionIsolation',cause:{}
java.sql.SQLException: SQLite supports only TRANSACTION_SERIALIZABLE and TRANSACTION_READ_UNCOMMITTED.
        at org.sqlite.SQLiteConnection.setTransactionIsolation(SQLiteConnection.java:164)
        at cn.beecp.pool.FastConnectionPool.setDefaultOnRawConn(FastConnectionPool.java:252)
        at cn.beecp.pool.FastConnectionPool.createPooledConn(FastConnectionPool.java:207)
        at cn.beecp.pool.FastConnectionPool.createInitConnections(FastConnectionPool.java:347)
        at cn.beecp.pool.FastConnectionPool.init(FastConnectionPool.java:113)
        at cn.beecp.BeeDataSource.createPool(BeeDataSource.java:240)
        at cn.beecp.BeeDataSource.<init>(BeeDataSource.java:78)
        at cn.hutool.db.ds.bee.BeeDSFactory.createDataSource(BeeDSFactory.java:45)
        at cn.hutool.db.ds.AbstractDSFactory.createDataSource(AbstractDSFactory.java:127)
        at cn.hutool.db.ds.AbstractDSFactory.getDataSource(AbstractDSFactory.java:92)
        at cn.hutool.db.ds.DSFactory.get(DSFactory.java:111)
        at cn.hutool.db.DsTest.beeCPDsTest(DsTest.java:66)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
        at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
[main] DEBUG cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1))has created new pooled connection:cn.beecp.pool.PooledConnection@36c88a32,state:1
[main] DEBUG cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1))begin to remove pooled connection:cn.beecp.pool.PooledConnection@36c88a32,reason:pre_init
[main] DEBUG cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1))has removed pooled connection:cn.beecp.pool.PooledConnection@36c88a32,reason:pre_init
[main] INFO cn.beecp.pool.PoolStaticCenter - BeeCP(FastPool-1)has startup{mode:compete,init size:0,max size:10,semaphore size:5,max wait:8000ms,driver:org.sqlite.JDBC}
```

处理方案:
db.setting中sqllite添加隔离级别:
defaultTransactionIsolation = READ_UNCOMMITTED