### PR TITLE
Fix(excel) 写出时数据为空，强制写出标题行无效

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
@@ -32,13 +32,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -811,6 +806,13 @@ public class ExcelWriter extends ExcelBase<ExcelWriter> {
 	 */
 	public ExcelWriter write(Iterable<?> data, boolean isWriteKeyAsHead) {
 		Assert.isFalse(this.isClosed, "ExcelWriter has been closed!");
+
+		// 数据为空，但需要强制写出标题行时，写出标题
+		if (CollUtil.isEmpty(data) && isWriteKeyAsHead) {
+			writeHeadRow(headerAlias.values());
+			return this;
+		}
+
 		boolean isFirst = true;
 		for (Object object : data) {
 			writeRow(object, isFirst && isWriteKeyAsHead);


### PR DESCRIPTION
Closes gitee [#I3V1E5](https://gitee.com/dromara/hutool/issues/I3V1E5)

### 修改描述(包括说明bug修复或者添加新特性)

考虑到isWriteKeyAsHead 是否强制写出标题行（Map或Bean）这个参数，我认为空数据应当写出一行标题

![image](https://user-images.githubusercontent.com/34061813/121328983-5fad8380-c947-11eb-9b65-727700533871.png)

[bug修复]
- :bug: Fix(excel) 写出时数据为空，强制写出标题行无效