### PR TITLE
CollUtil和NumberUtil添加方法✒

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/CollUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/CollUtil.java
@@ -216,6 +216,63 @@ public class CollUtil {
 	}
 
 	/**
+	 * 多个集合的完全并集，类似于SQL中的“UNION ALL”<br>
+	 * 针对一个集合中存在多个相同元素的情况，保留全部元素<br>
+	 * 例如：2层集合：[[a, b, c, c, c],[a, b, c, c]]<br>
+	 * 结果：[a, b, c, c, c, a, b, c, c]
+	 *
+	 * @param <T>  集合元素类型
+	 * @param coll 2层集合
+	 * @return 并集的集合，返回 {@link Collection}
+	 * @since 5.7.14
+	 */
+	public static <T> Collection<T> unionAll(Collection<? extends Collection<T>> coll) {
+		Collection<T> marge = coll.iterator().next();
+		for (Collection<T> next : coll) {
+			marge = union(marge, next);
+		}
+		return marge;
+	}
+
+	/**
+	 * 多个集合的完全并集，类似于SQL中的“UNION ALL”<br>
+	 * 针对一个集合中存在多个相同元素的情况，保留全部元素<br>
+	 * 例如：2层集合：[[a, b, c, c, c],[a, b, c, c]]<br>
+	 * 结果：[a, b, c, c, c, a, b, c, c]
+	 *
+	 * @param <T>  集合元素类型
+	 * @param coll 2层集合
+	 * @return 并集的集合，返回 {@link ArrayList}
+	 * @since 5.7.14
+	 */
+	public static <T> List<T> unionAllToList(Collection<? extends Collection<T>> coll) {
+		List<T> marge = new ArrayList<>(coll.iterator().next());
+		for (Collection<T> next : coll) {
+			marge = new ArrayList<>(union(marge, next));
+		}
+		return marge;
+	}
+
+	/**
+	 * 多个集合的非重复并集，类似于SQL中的“UNION DISTINCT”<br>
+	 * 针对一个集合中存在多个相同元素的情况，只保留一个<br>
+	 * 例如：2层集合：[[a, b, c, c, c],[a, b, c, c]]<br>
+	 * 结果：[a, b, c]，此结果中只保留了一个c
+	 *
+	 * @param <T>  集合元素类型
+	 * @param coll 2层集合
+	 * @return 并集的集合，返回 {@link LinkedHashSet}
+	 * @since 5.7.14
+	 */
+	public static <T> Set<T> unionAllDistinct(Collection<? extends Collection<T>> coll) {
+		Collection<T> marge = coll.iterator().next();
+		for (Collection<T> next : coll) {
+			marge = unionDistinct(marge, next);
+		}
+		return new LinkedHashSet<>(marge);
+	}
+
+	/**
 	 * 两个集合的交集<br>
 	 * 针对一个集合中存在多个相同元素的情况，计算两个集合中此元素的个数，保留最少的个数<br>
 	 * 例如：集合1：[a, b, c, c, c]，集合2：[a, b, c, c]<br>
@@ -309,6 +366,63 @@ public class CollUtil {
 		result.retainAll(coll2);
 
 		return result;
+	}
+
+	/**
+	 * 多个集合的交集<br>
+	 * 针对一个集合中存在多个相同元素的情况，计算两个集合中此元素的个数，保留最少的个数<br>
+	 * 例如：2层集合：[[a, b, c, c, c],[a, b, c, c]]<br>
+	 * 结果：[a, b, c, c]，此结果中只保留了两个c
+	 *
+	 * @param <T>  集合元素类型
+	 * @param coll 2层集合
+	 * @return 交集的集合，返回 {@link Collection}
+	 * @since 5.7.14
+	 */
+	public static <T> Collection<T> intersectionAll(Collection<? extends Collection<T>> coll) {
+		Collection<T> marge = coll.iterator().next();
+		for (Collection<T> next : coll) {
+			marge = intersection(marge, next);
+		}
+		return marge;
+	}
+
+	/**
+	 * 多个集合的交集<br>
+	 * 针对一个集合中存在多个相同元素的情况，计算两个集合中此元素的个数，保留最少的个数<br>
+	 * 例如：2层集合：[[a, b, c, c, c],[a, b, c, c]]<br>
+	 * 结果：[a, b, c, c]，此结果中只保留了两个c
+	 *
+	 * @param <T>  集合元素类型
+	 * @param coll 2层集合
+	 * @return 交集的集合，返回 {@link ArrayList}
+	 * @since 5.7.14
+	 */
+	public static <T> List<T> intersectionAllToList(Collection<? extends Collection<T>> coll) {
+		List<T> marge = new ArrayList<>(coll.iterator().next());
+		for (Collection<T> next : coll) {
+			marge = new ArrayList<>(intersection(marge, next));
+		}
+		return marge;
+	}
+
+	/**
+	 * 多个集合的交集<br>
+	 * 针对一个集合中存在多个相同元素的情况，只保留一个<br>
+	 * 例如：2层集合：[[a, b, c, c, c],[a, b, c, c]]<br>
+	 * 结果：[a, b, c]，此结果中只保留了一个c
+	 *
+	 * @param <T>  集合元素类型
+	 * @param coll 2层集合
+	 * @return 交集的集合，返回 {@link LinkedHashSet}
+	 * @since 5.7.14
+	 */
+	public static <T> Set<T> intersectionAllDistinct(Collection<? extends Collection<T>> coll) {
+		Collection<T> marge = coll.iterator().next();
+		for (Collection<T> next : coll) {
+			marge = intersectionDistinct(marge, next);
+		}
+		return new LinkedHashSet<>(marge);
 	}
 
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -45,6 +45,11 @@ public class NumberUtil {
 	private static final int DEFAULT_DIV_SCALE = 10;
 
 	/**
+	 * 默认百分比精度
+	 */
+	private static final int DEFAULT_PERCENT_SCALE = 2;
+
+	/**
 	 * 0-20对应的阶乘，超过20的阶乘会超过Long.MAX_VALUE
 	 */
 	private static final long[] FACTORIALS = new long[]{
@@ -1102,6 +1107,21 @@ public class NumberUtil {
 	}
 
 	/**
+	 * 格式化金额输出，每三位用逗号分隔 (带前缀￥) <br>
+	 * eg:五万元 => ￥50,000  <br>
+	 * 如果不需要前缀 @see decimalFormatMoney
+	 *
+	 * @param money 金额
+	 * @return 格式化后的值
+	 * @since 5.7.14
+	 */
+	public static String formatMoney(Number money) {
+		final NumberFormat format = NumberFormat.getCurrencyInstance();
+		format.setMaximumFractionDigits(2);
+		return format.format(money);
+	}
+
+	/**
 	 * 格式化百分比，小数采用四舍五入方式
 	 *
 	 * @param number 值
@@ -1113,6 +1133,38 @@ public class NumberUtil {
 		final NumberFormat format = NumberFormat.getPercentInstance();
 		format.setMaximumFractionDigits(scale);
 		return format.format(number);
+	}
+
+	/**
+	 * 求百分比 不带%号 保留小数点后2位
+	 * 如需 %号，可自行追加%，或者再调用 formatPercent <br>
+	 * 如需类型转换，可使用Convert.toXXX方法转换 <br>
+	 *
+	 * @param num   当前num
+	 * @param total 总长度
+	 * @return String 百分比 (不带百分号后缀)
+	 * @since 5.7.14
+	 */
+	public static String percent(Number num, Number total) {
+		return percent(num, total, DEFAULT_PERCENT_SCALE);
+	}
+
+	/**
+	 * 求百分比 不带%号 可指定精度
+	 * 如需 %号，可自行追加%，或者再调用 formatPercent <br>
+	 * 如需类型转换，可使用Convert.toXXX方法转换 <br>
+	 *
+	 * @param num   当前num
+	 * @param total 总长度
+	 * @param scale 精度(保留小数点后几位)
+	 * @return String 百分比 (不带百分号后缀)
+	 * @since 5.7.14
+	 */
+	public static String percent(Number num, Number total, int scale) {
+		BigDecimal div = div(mul(num, 100), total, scale);
+		final NumberFormat format = NumberFormat.getNumberInstance();
+		format.setMaximumFractionDigits(scale);
+		return format.format(div);
 	}
 
 	// ------------------------------------------------------------------------------------------- isXXX

--- a/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
@@ -105,12 +105,66 @@ public class CollUtilTest {
 	}
 
 	@Test
+	public void unionAllTest() {
+		List<List<String>> allList1 = new ArrayList<>();
+		ArrayList<String> list1 = CollUtil.newArrayList("1", "3", "5", "7", "9");
+		ArrayList<String> list2 = CollUtil.newArrayList("3", "4", "5", "6", "7");
+		allList1.add(list1);
+		allList1.add(list2);
+		Collection<String> union1 = CollUtil.union(list1, list2);
+		Collection<String> union2 = CollUtil.unionAll(allList1);
+		Collection<String> union3 = CollUtil.unionDistinct(list1, list2);
+		Collection<String> union4 = CollUtil.unionAllDistinct(allList1);
+		Assert.assertEquals(union1.size(), union2.size());
+		Assert.assertEquals(union3.size(), union4.size());
+
+		List<List<String>> allList2 = new ArrayList<>();
+		ArrayList<String> list3 = CollUtil.newArrayList("a", "b", "c", "c", "c");
+		ArrayList<String> list4 = CollUtil.newArrayList("a", "b", "c", "c");
+		allList2.add(list3);
+		allList2.add(list4);
+		Collection<String> union5 = CollUtil.union(list3, list4);
+		Collection<String> union6 = CollUtil.unionAll(allList2);
+		Collection<String> union7 = CollUtil.unionDistinct(list3, list4);
+		Collection<String> union8 = CollUtil.unionAllDistinct(allList2);
+		Assert.assertEquals(union5.size(), union6.size());
+		Assert.assertEquals(union7.size(), union8.size());
+	}
+
+	@Test
 	public void intersectionTest() {
 		ArrayList<String> list1 = CollUtil.newArrayList("a", "b", "b", "c", "d", "x");
 		ArrayList<String> list2 = CollUtil.newArrayList("a", "b", "b", "b", "c", "d");
 
 		Collection<String> intersection = CollUtil.intersection(list1, list2);
 		Assert.assertEquals(2, CollUtil.count(intersection, "b"::equals));
+	}
+
+	@Test
+	public void intersectionAllTest() {
+		List<List<String>> allList1 = new ArrayList<>();
+		ArrayList<String> list1 = CollUtil.newArrayList("1", "3", "5", "7", "9");
+		ArrayList<String> list2 = CollUtil.newArrayList("3", "4", "5", "6", "7");
+		allList1.add(list1);
+		allList1.add(list2);
+		Collection<String> intersection1 = CollUtil.intersection(list1, list2);
+		Collection<String> intersection2 = CollUtil.intersectionAll(allList1);
+		Collection<String> intersection3 = CollUtil.intersectionDistinct(list1, list2);
+		Collection<String> intersection4 = CollUtil.intersectionAllDistinct(allList1);
+		Assert.assertEquals(intersection1.size(), intersection2.size());
+		Assert.assertEquals(intersection3.size(), intersection4.size());
+
+		List<List<String>> allList2 = new ArrayList<>();
+		ArrayList<String> list3 = CollUtil.newArrayList("a", "b", "c", "c", "c");
+		ArrayList<String> list4 = CollUtil.newArrayList("a", "b", "c", "c");
+		allList2.add(list3);
+		allList2.add(list4);
+		Collection<String> intersection5 = CollUtil.intersection(list3, list4);
+		Collection<String> intersection6 = CollUtil.intersectionAll(allList2);
+		Collection<String> intersection7 = CollUtil.intersectionDistinct(list3, list4);
+		Collection<String> intersection8 = CollUtil.intersectionAllDistinct(allList2);
+		Assert.assertEquals(intersection5.size(), intersection6.size());
+		Assert.assertEquals(intersection7.size(), intersection8.size());
 	}
 
 	@Test

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -193,6 +193,21 @@ public class NumberUtilTest {
 		Assert.assertEquals("467.81", format);
 	}
 
+
+	@Test
+	public void formatMoneyTest() {
+		double money1 = 36.5;
+
+		//默认保留小数点后2位，即精确到分
+		Assert.assertEquals("36.50", NumberUtil.decimalFormatMoney(money1));
+		Assert.assertEquals("￥36.50", NumberUtil.formatMoney(money1));
+
+		//三位一分割
+		double money2 = 299792400.543534534;
+		Assert.assertEquals("299,792,400.54", NumberUtil.decimalFormatMoney(money2));
+		Assert.assertEquals("￥299,792,400.54", NumberUtil.formatMoney(money2));
+	}
+
 	@Test
 	public void decimalFormatMoneyTest() {
 		double c = 299792400.543534534;
@@ -203,6 +218,32 @@ public class NumberUtilTest {
 		double value = 0.5;
 		String money = NumberUtil.decimalFormatMoney(value);
 		Assert.assertEquals("0.50", money);
+	}
+
+
+	@Test
+	public void formatPercentTest() {
+		double percent1 = 0.8;
+		double percent2 = 0.88888888;
+
+		//默认保留小数点后2位，即精确到分
+		Assert.assertEquals("80%", NumberUtil.formatPercent(percent1, 2));
+		Assert.assertEquals("88.89%", NumberUtil.formatPercent(percent2, 2));
+	}
+
+	@Test
+	public void percentTest() {
+		double percent1 = 3;
+		double percent2 = 10;
+		double percent3 = 1;
+		double percent4 = 3;
+
+		//默认保留小数点后2位，即精确到分
+		Assert.assertEquals("30", NumberUtil.percent(percent1, percent2));
+		Assert.assertEquals("33.33", NumberUtil.percent(percent3, percent4));
+
+		//指定精度
+		Assert.assertEquals("33.333", NumberUtil.percent(percent3, percent4, 3));
 	}
 
 	@Test


### PR DESCRIPTION
``[新特性]

### CollUtil.java

**添加  `unionAll(Collection<? extends Collection<T>> coll) `方法**
有些时候数据库查出的数或者JSON转来的数据可能是List嵌套List的数据。
此时需要合并多个集合。若需要合并多个集合。

用老的方法`unionAll(Collection<T> coll1, Collection<T> coll2, Collection<T>... otherColls)`
则还需要将嵌套List进行拆分。传到不同的参数上。不太方便。


**intersectionAll方法 同理**


### NumberUtil.java

**添加percent()求百分比方法**
NumberUtil已有formatPercent方法用于将double转位百分比。可能还不太方便。

有时我们可能需要求进度，求百分比，等，而入参可能是当前进度，和总长度2个参数。
为了简化用户的除法操作。直接提供一个求百分比的方法。不带%的目的是方便用户转换成其他类型。

**添加formatMoney方法。**
eg:五万元 => ￥50,000


