### PR TITLE
优化Base64.isBase64方法：减少一次多余的判断

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/codec/Base64.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/Base64.java
@@ -344,8 +344,7 @@ public class Base64 {
 			} else if('=' == base64Byte){
 				// 发现'=' 标记之
 				hasPadding = true;
-			}
-			if (false == (Base64Decoder.isBase64Code(base64Byte) || isWhiteSpace(base64Byte))) {
+			} else if (false == (Base64Decoder.isBase64Code(base64Byte) || isWhiteSpace(base64Byte))) {
 				return false;
 			}
 		}


### PR DESCRIPTION
1. [优化] 优化Base64.isBase64方法：减少一次多余的判断