### PR TITLE
增加 TreeUtil 查询父节点下的所有子节点id方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/tree/TreeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/tree/TreeUtil.java
@@ -1,5 +1,6 @@
 package cn.hutool.core.lang.tree;
 
+import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.IterUtil;
 import cn.hutool.core.lang.tree.parser.DefaultNodeParser;
 import cn.hutool.core.lang.tree.parser.NodeParser;
@@ -232,4 +233,73 @@ public class TreeUtil {
 	public static <E> Tree<E> createEmptyNode(E id) {
 		return new Tree<E>().setId(id);
 	}
+
+	/**
+	 * 找到所有的 children 不包括查询父节点id
+	 *
+	 * @param trees    完整的树
+	 * @param parentId 要查询所有子集的父id
+	 * @param <T>      节点ID类型
+	 * @return 返回所有的子集集合
+	 * @since 5.7.16
+	 */
+	public static <T> List<T> findAllChildren(List<Tree<T>> trees, T parentId) {
+		return findAllChildren(trees,parentId,Boolean.TRUE);
+	}
+
+	/**
+	 * 找到所有的 children
+	 *
+	 * @param trees    完整的树
+	 * @param parentId 要查询所有子集的父id
+	 * @param <T>      节点ID类型
+	 * @param removeFirst true 删除根节点id false 保留根节点id
+	 * @return 返回所有的子集集合
+	 * @since 5.7.16
+	 */
+	public static <T> List<T> findAllChildren(List<Tree<T>> trees, T parentId,Boolean removeFirst) {
+		List<T> result = recursiveSearchAllChildren(new ArrayList<>(), trees, parentId, Boolean.FALSE);
+		if (removeFirst && result.size() > 0) {
+			result.remove(0);
+		}
+		return result;
+	}
+
+	/**
+	 * 递归方法
+	 * @param result 结果
+	 * @param trees 要查找的集合
+	 * @param parentId 要查找所有子集的父id
+	 * @param loop 递归标记
+	 * @param <T> 节点ID类型
+	 * @return 返回所有的子集集合
+	 * @since 5.7.16
+	 */
+	private static <T> List<T> recursiveSearchAllChildren(List<T> result, List<Tree<T>> trees, T parentId, Boolean loop) {
+		if (loop) {
+			for (Tree<T> tree : trees) {
+				result.add(tree.getId());
+				if (ObjectUtil.isNotNull(tree.getChildren()) && CollUtil.isNotEmpty(tree.getChildren())) {
+					recursiveSearchAllChildren(result, tree.getChildren(), parentId, Boolean.TRUE);
+				}
+			}
+		} else {
+			for (Tree<T> tree : trees) {
+				if (parentId != null) {
+					if (tree.getId().equals(parentId)) {
+						result.add(tree.getId());
+						if (ObjectUtil.isNotNull(tree.getChildren()) && CollUtil.isNotEmpty(tree.getChildren())) {
+							recursiveSearchAllChildren(result, tree.getChildren(), parentId, Boolean.TRUE);
+						}
+					} else {
+						if (ObjectUtil.isNotNull(tree.getChildren()) && CollUtil.isNotEmpty(tree.getChildren())) {
+							recursiveSearchAllChildren(result, tree.getChildren(), parentId, Boolean.FALSE);
+						}
+					}
+				}
+			}
+		}
+		return result;
+	}
+
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeUtilTest.java
@@ -1,0 +1,42 @@
+package cn.hutool.core.lang.tree;
+
+import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.collection.CollectionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TreeUtilTest {
+
+	static List<TreeNode<String>> nodeList = CollUtil.newArrayList();
+	static List<Tree<String>> treeList = new ArrayList<>();
+
+	static {
+		// 模拟数据
+
+		nodeList.add(new TreeNode<>("001", "0", "菜单", 0));
+
+
+		nodeList.add(new TreeNode<>("1", "001", "系统管理", 5));
+		nodeList.add(new TreeNode<>("111", "11", "用户添加", 0));
+		nodeList.add(new TreeNode<>("11", "1", "用户管理", 222222));
+
+		nodeList.add(new TreeNode<>("2", "001", "店铺管理", 1));
+		nodeList.add(new TreeNode<>("21", "2", "商品管理", 44));
+		nodeList.add(new TreeNode<>("221", "2", "商品管理2", 2));
+		treeList = TreeUtil.build(nodeList, "0", new TreeNodeConfig(), (treeNode, tree) -> {
+			tree.setId(treeNode.getId());
+			tree.setParentId(treeNode.getParentId());
+			tree.setWeight(treeNode.getWeight());
+			tree.setName(treeNode.getName());
+		});
+	}
+
+	@Test
+	public void testFindAllChildren() {
+		List<String> allChildren = TreeUtil.findAllChildren(treeList, "001");
+		Assert.assertArrayEquals(allChildren.toArray(), CollectionUtil.newArrayList("2","221","21","1","11","111").toArray());
+	}
+}


### PR DESCRIPTION
#### 说明

有这么一个场景，现在有个购物网站，他有很多类目比如 ”电子产品“，下面有 “手机” “笔记本电脑”
那么当用户点击 “电子产品” 的类目就要获取所有的子类目。
因此增加此方法，方便获取所有的子类目id，方便于查询

