### PR TITLE
[cleanup] erefactor/EclipseJdt - Remove unused local variables

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/sax/Excel03SaxReader.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/sax/Excel03SaxReader.java
@@ -385,7 +385,6 @@ public class Excel03SaxReader implements HSSFListener, ExcelSaxReader<Excel03Sax
 			return Integer.parseInt(StrUtil.removePrefixIgnoreCase(idOrRidOrSheetName, RID_PREFIX));
 		}
 
-		final int sheetIndex;
 		try {
 			return Integer.parseInt(idOrRidOrSheetName);
 		} catch (NumberFormatException ignore) {

--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/sax/ExcelSaxUtil.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/sax/ExcelSaxUtil.java
@@ -247,7 +247,6 @@ public class ExcelSaxUtil {
 	 * @since 5.5.0
 	 */
 	public static Object getNumberOrDateValue(CellValueRecordInterface cell, double value, FormatTrackingHSSFListener formatListener) {
-		Object result;
 		if (isDateFormat(cell, formatListener)) {
 			// 可能为日期格式
 			return getDateValue(value);


### PR DESCRIPTION
EclipseJdt cleanup 'RemoveUnusedLocalVariable' applied by erefactor.

For EclipseJdt see https://www.eclipse.org/eclipse/news/4.19/jdt.php
For erefactor see https://github.com/cal101/erefactor
