### PR TITLE
修复 hutool-log模块编译错误 和 javadoc插件生成javadoc文档时的报错

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/CollStreamUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/CollStreamUtil.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 /**
  * 集合的stream操作封装
  *
- * @author 528910437@QQ.COM VampireAchao<achao1441470436@gmail.com>
+ * @author 528910437@QQ.COM VampireAchao[achao1441470436@gmail.com]
  * @since 5.5.2
  */
 public class CollStreamUtil {

--- a/hutool-log/pom.xml
+++ b/hutool-log/pom.xml
@@ -61,6 +61,12 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j2.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging</artifactId>
 			<version>${commons-logging.version}</version>


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 
    (1) 修复编译时hutool-log模块报 "找不到包org.apache.logging.log4j"的错误
    (2) 修复javadoc插件生成javadoc时由于特殊字符'<' 和 '>'导致的报错