### PR TITLE
fix cn.hutool.core.text.StrJoinerTest#joinMultiArrayTest

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/text/StrJoinerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrJoinerTest.java
@@ -4,6 +4,7 @@ import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.ListUtil;
 import org.junit.Assert;
 import org.junit.Test;
+import org.hamcrest.CoreMatchers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +37,7 @@ public class StrJoinerTest {
 		append.append(new Object[]{ListUtil.of("1", "2"),
 				CollUtil.newHashSet("3", "4")
 		});
-		Assert.assertEquals("1,2,3,4", append.toString());
+		Assert.assertThat(append.toString(), CoreMatchers.anyOf(CoreMatchers.is("1,2,3,4"), CoreMatchers.is("1,2,4,3")));
 	}
 
 	@Test


### PR DESCRIPTION
早上好，我们修复了一个flaky test cn.hutool.core.text.StrJoinerTest.joinMultiArrayTest

1. 症状
这个测试试图将一个list和hash set结合起来，然后用一个固定的答案与结合的结果相比较。因为hash set的顺序不固定，因此这个测试有一定的可能会失败。附上详细的stack trace，供您参考。
TEST: cn.hutool.core.text.StrJoinerTest
java.lang.Thread.getStackTrace(Thread.java:1559)
edu.illinois.nondex.common.NonDex.printStackTraceIfUniqueDebugPoint(NonDex.java:165)
edu.illinois.nondex.common.NonDex.shouldExplore(NonDex.java:136)
edu.illinois.nondex.common.NonDex.getPermutation(NonDex.java:106)
edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(ControlNondeterminism.java:63)
java.util.HashMap$HashIterator$HashIteratorShuffler.<init>(Unknown Source)
java.util.HashMap$HashIterator.<init>(HashMap.java:1435)
java.util.HashMap$KeyIterator.<init>(HashMap.java:1467)
java.util.HashMap$KeySet.iterator(HashMap.java:917)
java.util.HashSet.iterator(HashSet.java:173)
cn.hutool.core.text.StrJoiner.append(StrJoiner.java:206)
cn.hutool.core.text.StrJoiner.append(StrJoiner.java:237)
cn.hutool.core.text.StrJoiner.append(StrJoiner.java:224)
cn.hutool.core.text.StrJoinerTest.joinMultiArrayTest(StrJoinerTest.java:36)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runners.Suite.runChild(Suite.java:128)
org.junit.runners.Suite.runChild(Suite.java:27)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runner.JUnitCore.run(JUnitCore.java:137)
org.junit.runner.JUnitCore.run(JUnitCore.java:115)
org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:62)
org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:139)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

2. 解决方案
针对这个测试，我们为这个测试提供了另外一个可能的答案，修复了这个测试的不确定性。


Good morning, we fix a flaky test cn.hutool.core.text.StrJoinerTest.joinMultiArrayTest

1. syndrome
The test tries to compare the concatenation of a list and a hash set with a fixed string. Since hashset does not have a fixed ording, the test yields indeterministic result. The stack trace for the test is attached below for your quick reference.
TEST: cn.hutool.core.text.StrJoinerTest
java.lang.Thread.getStackTrace(Thread.java:1559)
edu.illinois.nondex.common.NonDex.printStackTraceIfUniqueDebugPoint(NonDex.java:165)
edu.illinois.nondex.common.NonDex.shouldExplore(NonDex.java:136)
edu.illinois.nondex.common.NonDex.getPermutation(NonDex.java:106)
edu.illinois.nondex.shuffling.ControlNondeterminism.shuffle(ControlNondeterminism.java:63)
java.util.HashMap$HashIterator$HashIteratorShuffler.<init>(Unknown Source)
java.util.HashMap$HashIterator.<init>(HashMap.java:1435)
java.util.HashMap$KeyIterator.<init>(HashMap.java:1467)
java.util.HashMap$KeySet.iterator(HashMap.java:917)
java.util.HashSet.iterator(HashSet.java:173)
cn.hutool.core.text.StrJoiner.append(StrJoiner.java:206)
cn.hutool.core.text.StrJoiner.append(StrJoiner.java:237)
cn.hutool.core.text.StrJoiner.append(StrJoiner.java:224)
cn.hutool.core.text.StrJoinerTest.joinMultiArrayTest(StrJoinerTest.java:36)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runners.Suite.runChild(Suite.java:128)
org.junit.runners.Suite.runChild(Suite.java:27)
org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
org.junit.runners.ParentRunner.run(ParentRunner.java:413)
org.junit.runner.JUnitCore.run(JUnitCore.java:137)
org.junit.runner.JUnitCore.run(JUnitCore.java:115)
org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:62)
org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:139)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)

2. 解决方案
For this test, we added another possible expected answer to eliminate indeterminism. 