### PR TITLE
fix flaky test cn.hutool.core.util.JAXBUtilTest#beanToXmlTest. no per…

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/util/JAXBUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/JAXBUtilTest.java
@@ -50,6 +50,7 @@ public class JAXBUtilTest {
 
 	@XmlRootElement(name = "school")
 	@XmlAccessorType(XmlAccessType.FIELD)
+	@XmlType(propOrder={"schoolName", "school_address", "room"})
 	public static class SchoolVo {
 		@XmlElement(name = "school_name", required = true)
 		private String schoolName;
@@ -86,6 +87,7 @@ public class JAXBUtilTest {
 		}
 
 		@XmlAccessorType(XmlAccessType.FIELD)
+		@XmlType(propOrder={"room_no", "room_name"})
 		public static final class RoomVo {
 			@XmlElement(name = "room_no", required = true)
 			private String roomNo;


### PR DESCRIPTION
您好！我是来自伊利诺伊大学的一名研究生。我们正在研究Flaky Test。 我们发现您的一个测试cn.hutool.core.util.JAXBUtilTest#beanToXmlTest的结果并不固定。究其原因是因为JAXB库序列化的结果并不是固定的，而您用了固定的string来对比测试的结果。我在这里附上这个库的作者stackoverflow的回答，供您参考：https://stackoverflow.com/questions/5435138/jaxb-and-property-ordering)
解决方法非常简单，只修改了测试的类，加了annotation使其序列化的结果固定。希望您能接受这个申请，如果有什么不足，欢迎提出建议！

Hello, I am a computer science major student who is recently taking a class about testing. We found that one of your tests cn.hutool.core.util.JAXBUtilTest produces an indeterministic result. The root cause is that JAXB does not provide a guarantee for the ordering serialization order. The fix is to add an annotation for the testing class to specify the returned ordering. It is simple and does not introduce any performance regression. It would be my honor if you could kindly accept the pull request and any criticism and advice are welcome!

