### PR TITLE
修复'Excel导出,设置列别名,如果数据源无别名对应字段,Excel不会导出此列'问题

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
@@ -1273,6 +1273,10 @@ public class ExcelWriter extends ExcelBase<ExcelWriter> {
 				filteredMap.put(entry.getKey(), entry.getValue());
 			}
 		}
+		// 补全'this.headerAlias'存在且未包含在'filteredMap'的header信息
+		for (String value : this.headerAlias.values()) {
+			filteredMap.putIfAbsent(value, null);
+		}
 		return filteredMap;
 	}
 

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
@@ -317,8 +317,9 @@ public class ExcelWriteTest {
 		writer.addHeaderAlias("score", "分数");
 		writer.addHeaderAlias("isPass", "是否通过");
 		writer.addHeaderAlias("examDate", "考试时间");
+		writer.addHeaderAlias("other", "其他");
 		// 合并单元格后的标题行，使用默认标题样式
-		writer.merge(4, "一班成绩单");
+		writer.merge(5, "一班成绩单");
 		// 一次性写出内容，使用默认样式
 		writer.write(rows, true);
 		// 关闭writer，释放内存


### PR DESCRIPTION

### 修改描述

1. [bug修复] #1690