### PR TITLE
修复getMainColor方法中参数rgbFilters无效问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/img/ImgUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/img/ImgUtil.java
@@ -2069,6 +2069,11 @@ public class ImgUtil {
 				countMap.merge(r + "-" + g + "-" + b, 1L, Long::sum);
 			}
 		}
+		if (rgbFilters != null && rgbFilters.length > 0) {
+			for (int[] rgbFilter : rgbFilters) {
+				countMap.remove(rgbFilter[0] + "-" + rgbFilter[1] + "-" + rgbFilter[2]);
+			}
+		}
 		String maxColor = null;
 		long maxCount = 0;
 		for (Map.Entry<String, Long> entry : countMap.entrySet()) {


### PR DESCRIPTION
 [bug修复] 修复getMainColor方法中参数rgbFilters无效问题

#### 复现
如给定一张大部分白色的图片，添加过滤参数，最终还是会输出#ffffff
```
int[] filter = {255, 255, 255};
String color = ImgUtil.getMainColor(image, filter);
System.out.println(color);
```