### PR TITLE
fix flaky test cn.hutool.json.xml.XMLTest#toXmlTest

### DIFF
--- a/hutool-json/src/test/java/cn/hutool/json/xml/XMLTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/xml/XMLTest.java
@@ -5,6 +5,7 @@ import cn.hutool.json.JSONUtil;
 import cn.hutool.json.XML;
 import org.junit.Assert;
 import org.junit.Test;
+import org.hamcrest.CoreMatchers;
 
 public class XMLTest {
 
@@ -14,7 +15,7 @@ public class XMLTest {
 				.set("aaa", "你好")
 				.set("键2", "test");
 		final String s = JSONUtil.toXmlStr(put);
-		Assert.assertEquals("<aaa>你好</aaa><键2>test</键2>", s);
+		Assert.assertThat(s, CoreMatchers.anyOf(CoreMatchers.is("<aaa>你好</aaa><键2>test</键2>"), CoreMatchers.is("<键2>test</键2><aaa>你好</aaa>")));
 	}
 
 	@Test


### PR DESCRIPTION
下午好，我们修复了一个flaky test: cn.hutool.json.xml.XMLTest#toXmlTest.
1. 症状
由于在JSON object里面的元素的顺序是不固定的，因此在序列化的过程中，结果并不固定。
附上stack trace供您参考：
TEST: cn.hutool.json.xml.XMLTest
java.lang.Thread.getStackTrace(Thread.java:1559)
edu.illinois.nondex.common.NonDex.printStackTraceIfUniqueDebugPoint(NonDex.java:165)
edu.illinois.nondex.common.NonDex.shouldExplore(NonDex.java:136)
edu.illinois.nondex.common.NonDex.getPermutation(NonDex.java:106)
edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(ControlNondeterminism.java:63)
java.util.HashMap$HashIterator$HashIteratorShuffler.<init>(Unknown Source)
java.util.HashMap$HashIterator.<init>(HashMap.java:1435)
java.util.HashMap$EntryIterator.<init>(HashMap.java:1477)
java.util.HashMap$EntrySet.iterator(HashMap.java:1014)
***（map 调用） java.util.Map.forEach(Map.java:620)
cn.hutool.json.xml.JSONXMLSerializer.toXml(JSONXMLSerializer.java:63)
cn.hutool.json.XML.toXml(XML.java:138)
cn.hutool.json.XML.toXml(XML.java:125)
cn.hutool.json.XML.toXml(XML.java:113)
cn.hutool.json.JSONUtil.toXmlStr(JSONUtil.java:409)
cn.hutool.json.xml.XMLTest.toXmlTest(XMLTest.java:16)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runners.Suite.runChild(Suite.java:128)
org.junit.runners.Suite.runChild(Suite.java:27)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runner.JUnitCore.run(JUnitCore.java:137)
org.junit.runner.JUnitCore.run(JUnitCore.java:115)
org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:62)
org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:139)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

2. 解决方案
如果没有固定化序列化的结果的需求的话，我个人认为更改测试是比较合适的。不然对JSON的排序可能会导致性能下降。我更改了测试样例，使其能比对两个可能出现的结果。我本来想用Junit中的asserttrue，但是asserttrue在失败的时候并不能提供更详尽的debug信息。我注意到您的代码格式非常的规范整洁，为了向您学习和符合您的规范，我用了junit里面的一个package org.hamcrest用于比对两个可能出现的结果。我附上junit 4.13（您适用的版本）的API网页，供您参考（https://junit.org/junit4/javadoc/4.13/overview-summary.html）。希望能得到您的批评和指正。


Hello,
I fixed a flaky test cn.hutool.json.xml.XMLTest#toXmlTest. Due to the fact that JSON is not an ordered collection, its serialization result is not deterministic. By taking a closer look into stack trace, we found that internally JSON objects iterate over the map. The stack trace is attached below for your quick reference.

java.lang.Thread.getStackTrace(Thread.java:1559)
edu.illinois.nondex.common.NonDex.printStackTraceIfUniqueDebugPoint(NonDex.java:165)
edu.illinois.nondex.common.NonDex.shouldExplore(NonDex.java:136)
edu.illinois.nondex.common.NonDex.getPermutation(NonDex.java:106)
edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(ControlNondeterminism.java:63)
java.util.HashMap$HashIterator$HashIteratorShuffler.<init>(Unknown Source)
java.util.HashMap$HashIterator.<init>(HashMap.java:1435)
java.util.HashMap$EntryIterator.<init>(HashMap.java:1477)
java.util.HashMap$EntrySet.iterator(HashMap.java:1014)
***（map 调用） java.util.Map.forEach(Map.java:620)
cn.hutool.json.xml.JSONXMLSerializer.toXml(JSONXMLSerializer.java:63)
cn.hutool.json.XML.toXml(XML.java:138)
cn.hutool.json.XML.toXml(XML.java:125)
cn.hutool.json.XML.toXml(XML.java:113)
cn.hutool.json.JSONUtil.toXmlStr(JSONUtil.java:409)
cn.hutool.json.xml.XMLTest.toXmlTest(XMLTest.java:16)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runners.Suite.runChild(Suite.java:128)
org.junit.runners.Suite.runChild(Suite.java:27)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runner.JUnitCore.run(JUnitCore.java:137)
org.junit.runner.JUnitCore.run(JUnitCore.java:115)
org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:62)
org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:139)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

Propose Solution:
Personally, I think that it would be better to change the test instead of sorting the JSON object due to the fact that sorting generally introduces a performance penalty. To hold myself's PR to the high standard of this repo, I used org.hamcrest, which is integrated into junit 4.13, to assert the two possible outcomes instead of simply using asserttrue. It would provide more debug information than asserttrue in the case of test failure. Any criticism or advice is welcome. Thank you for your time!
