### PR TITLE
fix: firefox version regex

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
+++ b/hutool-http/src/main/java/cn/hutool/http/useragent/Browser.java
@@ -50,7 +50,7 @@ public class Browser extends UserAgentInfo {
 
 			new Browser("MSEdge", "Edge|Edg", "(?:edge|Edg)\\/([\\d\\w\\.\\-]+)"),
 			new Browser("Chrome", "chrome", "chrome\\/([\\d\\w\\.\\-]+)"),
-			new Browser("Firefox", "firefox", Other_Version),
+			new Browser("Firefox", "firefox", "firefox\\/([\\d\\w\\.\\-]+)"),
 			new Browser("IEMobile", "iemobile", Other_Version),
 			new Browser("Android Browser", "android", "version\\/([\\d\\w\\.\\-]+)"),
 			new Browser("Safari", "safari", "version\\/([\\d\\w\\.\\-]+)"),


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 在我的 windows 上 firefox 92.0 版本，使用的UA是 `Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:92.0) Gecko/20100101 Firefox/92.0` 原先的 regex 解析到的版本为 `5.0`