### PR TITLE
:bug: fix #2043

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/sql/Condition.java
+++ b/hutool-db/src/main/java/cn/hutool/db/sql/Condition.java
@@ -409,12 +409,14 @@ public class Condition extends CloneSupport<Condition> {
 		conditionStrBuilder.append(" (");
 		final Object value = this.value;
 		if (isPlaceHolder()) {
-			List<?> valuesForIn;
+			Collection<?> valuesForIn;
 			// 占位符对应值列表
 			if (value instanceof CharSequence) {
 				valuesForIn = StrUtil.split((CharSequence) value, ',');
+			} else if (value instanceof Collection) {
+				valuesForIn = (Collection<?>) value;
 			} else {
-				valuesForIn = Arrays.asList(Convert.convert(String[].class, value));
+				valuesForIn = Arrays.asList(Convert.convert(Object[].class, value));
 			}
 			conditionStrBuilder.append(StrUtil.repeatAndJoin("?", valuesForIn.size(), ","));
 			if (null != paramValues) {


### PR DESCRIPTION
SQL 构建使用条件占位符，会将值类型转为String
使用jdk1.8，先进行类型判断或许可以减少数据复制的次数