### PR TITLE
Fix 参数类型不同且不为数组类型的断言报错

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/builder/EqualsBuilder.java
+++ b/hutool-core/src/main/java/cn/hutool/core/builder/EqualsBuilder.java
@@ -381,7 +381,8 @@ public class EqualsBuilder implements Builder<Boolean> {
 		final Class<?> lhsClass = lhs.getClass();
 		if (false == lhsClass.isArray()) {
 			// The simple case, not an array, just test the element
-			isEquals = lhs.equals(rhs);
+			this.setEquals(lhs.equals(rhs));
+			return this;
 		}
 
 		// 判断数组的equals


### PR DESCRIPTION
### 修改描述

1. [bug修复] #1692