### PR TITLE
fix #1818

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -2160,7 +2160,9 @@ public class NumberUtil {
 	 */
 	public static BigDecimal toBigDecimal(String number) {
 		try {
-			number = parseNumber(number).toString();
+			DecimalFormat decimalFormat = new DecimalFormat();
+			decimalFormat.setParseBigDecimal(true);
+			number=decimalFormat.parse(number).toString();
 		} catch (Exception ignore) {
 			// 忽略解析错误
 		}


### PR DESCRIPTION
1. [bug修复] 
#1818  NumberFormat 如果不设置parseBigDecimal 默认是转成double所以数字会截断。