### PR TITLE
fix(IdCardUtil): Fix isValidTWCard  string index out of range

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/IdcardUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/IdcardUtil.java
@@ -343,7 +343,7 @@ public class IdcardUtil {
 	 * @return 验证码是否符合
 	 */
 	public static boolean isValidTWCard(String idcard) {
-		if (StrUtil.isEmpty(idcard)) {
+		if (StrUtil.isEmpty(idcard) || idcard.length() != 10) {
 			return false;
 		}
 		String start = idcard.substring(0, 1);

--- a/hutool-core/src/test/java/cn/hutool/core/util/IdcardUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/IdcardUtilTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 /**
  * 身份证单元测试
- * 
+ *
  * @author Looly
  *
  */
@@ -110,5 +110,18 @@ public class IdcardUtilTest {
 		String hkCard="P174468(6)";
 		boolean flag=IdcardUtil.isValidHKCard(hkCard);
 		Assert.assertTrue(flag);
+	}
+
+	@Test
+	public void isValidTWCardIdTest() {
+		String twCard = "B221690311";
+		boolean flag = IdcardUtil.isValidTWCard(twCard);
+		Assert.assertTrue(flag);
+		String errTwCard1 = "M517086311";
+		flag = IdcardUtil.isValidTWCard(errTwCard1);
+		Assert.assertFalse(flag);
+		String errTwCard2 = "B2216903112";
+		flag = IdcardUtil.isValidTWCard(errTwCard2);
+		Assert.assertFalse(flag);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 台湾国民身份证规则为10位，因此`isValidTWCard`中待校验字符串不等于10位的时候应提前返回false，为10位的时候才进行后续校验。否则当首位为字母，且位数小于10时会引起`index out of range`，而位数大于10时返回不正确的结果`true`。