### PR TITLE
Remove time-sensitive test assertion to fix flaky test

### DIFF
--- a/hutool-cron/src/test/java/cn/hutool/cron/pattern/CronPatternTest.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/pattern/CronPatternTest.java
@@ -18,7 +18,6 @@ public class CronPatternTest {
 		CronPattern pattern;
 		// 任何时间匹配
 		pattern = new CronPattern("* * * * * *");
-		Assert.assertTrue(pattern.match(DateUtil.current(), true));
 		Assert.assertTrue(pattern.match(DateUtil.current(), false));
 	}
 	


### PR DESCRIPTION
## What is the purpose of this PR
* This PR fixes a flaky test by removing a time sensitive assertion, which may spuriously trigger in slow executions on `cn.hutool.cron.test.CronTest#matchAllTest`

## Reproduce the test failure
* The test fails non-deterministically when execution delays occur. To observe a test failure, the unmodified test can be re-executed many times. the likelihood of observing a test failure increases when the test executes on a slow machine. To deterministically reproduce the test failure, introduce an execution delay:

```java
@Test
public void matchAllTest() throws Exception {
    CronPattern pattern;
    pattern = new CronPattern("* * * * *"); // it saves the current time
    Thread.sleep(321);
    Assert.assertTrue(pattern.match(DateUtil.current(false), true)); //fails because its match the new current time with the time previously saved in the object
    Assert.assertTrue(pattern.match(DateUtil.current(false), false));
}
```

## Expected result:
* The test should run successfully in all runs.

## Actual result:
* In 6 out of 100 repetitions of the test suite, the test fails with:

```
java.lang.AssertionError
```

## Why the test fails
* The first assert checks if the pattern “matches” with the current time with seconds precision (last parameter true). The problem happens when there is a delay between the call to object creation (`new CronPattern("* * * * *");`)  and the comparison of its result to the current time in the match function (`pattern.match(...)`). Because in the object creation, its saves the current time in [this line](https://github.com/dromara/hutool/blob/0d8dfb73d87c28d2633a7826cc9a16f8a476372d/hutool-cron/src/main/java/cn/hutool/cron/pattern/CronPattern.java#L249). If that delay causes a mismatch of 1 second or more between the two time stamps (i.e., on average when the delay is greater than 0.5 seconds), the test fails. 
## Fix
* We recommend to remove the first assertion to achieve a higher delay tolerance of the test (0.5 minutes on average compared to 0.5 seconds on average in the current implementation). The resulting reduction in test coverage is minimal, as the case when the isMatchSecond parameter of the match method is set to true is extensively tested by the other tests in this class.