### PR TITLE
`Junit4` 替换为 `Junit5`

### DIFF
--- a/hutool-aop/src/test/java/cn/hutool/aop/test/AopTest.java
+++ b/hutool-aop/src/test/java/cn/hutool/aop/test/AopTest.java
@@ -4,8 +4,8 @@ import cn.hutool.aop.ProxyUtil;
 import cn.hutool.aop.aspects.TimeIntervalAspect;
 import cn.hutool.core.lang.Console;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * AOP模块单元测试
@@ -18,7 +18,7 @@ public class AopTest {
 	public void aopTest() {
 		Animal cat = ProxyUtil.proxy(new Cat(), TimeIntervalAspect.class);
 		String result = cat.eat();
-		Assert.assertEquals("猫吃鱼", result);
+		Assertions.assertEquals("猫吃鱼", result);
 		cat.seize();
 	}
 
@@ -26,7 +26,7 @@ public class AopTest {
 	public void aopByAutoCglibTest() {
 		Dog dog = ProxyUtil.proxy(new Dog(), TimeIntervalAspect.class);
 		String result = dog.eat();
-		Assert.assertEquals("狗吃肉", result);
+		Assertions.assertEquals("狗吃肉", result);
 
 		dog.seize();
 	}
@@ -78,7 +78,7 @@ public class AopTest {
 
 		TagObj proxy = ProxyUtil.proxy(target, TimeIntervalAspect.class);
 		//代理类获取标记tag (断言错误)
-		Assert.assertEquals("tag", proxy.getTag());
+		Assertions.assertEquals("tag", proxy.getTag());
 	}
 
 	@Data

--- a/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/BitMapBloomFilterTest.java
+++ b/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/BitMapBloomFilterTest.java
@@ -1,8 +1,7 @@
 package cn.hutool.bloomfilter;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.bloomfilter.bitMap.IntMap;
 import cn.hutool.bloomfilter.bitMap.LongMap;
@@ -16,13 +15,12 @@ public class BitMapBloomFilterTest {
 		filter.add("abc");
 		filter.add("ddd");
 
-		Assert.assertTrue(filter.contains("abc"));
-		Assert.assertTrue(filter.contains("ddd"));
-		Assert.assertTrue(filter.contains("123"));
+		Assertions.assertTrue(filter.contains("abc"));
+		Assertions.assertTrue(filter.contains("ddd"));
+		Assertions.assertTrue(filter.contains("123"));
 	}
 
 	@Test
-	@Ignore
 	public void testIntMap(){
 		IntMap intMap = new IntMap();
 
@@ -38,7 +36,6 @@ public class BitMapBloomFilterTest {
 	}
 
 	@Test
-	@Ignore
 	public void testLongMap(){
 		LongMap longMap = new LongMap();
 

--- a/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/BitMapBloomFilterTest.java
+++ b/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/BitMapBloomFilterTest.java
@@ -1,6 +1,7 @@
 package cn.hutool.bloomfilter;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import cn.hutool.bloomfilter.bitMap.IntMap;
@@ -21,6 +22,7 @@ public class BitMapBloomFilterTest {
 	}
 
 	@Test
+	@Disabled
 	public void testIntMap(){
 		IntMap intMap = new IntMap();
 
@@ -36,6 +38,7 @@ public class BitMapBloomFilterTest {
 	}
 
 	@Test
+	@Disabled
 	public void testLongMap(){
 		LongMap longMap = new LongMap();
 

--- a/hutool-cache/src/test/java/cn/hutool/cache/CacheConcurrentTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/CacheConcurrentTest.java
@@ -6,9 +6,9 @@ import cn.hutool.cache.impl.WeakCache;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ConcurrencyTester;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CacheConcurrentTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void fifoCacheTest() {
 		int threadCount = 4000;
 		final Cache<String, String> cache = new FIFOCache<>(3);
@@ -52,7 +52,7 @@ public class CacheConcurrentTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void lruCacheTest() {
 		int threadCount = 40000;
 		final Cache<String, String> cache = new LRUCache<>(1000);
@@ -102,6 +102,6 @@ public class CacheConcurrentTest {
 		});
 		long interval = concurrencyTester.getInterval();
 		// 总耗时应与单次操作耗时在同一个数量级
-		Assert.assertTrue(interval < delay * 2);
+		Assertions.assertTrue(interval < delay * 2);
 	}
 }

--- a/hutool-cache/src/test/java/cn/hutool/cache/CacheTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/CacheTest.java
@@ -4,8 +4,8 @@ import cn.hutool.cache.impl.TimedCache;
 import cn.hutool.core.date.DateUnit;
 import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.core.util.RandomUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 缓存测试用例
@@ -19,8 +19,8 @@ public class CacheTest {
 		Cache<String,String> fifoCache = CacheUtil.newFIFOCache(3);
 		fifoCache.setListener((key, value)->{
 			// 监听测试，此测试中只有key1被移除，测试是否监听成功
-			Assert.assertEquals("key1", key);
-			Assert.assertEquals("value1", value);
+			Assertions.assertEquals("key1", key);
+			Assertions.assertEquals("value1", value);
 		});
 
 		fifoCache.put("key1", "value1", DateUnit.SECOND.getMillis() * 3);
@@ -30,7 +30,7 @@ public class CacheTest {
 
 		//由于缓存容量只有3，当加入第四个元素的时候，根据FIFO规则，最先放入的对象将被移除
 		String value1 = fifoCache.get("key1");
-		Assert.assertNull(value1);
+		Assertions.assertNull(value1);
 	}
 
 	@Test
@@ -39,7 +39,7 @@ public class CacheTest {
 		for (int i = 0; i < RandomUtil.randomInt(100, 1000); i++) {
 			fifoCache.put("key" + i, "value" + i);
 		}
-		Assert.assertEquals(100, fifoCache.size());
+		Assertions.assertEquals(100, fifoCache.size());
 	}
 
 	@Test
@@ -56,9 +56,9 @@ public class CacheTest {
 		String value1 = lfuCache.get("key1");
 		String value2 = lfuCache.get("key2");
 		String value3 = lfuCache.get("key3");
-		Assert.assertNotNull(value1);
-		Assert.assertNull(value2);
-		Assert.assertNull(value3);
+		Assertions.assertNotNull(value1);
+		Assertions.assertNull(value2);
+		Assertions.assertNull(value3);
 	}
 
 	@Test
@@ -74,10 +74,10 @@ public class CacheTest {
 		lruCache.put("key4", "value4", DateUnit.SECOND.getMillis() * 3);
 
 		String value1 = lruCache.get("key1");
-		Assert.assertNotNull(value1);
+		Assertions.assertNotNull(value1);
 		//由于缓存容量只有3，当加入第四个元素的时候，根据LRU规则，最少使用的将被移除（2被移除）
 		String value2 = lruCache.get("key2");
-		Assert.assertNull(value2);
+		Assertions.assertNull(value2);
 	}
 
 	@Test
@@ -96,20 +96,20 @@ public class CacheTest {
 
 		//5毫秒后由于value2设置了5毫秒过期，因此只有value2被保留下来
 		String value1 = timedCache.get("key1");
-		Assert.assertNull(value1);
+		Assertions.assertNull(value1);
 		String value2 = timedCache.get("key2");
-		Assert.assertEquals("value2", value2);
+		Assertions.assertEquals("value2", value2);
 
 		//5毫秒后，由于设置了默认过期，key3只被保留4毫秒，因此为null
 		String value3 = timedCache.get("key3");
-		Assert.assertNull(value3);
+		Assertions.assertNull(value3);
 
 		String value3Supplier = timedCache.get("key3", () -> "Default supplier");
-		Assert.assertEquals("Default supplier", value3Supplier);
+		Assertions.assertEquals("Default supplier", value3Supplier);
 
 		// 永不过期
 		String value4 = timedCache.get("key4");
-		Assert.assertEquals("value4", value4);
+		Assertions.assertEquals("value4", value4);
 
 		//取消定时清理
 		timedCache.cancelPruneSchedule();

--- a/hutool-cache/src/test/java/cn/hutool/cache/FileCacheTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/FileCacheTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.cache;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.cache.file.LFUFileCache;
 
@@ -14,6 +14,6 @@ public class FileCacheTest {
 	@Test
 	public void lfuFileCacheTest() {
 		LFUFileCache cache = new LFUFileCache(1000, 500, 2000);
-		Assert.assertNotNull(cache);
+		Assertions.assertNotNull(cache);
 	}
 }

--- a/hutool-cache/src/test/java/cn/hutool/cache/LRUCacheTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/LRUCacheTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.cache;
 
 import cn.hutool.cache.impl.LRUCache;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -38,7 +38,7 @@ public class LRUCacheTest {
 		for (int i = 0; i < 10; i++) {
 			sb1.append(cache.get(i));
 		}
-		Assert.assertEquals("0123456789", sb1.toString());
+		Assertions.assertEquals("0123456789", sb1.toString());
 
 		// 新加11，此时0最久未使用，应该淘汰0
 		cache.put(11, 11);
@@ -47,6 +47,6 @@ public class LRUCacheTest {
 		for (int i = 0; i < 10; i++) {
 			sb2.append(cache.get(i));
 		}
-		Assert.assertEquals("null123456789", sb2.toString());
+		Assertions.assertEquals("null123456789", sb2.toString());
 	}
 }

--- a/hutool-cache/src/test/java/cn/hutool/cache/WeakCacheTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/WeakCacheTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.cache;
 
 import cn.hutool.cache.impl.WeakCache;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class WeakCacheTest {
 
@@ -12,10 +12,10 @@ public class WeakCacheTest {
 		cache.put("abc", "123");
 		cache.put("def", "456");
 
-		Assert.assertEquals(2, cache.size());
+		Assertions.assertEquals(2, cache.size());
 
 		cache.remove("abc");
 
-		Assert.assertEquals(1, cache.size());
+		Assertions.assertEquals(1, cache.size());
 	}
 }

--- a/hutool-captcha/src/test/java/cn/hutool/captcha/CaptchaTest.java
+++ b/hutool-captcha/src/test/java/cn/hutool/captcha/CaptchaTest.java
@@ -2,9 +2,9 @@ package cn.hutool.captcha;
 
 import cn.hutool.captcha.generator.MathGenerator;
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.*;
 
@@ -19,12 +19,12 @@ public class CaptchaTest {
 	public void lineCaptchaTest1() {
 		// 定义图形验证码的长和宽
 		LineCaptcha lineCaptcha = CaptchaUtil.createLineCaptcha(200, 100);
-		Assert.assertNotNull(lineCaptcha.getCode());
-		Assert.assertTrue(lineCaptcha.verify(lineCaptcha.getCode()));
+		Assertions.assertNotNull(lineCaptcha.getCode());
+		Assertions.assertTrue(lineCaptcha.verify(lineCaptcha.getCode()));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void lineCaptchaTest3() {
 		// 定义图形验证码的长和宽
 		LineCaptcha lineCaptcha = CaptchaUtil.createLineCaptcha(200, 70, 4, 15);
@@ -33,7 +33,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void lineCaptchaWithMathTest() {
 		// 定义图形验证码的长和宽
 		LineCaptcha lineCaptcha = CaptchaUtil.createLineCaptcha(200, 80);
@@ -43,7 +43,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void lineCaptchaTest2() {
 
 		// 定义图形验证码的长和宽
@@ -63,7 +63,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void circleCaptchaTest() {
 
 		// 定义图形验证码的长和宽
@@ -76,7 +76,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void shearCaptchaTest() {
 
 		// 定义图形验证码的长和宽
@@ -89,7 +89,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void shearCaptchaTest2() {
 
 		// 定义图形验证码的长和宽
@@ -101,7 +101,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void ShearCaptchaWithMathTest() {
 		// 定义图形验证码的长和宽
 		ShearCaptcha captcha = CaptchaUtil.createShearCaptcha(200, 45, 4, 4);
@@ -114,7 +114,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void GifCaptchaTest() {
 		GifCaptcha captcha = CaptchaUtil.createGifCaptcha(200, 100, 4);
 		captcha.write("d:/test/gif_captcha.gif");
@@ -122,7 +122,7 @@ public class CaptchaTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void bgTest(){
 		LineCaptcha captcha = CaptchaUtil.createLineCaptcha(200, 100, 4, 1);
 		captcha.setBackground(Color.WHITE);

--- a/hutool-captcha/src/test/java/cn/hutool/captcha/CaptchaUtilTest.java
+++ b/hutool-captcha/src/test/java/cn/hutool/captcha/CaptchaUtilTest.java
@@ -1,12 +1,12 @@
 package cn.hutool.captcha;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CaptchaUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void createTest() {
 		for(int i = 0; i < 1; i++) {
 			CaptchaUtil.createShearCaptcha(320, 240);

--- a/hutool-captcha/src/test/java/cn/hutool/captcha/GeneratorTest.java
+++ b/hutool-captcha/src/test/java/cn/hutool/captcha/GeneratorTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.captcha;
 
 import cn.hutool.captcha.generator.MathGenerator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GeneratorTest {
 

--- a/hutool-core/src/test/java/cn/hutool/core/annotation/AnnotationUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/annotation/AnnotationUtilTest.java
@@ -1,14 +1,14 @@
 package cn.hutool.core.annotation;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AnnotationUtilTest {
 
 	@Test
 	public void getAnnotationValueTest() {
 		Object value = AnnotationUtil.getAnnotationValue(ClassWithAnnotation.class, AnnotationForTest.class);
-		Assert.assertEquals("测试", value);
+		Assertions.assertEquals("测试", value);
 
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanCopyMappingTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanCopyMappingTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.bean.copier.CopyOptions;
 import cn.hutool.core.map.MapUtil;
 import lombok.Builder;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BeanCopyMappingTest {
 
@@ -24,7 +24,7 @@ public class BeanCopyMappingTest {
 		BeanUtil.copyProperties(b, a, copyOptions);
 		BeanUtil.copyProperties(a, c);
 
-		Assert.assertEquals("12312312", c.getCarNo());
+		Assertions.assertEquals("12312312", c.getCarNo());
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanDescTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanDescTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.bean;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@link BeanDesc} 单元测试类
@@ -14,13 +14,13 @@ public class BeanDescTest {
 	@Test
 	public void propDescTes() {
 		BeanDesc desc = BeanUtil.getBeanDesc(User.class);
-		Assert.assertEquals("User", desc.getSimpleName());
+		Assertions.assertEquals("User", desc.getSimpleName());
 
-		Assert.assertEquals("age", desc.getField("age").getName());
-		Assert.assertEquals("getAge", desc.getGetter("age").getName());
-		Assert.assertEquals("setAge", desc.getSetter("age").getName());
-		Assert.assertEquals(1, desc.getSetter("age").getParameterTypes().length);
-		Assert.assertSame(int.class, desc.getSetter("age").getParameterTypes()[0]);
+		Assertions.assertEquals("age", desc.getField("age").getName());
+		Assertions.assertEquals("getAge", desc.getGetter("age").getName());
+		Assertions.assertEquals("setAge", desc.getSetter("age").getName());
+		Assertions.assertEquals(1, desc.getSetter("age").getParameterTypes().length);
+		Assertions.assertSame(int.class, desc.getSetter("age").getParameterTypes()[0]);
 
 	}
 
@@ -29,29 +29,29 @@ public class BeanDescTest {
 		BeanDesc desc = BeanUtil.getBeanDesc(User.class);
 
 		PropDesc prop = desc.getProp("name");
-		Assert.assertEquals("name", prop.getFieldName());
-		Assert.assertEquals("getName", prop.getGetter().getName());
-		Assert.assertEquals("setName", prop.getSetter().getName());
-		Assert.assertEquals(1, prop.getSetter().getParameterTypes().length);
-		Assert.assertSame(String.class, prop.getSetter().getParameterTypes()[0]);
+		Assertions.assertEquals("name", prop.getFieldName());
+		Assertions.assertEquals("getName", prop.getGetter().getName());
+		Assertions.assertEquals("setName", prop.getSetter().getName());
+		Assertions.assertEquals(1, prop.getSetter().getParameterTypes().length);
+		Assertions.assertSame(String.class, prop.getSetter().getParameterTypes()[0]);
 	}
 
 	@Test
 	public void propDescOfBooleanTest() {
 		BeanDesc desc = BeanUtil.getBeanDesc(User.class);
 
-		Assert.assertEquals("isAdmin", desc.getGetter("isAdmin").getName());
-		Assert.assertEquals("setAdmin", desc.getSetter("isAdmin").getName());
-		Assert.assertEquals("isGender", desc.getGetter("gender").getName());
-		Assert.assertEquals("setGender", desc.getSetter("gender").getName());
+		Assertions.assertEquals("isAdmin", desc.getGetter("isAdmin").getName());
+		Assertions.assertEquals("setAdmin", desc.getSetter("isAdmin").getName());
+		Assertions.assertEquals("isGender", desc.getGetter("gender").getName());
+		Assertions.assertEquals("setGender", desc.getSetter("gender").getName());
 	}
 
 	@Test
 	public void propDescOfBooleanTest2() {
 		BeanDesc desc = BeanUtil.getBeanDesc(User.class);
 
-		Assert.assertEquals("isIsSuper", desc.getGetter("isSuper").getName());
-		Assert.assertEquals("setIsSuper", desc.getSetter("isSuper").getName());
+		Assertions.assertEquals("isIsSuper", desc.getGetter("isSuper").getName());
+		Assertions.assertEquals("setIsSuper", desc.getSetter("isSuper").getName());
 	}
 
 	@Test
@@ -60,10 +60,10 @@ public class BeanDescTest {
 
 		User user = new User();
 		desc.getProp("name").setValue(user, "张三");
-		Assert.assertEquals("张三", user.getName());
+		Assertions.assertEquals("张三", user.getName());
 
 		Object value = desc.getProp("name").getValue(user);
-		Assert.assertEquals("张三", value);
+		Assertions.assertEquals("张三", value);
 	}
 
 	public static class User {

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
@@ -5,9 +5,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.test.bean.ExamInfoDict;
 import cn.hutool.core.lang.test.bean.UserInfoDict;
@@ -20,10 +20,10 @@ import cn.hutool.core.lang.test.bean.UserInfoDict;
  */
 public class BeanPathTest {
 
-	Map<String, Object> tempMap;
+	static Map<String, Object> tempMap;
 
-	@Before
-	public void init() {
+	@BeforeAll
+	static void init() {
 		// ------------------------------------------------- 考试信息列表
 		ExamInfoDict examInfoDict = new ExamInfoDict();
 		examInfoDict.setId(1);
@@ -60,36 +60,36 @@ public class BeanPathTest {
 	@Test
 	public void beanPathTest1() {
 		BeanPath pattern = new BeanPath("userInfo.examInfoDict[0].id");
-		Assert.assertEquals("userInfo", pattern.patternParts.get(0));
-		Assert.assertEquals("examInfoDict", pattern.patternParts.get(1));
-		Assert.assertEquals("0", pattern.patternParts.get(2));
-		Assert.assertEquals("id", pattern.patternParts.get(3));
+		Assertions.assertEquals("userInfo", pattern.patternParts.get(0));
+		Assertions.assertEquals("examInfoDict", pattern.patternParts.get(1));
+		Assertions.assertEquals("0", pattern.patternParts.get(2));
+		Assertions.assertEquals("id", pattern.patternParts.get(3));
 
 	}
 
 	@Test
 	public void beanPathTest2() {
 		BeanPath pattern = new BeanPath("[userInfo][examInfoDict][0][id]");
-		Assert.assertEquals("userInfo", pattern.patternParts.get(0));
-		Assert.assertEquals("examInfoDict", pattern.patternParts.get(1));
-		Assert.assertEquals("0", pattern.patternParts.get(2));
-		Assert.assertEquals("id", pattern.patternParts.get(3));
+		Assertions.assertEquals("userInfo", pattern.patternParts.get(0));
+		Assertions.assertEquals("examInfoDict", pattern.patternParts.get(1));
+		Assertions.assertEquals("0", pattern.patternParts.get(2));
+		Assertions.assertEquals("id", pattern.patternParts.get(3));
 	}
 
 	@Test
 	public void beanPathTest3() {
 		BeanPath pattern = new BeanPath("['userInfo']['examInfoDict'][0]['id']");
-		Assert.assertEquals("userInfo", pattern.patternParts.get(0));
-		Assert.assertEquals("examInfoDict", pattern.patternParts.get(1));
-		Assert.assertEquals("0", pattern.patternParts.get(2));
-		Assert.assertEquals("id", pattern.patternParts.get(3));
+		Assertions.assertEquals("userInfo", pattern.patternParts.get(0));
+		Assertions.assertEquals("examInfoDict", pattern.patternParts.get(1));
+		Assertions.assertEquals("0", pattern.patternParts.get(2));
+		Assertions.assertEquals("id", pattern.patternParts.get(3));
 	}
 
 	@Test
 	public void getTest() {
 		BeanPath pattern = BeanPath.create("userInfo.examInfoDict[0].id");
 		Object result = pattern.get(tempMap);
-		Assert.assertEquals(1, result);
+		Assertions.assertEquals(1, result);
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class BeanPathTest {
 		BeanPath pattern = BeanPath.create("userInfo.examInfoDict[0].id");
 		pattern.set(tempMap, 2);
 		Object result = pattern.get(tempMap);
-		Assert.assertEquals(2, result);
+		Assertions.assertEquals(2, result);
 	}
 
 	@Test
@@ -105,7 +105,7 @@ public class BeanPathTest {
 		BeanPath pattern = BeanPath.create("userInfo[id, photoPath]");
 		@SuppressWarnings("unchecked")
 		Map<String, Object> result = (Map<String, Object>)pattern.get(tempMap);
-		Assert.assertEquals(1, result.get("id"));
-		Assert.assertEquals("yx.mm.com", result.get("photoPath"));
+		Assertions.assertEquals(1, result.get("id"));
+		Assertions.assertEquals("yx.mm.com", result.get("photoPath"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.test.bean.ExamInfoDict;
@@ -20,10 +20,10 @@ import cn.hutool.core.lang.test.bean.UserInfoDict;
  */
 public class BeanPathTest {
 
-	static Map<String, Object> tempMap;
+	Map<String, Object> tempMap;
 
-	@BeforeAll
-	static void init() {
+	@BeforeEach
+	public void init() {
 		// ------------------------------------------------- 考试信息列表
 		ExamInfoDict examInfoDict = new ExamInfoDict();
 		examInfoDict.setId(1);

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.test.bean.ExamInfoDict;
@@ -20,10 +20,10 @@ import cn.hutool.core.lang.test.bean.UserInfoDict;
  */
 public class BeanPathTest {
 
-	Map<String, Object> tempMap;
+	static Map<String, Object> tempMap;
 
-	@BeforeEach
-	public void init() {
+	@BeforeAll
+	public static void init() {
 		// ------------------------------------------------- 考试信息列表
 		ExamInfoDict examInfoDict = new ExamInfoDict();
 		examInfoDict.setId(1);

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
@@ -15,9 +15,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.beans.PropertyDescriptor;
 import java.io.Serializable;
@@ -46,7 +46,7 @@ public class BeanUtilTest {
 
 		// HashMap不包含setXXX方法，不是bean
 		boolean isBean = BeanUtil.isBean(HashMap.class);
-		Assert.assertFalse(isBean);
+		Assertions.assertFalse(isBean);
 	}
 
 	@Test
@@ -72,8 +72,8 @@ public class BeanUtilTest {
 
 		}, CopyOptions.create());
 
-		Assert.assertEquals(person.getName(), "张三");
-		Assert.assertEquals(person.getAge(), 18);
+		Assertions.assertEquals(person.getName(), "张三");
+		Assertions.assertEquals(person.getAge(), 18);
 	}
 
 	@Test
@@ -83,9 +83,9 @@ public class BeanUtilTest {
 		map.put("aGe", 12);
 		map.put("openId", "DFDFSDFWERWER");
 		SubPerson person = BeanUtil.fillBeanWithMapIgnoreCase(map, new SubPerson(), false);
-		Assert.assertEquals(person.getName(), "Joe");
-		Assert.assertEquals(person.getAge(), 12);
-		Assert.assertEquals(person.getOpenid(), "DFDFSDFWERWER");
+		Assertions.assertEquals(person.getName(), "Joe");
+		Assertions.assertEquals(person.getAge(), 12);
+		Assertions.assertEquals(person.getOpenid(), "DFDFSDFWERWER");
 	}
 
 	@Test
@@ -97,11 +97,11 @@ public class BeanUtilTest {
 		person.setSubName("sub名字");
 
 		final Map<?, ?> map = BeanUtil.toBean(person, Map.class);
-		Assert.assertEquals("测试A11", map.get("name"));
-		Assert.assertEquals(14, map.get("age"));
-		Assert.assertEquals("11213232", map.get("openid"));
+		Assertions.assertEquals("测试A11", map.get("name"));
+		Assertions.assertEquals(14, map.get("age"));
+		Assertions.assertEquals("11213232", map.get("openid"));
 		// static属性应被忽略
-		Assert.assertFalse(map.containsKey("SUBNAME"));
+		Assertions.assertFalse(map.containsKey("SUBNAME"));
 	}
 
 	/**
@@ -115,9 +115,9 @@ public class BeanUtilTest {
 		map.put("age", "aaaaaa");
 
 		Person person = BeanUtil.toBeanIgnoreError(map, Person.class);
-		Assert.assertEquals("Joe", person.getName());
+		Assertions.assertEquals("Joe", person.getName());
 		// 错误的类型，不copy这个字段，使用对象创建的默认值
-		Assert.assertEquals(0, person.getAge());
+		Assertions.assertEquals(0, person.getAge());
 	}
 
 	@Test
@@ -127,8 +127,8 @@ public class BeanUtilTest {
 		map.put("aGe", 12);
 
 		Person person = BeanUtil.toBeanIgnoreCase(map, Person.class, false);
-		Assert.assertEquals("Joe", person.getName());
-		Assert.assertEquals(12, person.getAge());
+		Assertions.assertEquals("Joe", person.getName());
+		Assertions.assertEquals(12, person.getAge());
 	}
 
 	@Test
@@ -143,8 +143,8 @@ public class BeanUtilTest {
 		mapping.put("b_age", "age");
 
 		Person person = BeanUtil.toBean(map, Person.class, CopyOptions.create().setFieldMapping(mapping));
-		Assert.assertEquals("Joe", person.getName());
-		Assert.assertEquals(12, person.getAge());
+		Assertions.assertEquals("Joe", person.getName());
+		Assertions.assertEquals(12, person.getAge());
 	}
 
 	/**
@@ -158,18 +158,20 @@ public class BeanUtilTest {
 
 		// 非空构造也可以实例化成功
 		Person2 person = BeanUtil.toBean(map, Person2.class, CopyOptions.create());
-		Assert.assertEquals("Joe", person.name);
-		Assert.assertEquals(12, person.age);
+		Assertions.assertEquals("Joe", person.name);
+		Assertions.assertEquals(12, person.age);
 	}
 
 	/**
 	 * 测试在不忽略错误情况下，转换失败需要报错。
 	 */
-	@Test(expected = NumberFormatException.class)
+	@Test
 	public void mapToBeanWinErrorTest() {
-		Map<String, String> map = new HashMap<>();
-		map.put("age", "哈哈");
-		BeanUtil.toBean(map, Person.class);
+		Assertions.assertThrows(NumberFormatException.class, () -> {
+			Map<String, String> map = new HashMap<>();
+			map.put("age", "哈哈");
+			BeanUtil.toBean(map, Person.class);
+		});
 	}
 
 	@Test
@@ -182,11 +184,11 @@ public class BeanUtilTest {
 
 		Map<String, Object> map = BeanUtil.beanToMap(person);
 
-		Assert.assertEquals("测试A11", map.get("name"));
-		Assert.assertEquals(14, map.get("age"));
-		Assert.assertEquals("11213232", map.get("openid"));
+		Assertions.assertEquals("测试A11", map.get("name"));
+		Assertions.assertEquals(14, map.get("age"));
+		Assertions.assertEquals("11213232", map.get("openid"));
 		// static属性应被忽略
-		Assert.assertFalse(map.containsKey("SUBNAME"));
+		Assertions.assertFalse(map.containsKey("SUBNAME"));
 	}
 
 	@Test
@@ -198,7 +200,7 @@ public class BeanUtilTest {
 		person.setSubName("sub名字");
 
 		Map<String, Object> map = BeanUtil.beanToMap(person, true, true);
-		Assert.assertEquals("sub名字", map.get("sub_name"));
+		Assertions.assertEquals("sub名字", map.get("sub_name"));
 	}
 
 	@Test
@@ -211,7 +213,7 @@ public class BeanUtilTest {
 
 		Map<String, Object> map = BeanUtil.beanToMap(person, new LinkedHashMap<>(),
 				CopyOptions.create().setFieldValueEditor((key, value) -> key + "_" + value));
-		Assert.assertEquals("subName_sub名字", map.get("subName"));
+		Assertions.assertEquals("subName_sub名字", map.get("subName"));
 	}
 
 	@Test
@@ -226,7 +228,7 @@ public class BeanUtilTest {
 		person.setBooleanb(true);
 
 		Map<String, Object> map = BeanUtil.beanToMap(person);
-		Assert.assertEquals("sub名字", map.get("aliasSubName"));
+		Assertions.assertEquals("sub名字", map.get("aliasSubName"));
 	}
 
 	@Test
@@ -238,9 +240,9 @@ public class BeanUtilTest {
 		map.put("is_booleanb", true);
 
 		final SubPersonWithAlias subPersonWithAlias = BeanUtil.toBean(map, SubPersonWithAlias.class);
-		Assert.assertEquals("sub名字", subPersonWithAlias.getSubName());
-		Assert.assertTrue(subPersonWithAlias.isBooleana());
-		Assert.assertEquals(true, subPersonWithAlias.getBooleanb());
+		Assertions.assertEquals("sub名字", subPersonWithAlias.getSubName());
+		Assertions.assertTrue(subPersonWithAlias.isBooleana());
+		Assertions.assertEquals(true, subPersonWithAlias.getBooleanb());
 	}
 
 	@Test
@@ -256,8 +258,8 @@ public class BeanUtilTest {
 		person.setDate2(now.toLocalDate());
 
 		Map<String, Object> map = BeanUtil.beanToMap(person, false, true);
-		Assert.assertEquals(now, map.get("date"));
-		Assert.assertEquals(now.toLocalDate(), map.get("date2"));
+		Assertions.assertEquals(now, map.get("date"));
+		Assertions.assertEquals(now.toLocalDate(), map.get("date2"));
 	}
 
 	@Test
@@ -269,16 +271,16 @@ public class BeanUtilTest {
 		person.setSubName("sub名字");
 
 		Object name = BeanUtil.getProperty(person, "name");
-		Assert.assertEquals("测试A11", name);
+		Assertions.assertEquals("测试A11", name);
 		Object subName = BeanUtil.getProperty(person, "subName");
-		Assert.assertEquals("sub名字", subName);
+		Assertions.assertEquals("sub名字", subName);
 	}
 
 	@Test
 	@SuppressWarnings("ConstantConditions")
 	public void getNullPropertyTest() {
 		final Object property = BeanUtil.getProperty(null, "name");
-		Assert.assertNull(property);
+		Assertions.assertNull(property);
 	}
 
 	@Test
@@ -288,12 +290,12 @@ public class BeanUtilTest {
 		for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
 			set.add(propertyDescriptor.getName());
 		}
-		Assert.assertTrue(set.contains("age"));
-		Assert.assertTrue(set.contains("id"));
-		Assert.assertTrue(set.contains("name"));
-		Assert.assertTrue(set.contains("openid"));
-		Assert.assertTrue(set.contains("slow"));
-		Assert.assertTrue(set.contains("subName"));
+		Assertions.assertTrue(set.contains("age"));
+		Assertions.assertTrue(set.contains("id"));
+		Assertions.assertTrue(set.contains("name"));
+		Assertions.assertTrue(set.contains("openid"));
+		Assertions.assertTrue(set.contains("slow"));
+		Assertions.assertTrue(set.contains("subName"));
 	}
 
 	@Test
@@ -305,14 +307,14 @@ public class BeanUtilTest {
 		person.setSubName("sub名字");
 
 		SubPerson person1 = BeanUtil.copyProperties(person, SubPerson.class);
-		Assert.assertEquals(14, person1.getAge());
-		Assert.assertEquals("11213232", person1.getOpenid());
-		Assert.assertEquals("测试A11", person1.getName());
-		Assert.assertEquals("sub名字", person1.getSubName());
+		Assertions.assertEquals(14, person1.getAge());
+		Assertions.assertEquals("11213232", person1.getOpenid());
+		Assertions.assertEquals("测试A11", person1.getName());
+		Assertions.assertEquals("sub名字", person1.getSubName());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void multiThreadTest(){
 		Student student = new Student();
 		student.setName("张三");
@@ -350,12 +352,12 @@ public class BeanUtilTest {
 		// 测试boolean参数值isXXX形式
 		SubPerson p2 = new SubPerson();
 		BeanUtil.copyProperties(p1, p2);
-		Assert.assertTrue(p2.getSlow());
+		Assertions.assertTrue(p2.getSlow());
 
 		// 测试boolean参数值非isXXX形式
 		SubPerson2 p3 = new SubPerson2();
 		BeanUtil.copyProperties(p1, p3);
-		Assert.assertTrue(p3.getSlow());
+		Assertions.assertTrue(p3.getSlow());
 	}
 
 	@Test
@@ -369,11 +371,11 @@ public class BeanUtilTest {
 
 		// null值不覆盖目标属性
 		BeanUtil.copyProperties(p1, p2, CopyOptions.create().ignoreNullValue());
-		Assert.assertEquals("oldName", p2.getName());
+		Assertions.assertEquals("oldName", p2.getName());
 
 		// null覆盖目标属性
 		BeanUtil.copyProperties(p1, p2);
-		Assert.assertNull(p2.getName());
+		Assertions.assertNull(p2.getName());
 	}
 
 	@Test
@@ -386,9 +388,9 @@ public class BeanUtilTest {
 
 		Map<String, Object> map = MapUtil.newHashMap();
 		BeanUtil.copyProperties(p1, map);
-		Assert.assertTrue((Boolean) map.get("slow"));
-		Assert.assertEquals("测试", map.get("name"));
-		Assert.assertEquals("sub测试", map.get("subName"));
+		Assertions.assertTrue((Boolean) map.get("slow"));
+		Assertions.assertEquals("测试", map.get("name"));
+		Assertions.assertEquals("sub测试", map.get("subName"));
 	}
 
 	@Test
@@ -401,9 +403,9 @@ public class BeanUtilTest {
 
 		Map<String, Object> map = MapUtil.newHashMap();
 		BeanUtil.copyProperties(p1, map);
-		Assert.assertTrue((Boolean) map.get("isSlow"));
-		Assert.assertEquals("测试", map.get("name"));
-		Assert.assertEquals("sub测试", map.get("subName"));
+		Assertions.assertTrue((Boolean) map.get("isSlow"));
+		Assertions.assertEquals("测试", map.get("name"));
+		Assertions.assertEquals("sub测试", map.get("subName"));
 	}
 
 	@Test
@@ -415,8 +417,8 @@ public class BeanUtilTest {
 		Person person2 = BeanUtil.trimStrFields(person);
 
 		// 是否改变原对象
-		Assert.assertEquals("张三", person.getName());
-		Assert.assertEquals("张三", person2.getName());
+		Assertions.assertEquals("张三", person.getName());
+		Assertions.assertEquals("张三", person2.getName());
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
@@ -501,9 +503,9 @@ public class BeanUtilTest {
 		SubPersonWithOverlayTransientField dest = new SubPersonWithOverlayTransientField();
 		BeanUtil.copyProperties(source, dest);
 
-		Assert.assertEquals(source.getName(), dest.getName());
-		Assert.assertEquals(source.getAge(), dest.getAge());
-		Assert.assertEquals(source.getOpenid(), dest.getOpenid());
+		Assertions.assertEquals(source.getName(), dest.getName());
+		Assertions.assertEquals(source.getAge(), dest.getAge());
+		Assertions.assertEquals(source.getOpenid(), dest.getOpenid());
 	}
 
 	@Test
@@ -534,8 +536,8 @@ public class BeanUtilTest {
 		info.setCode("123");
 		HllFoodEntity entity = new HllFoodEntity();
 		BeanUtil.copyProperties(info, entity);
-		Assert.assertEquals(info.getBookID(), entity.getBookId());
-		Assert.assertEquals(info.getCode(), entity.getCode2());
+		Assertions.assertEquals(info.getBookID(), entity.getBookId());
+		Assertions.assertEquals(info.getCode(), entity.getCode2());
 	}
 
 	@Test
@@ -544,8 +546,8 @@ public class BeanUtilTest {
 		info.setBookID("0");
 		info.setCode("123");
 		Food newFood = BeanUtil.copyProperties(info, Food.class, "code");
-		Assert.assertEquals(info.getBookID(), newFood.getBookID());
-		Assert.assertNull(newFood.getCode());
+		Assertions.assertEquals(info.getBookID(), newFood.getBookID());
+		Assertions.assertNull(newFood.getCode());
 	}
 
 	@Test
@@ -556,8 +558,8 @@ public class BeanUtilTest {
 		Food newFood = new Food();
 		CopyOptions copyOptions = CopyOptions.create().setPropertiesFilter((f, v) -> !(v instanceof CharSequence) || StrUtil.isNotBlank(v.toString()));
 		BeanUtil.copyProperties(info, newFood, copyOptions);
-		Assert.assertEquals(info.getBookID(), newFood.getBookID());
-		Assert.assertNull(newFood.getCode());
+		Assertions.assertEquals(info.getBookID(), newFood.getBookID());
+		Assertions.assertNull(newFood.getCode());
 	}
 
 	@Data
@@ -580,7 +582,7 @@ public class BeanUtilTest {
 	public void setPropertiesTest() {
 		Map<String, Object> resultMap = MapUtil.newHashMap();
 		BeanUtil.setProperty(resultMap, "codeList[0].name", "张三");
-		Assert.assertEquals("{codeList={0={name=张三}}}", resultMap.toString());
+		Assertions.assertEquals("{codeList={0={name=张三}}}", resultMap.toString());
 	}
 
 	@Test
@@ -591,7 +593,7 @@ public class BeanUtilTest {
 		final Station station2 = new Station();
 
 		BeanUtil.copyProperties(station, station2);
-		Assert.assertEquals(new Long(123456L), station2.getId());
+		Assertions.assertEquals(new Long(123456L), station2.getId());
 	}
 
 	static class Station extends Tree<Long> {}
@@ -617,10 +619,10 @@ public class BeanUtilTest {
 		List<Student> studentList = ListUtil.of(student, student2);
 		List<Person> people = BeanUtil.copyToList(studentList, Person.class);
 
-		Assert.assertEquals(studentList.size(), people.size());
+		Assertions.assertEquals(studentList.size(), people.size());
 		for (int i = 0; i < studentList.size(); i++) {
-			Assert.assertEquals(studentList.get(i).getName(), people.get(i).getName());
-			Assert.assertEquals(studentList.get(i).getAge(), people.get(i).getAge());
+			Assertions.assertEquals(studentList.get(i).getName(), people.get(i).getName());
+			Assertions.assertEquals(studentList.get(i).getAge(), people.get(i).getAge());
 		}
 
 	}
@@ -640,7 +642,7 @@ public class BeanUtilTest {
 				new LinkedHashMap<>(),
 				false,
 				key -> Arrays.asList("id", "name", "code", "sortOrder").contains(key) ? key : null);
-		Assert.assertFalse(f.containsKey(null));
+		Assertions.assertFalse(f.containsKey(null));
 	}
 
 	@Data
@@ -671,8 +673,8 @@ public class BeanUtilTest {
 		BeanPath beanPath = BeanPath.create("testPojo2List.age");
 		Object o = beanPath.get(testPojo);
 
-		Assert.assertEquals(Integer.valueOf(2), ArrayUtil.get(o, 0));
-		Assert.assertEquals(Integer.valueOf(3), ArrayUtil.get(o, 1));
+		Assertions.assertEquals(Integer.valueOf(2), ArrayUtil.get(o, 0));
+		Assertions.assertEquals(Integer.valueOf(3), ArrayUtil.get(o, 1));
 	}
 
 	@Data
@@ -716,10 +718,10 @@ public class BeanUtilTest {
 		ChildVo2 childVo2 = new ChildVo2();
 		BeanUtil.copyProperties(childVo1, childVo2, copyOptions);
 
-		Assert.assertEquals(childVo1.getChild_address(), childVo2.getChildAddress());
-		Assert.assertEquals(childVo1.getChild_name(), childVo2.getChildName());
-		Assert.assertEquals(childVo1.getChild_father_name(), childVo2.getChildFatherName());
-		Assert.assertEquals(childVo1.getChild_mother_name(), childVo2.getChildMotherName());
+		Assertions.assertEquals(childVo1.getChild_address(), childVo2.getChildAddress());
+		Assertions.assertEquals(childVo1.getChild_name(), childVo2.getChildName());
+		Assertions.assertEquals(childVo1.getChild_father_name(), childVo2.getChildFatherName());
+		Assertions.assertEquals(childVo1.getChild_mother_name(), childVo2.getChildMotherName());
 	}
 
 	@Data
@@ -743,7 +745,7 @@ public class BeanUtilTest {
 		Test1 t1 = new Test1().setStrList(ListUtil.toList("list"));
 		Test2 t2_hu = new Test2();
 		BeanUtil.copyProperties(t1, t2_hu, CopyOptions.create().setIgnoreError(true));
-		Assert.assertNull(t2_hu.getStrList());
+		Assertions.assertNull(t2_hu.getStrList());
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/bean/DynaBeanTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/DynaBeanTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.bean;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@link DynaBean}单元测试
@@ -19,18 +19,18 @@ public class DynaBeanTest {
 		bean.set("age", 12);
 
 		String name = bean.get("name");
-		Assert.assertEquals(user.getName(), name);
+		Assertions.assertEquals(user.getName(), name);
 		int age = bean.get("age");
-		Assert.assertEquals(user.getAge(), age);
+		Assertions.assertEquals(user.getAge(), age);
 
 		//重复包装测试
 		DynaBean bean2 = new DynaBean(bean);
 		User user2 = bean2.getBean();
-		Assert.assertEquals(user, user2);
+		Assertions.assertEquals(user, user2);
 
 		//执行指定方法
 		Object invoke = bean2.invoke("testMethod");
-		Assert.assertEquals("test for 李华", invoke);
+		Assertions.assertEquals("test for 李华", invoke);
 	}
 
 
@@ -43,19 +43,19 @@ public class DynaBeanTest {
 		bean.set("age", age_before);
 
 		String name_after = bean.get("name");
-		Assert.assertEquals(name_before, name_after);
+		Assertions.assertEquals(name_before, name_after);
 		int age_after = bean.get("age");
-		Assert.assertEquals(age_before, age_after);
+		Assertions.assertEquals(age_before, age_after);
 
 		//重复包装测试
 		DynaBean bean2 = new DynaBean(bean);
 		User user2 = bean2.getBean();
 		User user1 = bean.getBean();
-		Assert.assertEquals(user1, user2);
+		Assertions.assertEquals(user1, user2);
 
 		//执行指定方法
 		Object invoke = bean2.invoke("testMethod");
-		Assert.assertEquals("test for 李华", invoke);
+		Assertions.assertEquals("test for 李华", invoke);
 	}
 
 
@@ -68,19 +68,19 @@ public class DynaBeanTest {
 		bean.set("age", age_before);
 
 		String name_after = bean.get("name");
-		Assert.assertEquals(name_before, name_after);
+		Assertions.assertEquals(name_before, name_after);
 		int age_after = bean.get("age");
-		Assert.assertEquals(age_before, age_after);
+		Assertions.assertEquals(age_before, age_after);
 
 		//重复包装测试
 		DynaBean bean2 = new DynaBean(bean);
 		User user2 = bean2.getBean();
 		User user1 = bean.getBean();
-		Assert.assertEquals(user1, user2);
+		Assertions.assertEquals(user1, user2);
 
 		//执行指定方法
 		Object invoke = bean2.invoke("testMethod");
-		Assert.assertEquals("test for 李华", invoke);
+		Assertions.assertEquals("test for 李华", invoke);
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/bean/Issue1687Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/Issue1687Test.java
@@ -4,8 +4,8 @@ import cn.hutool.core.annotation.Alias;
 import cn.hutool.core.bean.copier.CopyOptions;
 import cn.hutool.core.map.MapUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 
@@ -22,8 +22,8 @@ public class Issue1687Test {
 
 		final SysUser sysUser = BeanUtil.toBean(sysUserFb, SysUser.class);
 		// 别名错位导致找不到字段
-		Assert.assertNull(sysUser.getDepart());
-		Assert.assertEquals(new Long(456L), sysUser.getOrgId());
+		Assertions.assertNull(sysUser.getDepart());
+		Assertions.assertEquals(new Long(456L), sysUser.getOrgId());
 	}
 
 	@Test
@@ -38,8 +38,8 @@ public class Issue1687Test {
 		);
 		final SysUser sysUser = BeanUtil.toBean(sysUserFb, SysUser.class, copyOptions);
 
-		Assert.assertEquals(new Long(123L), sysUser.getDepart());
-		Assert.assertEquals(new Long(456L), sysUser.getOrgId());
+		Assertions.assertEquals(new Long(123L), sysUser.getDepart());
+		Assertions.assertEquals(new Long(456L), sysUser.getOrgId());
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/bean/Issue2009Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/Issue2009Test.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.bean;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * https://github.com/dromara/hutool/issues/2009
@@ -71,6 +71,6 @@ public class Issue2009Test {
 		A a = new A();
 		BeanUtil.copyProperties(b, a);
 
-		Assert.assertEquals(b.getPapss(), a.getPapss());
+		Assertions.assertEquals(b.getPapss(), a.getPapss());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/bean/copier/BeanCopierTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/copier/BeanCopierTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.bean.copier;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BeanCopierTest {
 
@@ -19,7 +19,7 @@ public class BeanCopierTest {
 		final BeanCopier<B> copier = BeanCopier.create(a, b, CopyOptions.create().setOverride(false));
 		copier.copy();
 
-		Assert.assertEquals("abc", b.getValue());
+		Assertions.assertEquals("abc", b.getValue());
 	}
 
 	/**
@@ -35,7 +35,7 @@ public class BeanCopierTest {
 		final BeanCopier<B> copier = BeanCopier.create(a, b, CopyOptions.create());
 		copier.copy();
 
-		Assert.assertEquals("123", b.getValue());
+		Assertions.assertEquals("123", b.getValue());
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/clone/CloneTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/clone/CloneTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.clone;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 克隆单元测试
@@ -18,7 +18,7 @@ public class CloneTest {
 		//实现Cloneable接口
 		Cat cat = new Cat();
 		Cat cat2 = cat.clone();
-		Assert.assertEquals(cat, cat2);
+		Assertions.assertEquals(cat, cat2);
 	}
 
 	@Test
@@ -26,7 +26,7 @@ public class CloneTest {
 		//继承CloneSupport类
 		Dog dog = new Dog();
 		Dog dog2 = dog.clone();
-		Assert.assertEquals(dog, dog2);
+		Assertions.assertEquals(dog, dog2);
 	}
 
 	//------------------------------------------------------------------------------- private Class for test

--- a/hutool-core/src/test/java/cn/hutool/core/clone/DefaultCloneTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/clone/DefaultCloneTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.clone;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,14 +19,14 @@ public class DefaultCloneTest {
 		oldCar.setWheelList(Stream.of(new Wheel("h")).collect(Collectors.toList()));
 
 		Car newCar = oldCar.clone0();
-		Assert.assertEquals(oldCar.getId(), newCar.getId());
-		Assert.assertEquals(oldCar.getWheelList(), newCar.getWheelList());
+		Assertions.assertEquals(oldCar.getId(), newCar.getId());
+		Assertions.assertEquals(oldCar.getWheelList(), newCar.getWheelList());
 
 		newCar.setId(2);
-		Assert.assertNotEquals(oldCar.getId(), newCar.getId());
+		Assertions.assertNotEquals(oldCar.getId(), newCar.getId());
 		newCar.getWheelList().add(new Wheel("s"));
 
-		Assert.assertNotSame(oldCar, newCar);
+		Assertions.assertNotSame(oldCar, newCar);
 
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/codec/BCDTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/BCDTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BCDTest {
 
@@ -13,6 +13,6 @@ public class BCDTest {
 		byte[] bcd = BCD.strToBcd(strForTest);
 		String str = BCD.bcdToStr(bcd);
 		//解码BCD
-		Assert.assertEquals(strForTest, str);
+		Assertions.assertEquals(strForTest, str);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/Base32Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/Base32Test.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Base32Test {
 
@@ -9,9 +9,9 @@ public class Base32Test {
 	public void encodeAndDecodeTest(){
 		String a = "伦家是一个非常长的字符串";
 		String encode = Base32.encode(a);
-		Assert.assertEquals("4S6KNZNOW3TJRL7EXCAOJOFK5GOZ5ZNYXDUZLP7HTKCOLLMX46WKNZFYWI", encode);
+		Assertions.assertEquals("4S6KNZNOW3TJRL7EXCAOJOFK5GOZ5ZNYXDUZLP7HTKCOLLMX46WKNZFYWI", encode);
 
 		String decodeStr = Base32.decodeStr(encode);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/Base62Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/Base62Test.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base62单元测试
@@ -15,9 +15,9 @@ public class Base62Test {
 	public void encodeAndDecodeTest() {
 		String a = "伦家是一个非常长的字符串66";
 		String encode = Base62.encode(a);
-		Assert.assertEquals("17vKU8W4JMG8dQF8lk9VNnkdMOeWn4rJMva6F0XsLrrT53iKBnqo", encode);
+		Assertions.assertEquals("17vKU8W4JMG8dQF8lk9VNnkdMOeWn4rJMva6F0XsLrrT53iKBnqo", encode);
 
 		String decodeStr = Base62.decodeStr(encode);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/Base64Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/Base64Test.java
@@ -3,8 +3,8 @@ package cn.hutool.core.codec;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.RandomUtil;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base64单元测试
@@ -16,69 +16,69 @@ public class Base64Test {
 
 	@Test
 	public void isBase64Test(){
-		Assert.assertTrue(Base64.isBase64(Base64.encode(RandomUtil.randomString(1000))));
+		Assertions.assertTrue(Base64.isBase64(Base64.encode(RandomUtil.randomString(1000))));
 	}
 
 	@Test
 	public void isBase64Test2(){
 		String base64 = "dW1kb3MzejR3bmljM2J6djAyZzcwbWk5M213Nnk3cWQ3eDJwOHFuNXJsYmMwaXhxbmg0dmxrcmN0anRkbmd3\n" +
 				"ZzcyZWFwanI2NWNneTg2dnp6cmJoMHQ4MHpxY2R6c3pjazZtaQ==";
-		Assert.assertTrue(Base64.isBase64(base64));
+		Assertions.assertTrue(Base64.isBase64(base64));
 
 		// '=' 不位于末尾
 		base64 = "dW1kb3MzejR3bmljM2J6=djAyZzcwbWk5M213Nnk3cWQ3eDJwOHFuNXJsYmMwaXhxbmg0dmxrcmN0anRkbmd3\n" +
 				"ZzcyZWFwanI2NWNneTg2dnp6cmJoMHQ4MHpxY2R6c3pjazZtaQ=";
-		Assert.assertFalse(Base64.isBase64(base64));
+		Assertions.assertFalse(Base64.isBase64(base64));
 	}
 
 	@Test
 	public void encodeAndDecodeTest() {
 		String a = "伦家是一个非常长的字符串66";
 		String encode = Base64.encode(a);
-		Assert.assertEquals("5Lym5a625piv5LiA5Liq6Z2e5bi46ZW/55qE5a2X56ym5LiyNjY=", encode);
+		Assertions.assertEquals("5Lym5a625piv5LiA5Liq6Z2e5bi46ZW/55qE5a2X56ym5LiyNjY=", encode);
 
 		String decodeStr = Base64.decodeStr(encode);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 
 	@Test
 	public void encodeAndDecodeWithoutPaddingTest() {
 		String a = "伦家是一个非常长的字符串66";
 		String encode = Base64.encodeWithoutPadding(StrUtil.utf8Bytes(a));
-		Assert.assertEquals("5Lym5a625piv5LiA5Liq6Z2e5bi46ZW/55qE5a2X56ym5LiyNjY", encode);
+		Assertions.assertEquals("5Lym5a625piv5LiA5Liq6Z2e5bi46ZW/55qE5a2X56ym5LiyNjY", encode);
 
 		String decodeStr = Base64.decodeStr(encode);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 
 	@Test
 	public void encodeAndDecodeTest2() {
 		String a = "a61a5db5a67c01445ca2-HZ20181120172058/pdf/中国电信影像云单体网关Docker版-V1.2.pdf";
 		String encode = Base64.encode(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("YTYxYTVkYjVhNjdjMDE0NDVjYTItSFoyMDE4MTEyMDE3MjA1OC9wZGYv5Lit5Zu955S15L+h5b2x5YOP5LqR5Y2V5L2T572R5YWzRG9ja2Vy54mILVYxLjIucGRm", encode);
+		Assertions.assertEquals("YTYxYTVkYjVhNjdjMDE0NDVjYTItSFoyMDE4MTEyMDE3MjA1OC9wZGYv5Lit5Zu955S15L+h5b2x5YOP5LqR5Y2V5L2T572R5YWzRG9ja2Vy54mILVYxLjIucGRm", encode);
 
 		String decodeStr = Base64.decodeStr(encode, CharsetUtil.UTF_8);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 
 	@Test
 	public void encodeAndDecodeTest3() {
 		String a = ":";
 		String encode = Base64.encode(a);
-		Assert.assertEquals("Og==", encode);
+		Assertions.assertEquals("Og==", encode);
 
 		String decodeStr = Base64.decodeStr(encode);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 
 	@Test
 	public void urlSafeEncodeAndDecodeTest() {
 		String a = "广州伦家需要安全感55";
 		String encode = StrUtil.utf8Str(Base64.encodeUrlSafe(StrUtil.utf8Bytes(a), false));
-		Assert.assertEquals("5bm_5bee5Lym5a626ZyA6KaB5a6J5YWo5oSfNTU", encode);
+		Assertions.assertEquals("5bm_5bee5Lym5a626ZyA6KaB5a6J5YWo5oSfNTU", encode);
 
 		String decodeStr = Base64.decodeStr(encode);
-		Assert.assertEquals(a, decodeStr);
+		Assertions.assertEquals(a, decodeStr);
 	}
 
 	@Test
@@ -87,7 +87,7 @@ public class Base64Test {
 		String result = Base64.encode(orderDescription, "gbk");
 
 		final String s = Base64.decodeStr(result, "gbk");
-		Assert.assertEquals(orderDescription, s);
+		Assertions.assertEquals(orderDescription, s);
 	}
 
 	@Test
@@ -97,6 +97,6 @@ public class Base64Test {
 //		Console.log(encode);
 
 		final String decodeStr = Base64.decodeStr(encode);
-		Assert.assertEquals(str, decodeStr);
+		Assertions.assertEquals(str, decodeStr);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/CaesarTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/CaesarTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CaesarTest {
 
@@ -10,9 +10,9 @@ public class CaesarTest {
 		String str = "1f2e9df6131b480b9fdddc633cf24996";
 
 		String encode = Caesar.encode(str, 3);
-		Assert.assertEquals("1H2G9FH6131D480D9HFFFE633EH24996", encode);
+		Assertions.assertEquals("1H2G9FH6131D480D9HFFFE633EH24996", encode);
 
 		String decode = Caesar.decode(encode, 3);
-		Assert.assertEquals(str, decode);
+		Assertions.assertEquals(str, decode);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/MorseTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/MorseTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MorseTest {
 
@@ -11,23 +11,23 @@ public class MorseTest {
 	public void test0() {
 		String text = "Hello World!";
 		String morse = "...././.-../.-../---/-...../.--/---/.-./.-../-../-.-.--/";
-		Assert.assertEquals(morse, morseCoder.encode(text));
-		Assert.assertEquals(morseCoder.decode(morse), text.toUpperCase());
+		Assertions.assertEquals(morse, morseCoder.encode(text));
+		Assertions.assertEquals(morseCoder.decode(morse), text.toUpperCase());
 	}
 
 	@Test
 	public void test1() {
 		String text = "你好，世界！";
 		String morse = "-..----.--...../-.--..-.-----.-/--------....--../-..---....-.--./---.-.-.-..--../--------.......-/";
-		Assert.assertEquals(morseCoder.encode(text), morse);
-		Assert.assertEquals(morseCoder.decode(morse), text);
+		Assertions.assertEquals(morseCoder.encode(text), morse);
+		Assertions.assertEquals(morseCoder.decode(morse), text);
 	}
 
 	@Test
 	public void test2() {
 		String text = "こんにちは";
 		String morse = "--.....-.-..--/--....-..-..--/--.....--.-.--/--.....--....-/--.....--.----/";
-		Assert.assertEquals(morseCoder.encode(text), morse);
-		Assert.assertEquals(morseCoder.decode(morse), text);
+		Assertions.assertEquals(morseCoder.encode(text), morse);
+		Assertions.assertEquals(morseCoder.decode(morse), text);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PunyCodeTest {
 
@@ -9,10 +9,10 @@ public class PunyCodeTest {
 	public void encodeDecodeTest(){
 		String text = "Hutool编码器";
 		String strPunyCode = PunyCode.encode(text);
-		Assert.assertEquals("Hutool-ux9js33tgln", strPunyCode);
+		Assertions.assertEquals("Hutool-ux9js33tgln", strPunyCode);
 		String decode = PunyCode.decode("Hutool-ux9js33tgln");
-		Assert.assertEquals(text, decode);
+		Assertions.assertEquals(text, decode);
 		decode = PunyCode.decode("xn--Hutool-ux9js33tgln");
-		Assert.assertEquals(text, decode);
+		Assertions.assertEquals(text, decode);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/RotTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/RotTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.codec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RotTest {
 
@@ -10,9 +10,9 @@ public class RotTest {
 		String str = "1f2e9df6131b480b9fdddc633cf24996";
 
 		String encode13 = Rot.encode13(str);
-		Assert.assertEquals("4s5r2qs9464o713o2sqqqp966ps57229", encode13);
+		Assertions.assertEquals("4s5r2qs9464o713o2sqqqp966ps57229", encode13);
 
 		String decode13 = Rot.decode13(encode13);
-		Assert.assertEquals(str, decode13);
+		Assertions.assertEquals(str, decode13);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/collection/CollStreamUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/CollStreamUtilTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.map.MapUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.ToString;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.stream.Collector;
@@ -19,54 +19,54 @@ public class CollStreamUtilTest {
 	@Test
 	public void testToIdentityMap() {
 		Map<Long, Student> map = CollStreamUtil.toIdentityMap(null, Student::getStudentId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.toIdentityMap(list, Student::getStudentId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		list.add(new Student(1, 1, 1, "张三"));
 		list.add(new Student(1, 1, 2, "李四"));
 		list.add(new Student(1, 1, 3, "王五"));
 		map = CollStreamUtil.toIdentityMap(list, Student::getStudentId);
-		Assert.assertEquals(map.get(1L).getName(), "张三");
-		Assert.assertEquals(map.get(2L).getName(), "李四");
-		Assert.assertEquals(map.get(3L).getName(), "王五");
-		Assert.assertNull(map.get(4L));
+		Assertions.assertEquals(map.get(1L).getName(), "张三");
+		Assertions.assertEquals(map.get(2L).getName(), "李四");
+		Assertions.assertEquals(map.get(3L).getName(), "王五");
+		Assertions.assertNull(map.get(4L));
 
 		// 测试value为空时
 		list.add(null);
 		map = CollStreamUtil.toIdentityMap(list, Student::getStudentId);
-		Assert.assertNull(map.get(4L));
+		Assertions.assertNull(map.get(4L));
 	}
 
 	@Test
 	public void testToMap() {
 		Map<Long, String> map = CollStreamUtil.toMap(null, Student::getStudentId, Student::getName);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.toMap(list, Student::getStudentId, Student::getName);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		list.add(new Student(1, 1, 1, "张三"));
 		list.add(new Student(1, 1, 2, "李四"));
 		list.add(new Student(1, 1, 3, "王五"));
 		map = CollStreamUtil.toMap(list, Student::getStudentId, Student::getName);
-		Assert.assertEquals(map.get(1L), "张三");
-		Assert.assertEquals(map.get(2L), "李四");
-		Assert.assertEquals(map.get(3L), "王五");
-		Assert.assertNull(map.get(4L));
+		Assertions.assertEquals(map.get(1L), "张三");
+		Assertions.assertEquals(map.get(2L), "李四");
+		Assertions.assertEquals(map.get(3L), "王五");
+		Assertions.assertNull(map.get(4L));
 
 		// 测试value为空时
 		list.add(new Student(1, 1, 4, null));
 		map = CollStreamUtil.toMap(list, Student::getStudentId, Student::getName);
-		Assert.assertNull(map.get(4L));
+		Assertions.assertNull(map.get(4L));
 	}
 
 	@Test
 	public void testGroupByKey() {
 		Map<Long, List<Student>> map = CollStreamUtil.groupByKey(null, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.groupByKey(list, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		list.add(new Student(1, 1, 1, "张三"));
 		list.add(new Student(1, 2, 2, "李四"));
 		list.add(new Student(2, 1, 1, "擎天柱"));
@@ -86,16 +86,16 @@ public class CollStreamUtilTest {
 		List<Student> class3 = new ArrayList<>();
 		class3.add(new Student(2, 3, 2, "霸天虎"));
 		compare.put(3L, class3);
-		Assert.assertEquals(map, compare);
+		Assertions.assertEquals(map, compare);
 	}
 
 	@Test
 	public void testGroupBy2Key() {
 		Map<Long, Map<Long, List<Student>>> map = CollStreamUtil.groupBy2Key(null, Student::getTermId, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.groupBy2Key(list, Student::getTermId, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		list.add(new Student(1, 1, 1, "张三"));
 		list.add(new Student(1, 2, 2, "李四"));
 		list.add(new Student(1, 2, 3, "王五"));
@@ -125,17 +125,17 @@ public class CollStreamUtilTest {
 		list22.add(new Student(2, 2, 3, "霸天虎"));
 		map2.put(2L, list22);
 		compare.put(2L, map2);
-		Assert.assertEquals(map, compare);
+		Assertions.assertEquals(map, compare);
 	}
 
 	@Test
 	public void testGroup2Map() {
 		Map<Long, Map<Long, Student>> map = CollStreamUtil.group2Map(null, Student::getTermId, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.group2Map(list, Student::getTermId, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		list.add(new Student(1, 1, 1, "张三"));
 		list.add(new Student(1, 2, 1, "李四"));
 		list.add(new Student(2, 2, 1, "王五"));
@@ -148,18 +148,18 @@ public class CollStreamUtilTest {
 		Map<Long, Student> map2 = new HashMap<>();
 		map2.put(2L, new Student(2, 2, 1, "王五"));
 		compare.put(2L, map2);
-		Assert.assertEquals(compare, map);
+		Assertions.assertEquals(compare, map);
 
 	}
 
 	@Test
 	public void testGroupKeyValue() {
 		Map<Long, List<Long>> map = CollStreamUtil.groupKeyValue(null, Student::getTermId, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.groupKeyValue(list, Student::getTermId, Student::getClassId);
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		list.add(new Student(1, 1, 1, "张三"));
 		list.add(new Student(1, 2, 1, "李四"));
 		list.add(new Student(2, 2, 1, "王五"));
@@ -168,7 +168,7 @@ public class CollStreamUtilTest {
 		Map<Long, List<Long>> compare = new HashMap<>();
 		compare.put(1L, Arrays.asList(1L, 2L));
 		compare.put(2L, Collections.singletonList(2L));
-		Assert.assertEquals(compare, map);
+		Assertions.assertEquals(compare, map);
 	}
 
 	@Test
@@ -177,12 +177,12 @@ public class CollStreamUtilTest {
 
 		// 参数null测试
 		Map<Long, List<Student>> map = CollStreamUtil.groupBy(null, Student::getTermId, Collectors.toList());
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 
 		// 参数空数组测试
 		List<Student> list = new ArrayList<>();
 		map = CollStreamUtil.groupBy(list, Student::getTermId, Collectors.toList());
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 
 		// 放入元素
 		list.add(new Student(1, 1, 1, "张三"));
@@ -191,11 +191,11 @@ public class CollStreamUtilTest {
 		// 先根据termId分组，再通过classId比较，找出最大值所属的那个Student,返回的Optional
 		Map<Long, Optional<Student>> longOptionalMap = CollStreamUtil.groupBy(list, Student::getTermId, Collectors.maxBy(Comparator.comparing(Student::getClassId)));
 		//noinspection OptionalGetWithoutIsPresent
-		Assert.assertEquals("李四", longOptionalMap.get(1L).get().getName());
+		Assertions.assertEquals("李四", longOptionalMap.get(1L).get().getName());
 
 		// 先根据termId分组，再转换为Map<studentId,name>
 		Map<Long, HashMap<Long, String>> groupThen = CollStreamUtil.groupBy(list, Student::getTermId, Collector.of(HashMap::new, (m, v) -> m.put(v.getStudentId(), v.getName()), (l, r) -> l));
-		Assert.assertEquals(
+		Assertions.assertEquals(
 				MapUtil.builder()
 						.put(1L, MapUtil.builder().put(1L, "李四").build())
 						.put(2L, MapUtil.builder().put(1L, "王五").build())
@@ -209,10 +209,10 @@ public class CollStreamUtilTest {
 	@Test
 	public void testTranslate2List() {
 		List<String> list = CollStreamUtil.toList(null, Student::getName);
-		Assert.assertEquals(list, Collections.EMPTY_LIST);
+		Assertions.assertEquals(list, Collections.EMPTY_LIST);
 		List<Student> students = new ArrayList<>();
 		list = CollStreamUtil.toList(students, Student::getName);
-		Assert.assertEquals(list, Collections.EMPTY_LIST);
+		Assertions.assertEquals(list, Collections.EMPTY_LIST);
 		students.add(new Student(1, 1, 1, "张三"));
 		students.add(new Student(1, 2, 2, "李四"));
 		students.add(new Student(2, 1, 1, "李四"));
@@ -225,16 +225,16 @@ public class CollStreamUtilTest {
 		compare.add("李四");
 		compare.add("李四");
 		compare.add("霸天虎");
-		Assert.assertEquals(list, compare);
+		Assertions.assertEquals(list, compare);
 	}
 
 	@Test
 	public void testTranslate2Set() {
 		Set<String> set = CollStreamUtil.toSet(null, Student::getName);
-		Assert.assertEquals(set, Collections.EMPTY_SET);
+		Assertions.assertEquals(set, Collections.EMPTY_SET);
 		List<Student> students = new ArrayList<>();
 		set = CollStreamUtil.toSet(students, Student::getName);
-		Assert.assertEquals(set, Collections.EMPTY_SET);
+		Assertions.assertEquals(set, Collections.EMPTY_SET);
 		students.add(new Student(1, 1, 1, "张三"));
 		students.add(new Student(1, 2, 2, "李四"));
 		students.add(new Student(2, 1, 1, "李四"));
@@ -245,7 +245,7 @@ public class CollStreamUtilTest {
 		compare.add("张三");
 		compare.add("李四");
 		compare.add("霸天虎");
-		Assert.assertEquals(set, compare);
+		Assertions.assertEquals(set, compare);
 	}
 
 	@Test
@@ -253,19 +253,19 @@ public class CollStreamUtilTest {
 		Map<Long, Student> map1 = null;
 		Map<Long, Student> map2 = Collections.emptyMap();
 		Map<Long, String> map = CollStreamUtil.merge(map1, map2, (s1, s2) -> s1.getName() + s2.getName());
-		Assert.assertEquals(map, Collections.EMPTY_MAP);
+		Assertions.assertEquals(map, Collections.EMPTY_MAP);
 		map1 = new HashMap<>();
 		map1.put(1L, new Student(1, 1, 1, "张三"));
 		map = CollStreamUtil.merge(map1, map2, this::merge);
 		Map<Long, String> temp = new HashMap<>();
 		temp.put(1L, "张三");
-		Assert.assertEquals(map, temp);
+		Assertions.assertEquals(map, temp);
 		map2 = new HashMap<>();
 		map2.put(1L, new Student(2, 1, 1, "李四"));
 		map = CollStreamUtil.merge(map1, map2, this::merge);
 		Map<Long, String> compare = new HashMap<>();
 		compare.put(1L, "张三李四");
-		Assert.assertEquals(map, compare);
+		Assertions.assertEquals(map, compare);
 	}
 
 	private String merge(Student student1, Student student2) {

--- a/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
@@ -6,8 +6,8 @@ import cn.hutool.core.lang.Dict;
 import cn.hutool.core.map.MapUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,8 +35,8 @@ public class CollUtilTest {
 	@Test
 	public void testPredicateContains() {
 		ArrayList<String> list = CollUtil.newArrayList("bbbbb", "aaaaa", "ccccc");
-		Assert.assertTrue(CollUtil.contains(list, s -> s.startsWith("a")));
-		Assert.assertFalse(CollUtil.contains(list, s -> s.startsWith("d")));
+		Assertions.assertTrue(CollUtil.contains(list, s -> s.startsWith("a")));
+		Assertions.assertFalse(CollUtil.contains(list, s -> s.startsWith("d")));
 	}
 
 	@Test
@@ -46,14 +46,14 @@ public class CollUtilTest {
 		ArrayList<Integer> exceptResultList = CollUtil.newArrayList(1);
 
 		List<Integer> resultList = CollUtil.removeWithAddIf(list, ele -> 1 == ele);
-		Assert.assertEquals(list, exceptRemovedList);
-		Assert.assertEquals(resultList, exceptResultList);
+		Assertions.assertEquals(list, exceptRemovedList);
+		Assertions.assertEquals(resultList, exceptResultList);
 
 		list = CollUtil.newArrayList(1, 2, 3);
 		resultList = new ArrayList<>();
 		CollUtil.removeWithAddIf(list, resultList, ele -> 1 == ele);
-		Assert.assertEquals(list, exceptRemovedList);
-		Assert.assertEquals(resultList, exceptResultList);
+		Assertions.assertEquals(list, exceptRemovedList);
+		Assertions.assertEquals(resultList, exceptResultList);
 	}
 
 	@Test
@@ -62,17 +62,17 @@ public class CollUtilTest {
 		List<String> answerList = CollUtil.newArrayList("a", "b");
 		CollUtil.padLeft(srcList, 1, "b");
 		CollUtil.padLeft(srcList, 2, "a");
-		Assert.assertEquals(srcList, answerList);
+		Assertions.assertEquals(srcList, answerList);
 
 		srcList = CollUtil.newArrayList("a", "b");
 		answerList = CollUtil.newArrayList("a", "b");
 		CollUtil.padLeft(srcList, 2, "a");
-		Assert.assertEquals(srcList, answerList);
+		Assertions.assertEquals(srcList, answerList);
 
 		srcList = CollUtil.newArrayList("c");
 		answerList = CollUtil.newArrayList("a", "a", "c");
 		CollUtil.padLeft(srcList, 3, "a");
-		Assert.assertEquals(srcList, answerList);
+		Assertions.assertEquals(srcList, answerList);
 	}
 
 	@Test
@@ -80,18 +80,18 @@ public class CollUtilTest {
 		List<String> srcList = CollUtil.newArrayList("a");
 		List<String> answerList = CollUtil.newArrayList("a", "b", "b", "b", "b");
 		CollUtil.padRight(srcList, 5, "b");
-		Assert.assertEquals(srcList, answerList);
+		Assertions.assertEquals(srcList, answerList);
 	}
 
 	@Test
 	public void isNotEmptyTest() {
-		Assert.assertFalse(CollUtil.isNotEmpty((Collection<?>) null));
+		Assertions.assertFalse(CollUtil.isNotEmpty((Collection<?>) null));
 	}
 
 	@Test
 	public void newHashSetTest() {
 		Set<String> set = CollUtil.newHashSet((String[]) null);
-		Assert.assertNotNull(set);
+		Assertions.assertNotNull(set);
 	}
 
 	@Test
@@ -101,14 +101,14 @@ public class CollUtilTest {
 
 		final String[] keys = v1.keySet().toArray(new String[0]);
 		ArrayList<Object> v1s = CollUtil.valuesOfKeys(v1, keys);
-		Assert.assertTrue(v1s.contains(12));
-		Assert.assertTrue(v1s.contains(23));
-		Assert.assertTrue(v1s.contains("张三"));
+		Assertions.assertTrue(v1s.contains(12));
+		Assertions.assertTrue(v1s.contains(23));
+		Assertions.assertTrue(v1s.contains("张三"));
 
 		ArrayList<Object> v2s = CollUtil.valuesOfKeys(v2, keys);
-		Assert.assertTrue(v2s.contains(15));
-		Assert.assertTrue(v2s.contains(13));
-		Assert.assertTrue(v2s.contains("李四"));
+		Assertions.assertTrue(v2s.contains(15));
+		Assertions.assertTrue(v2s.contains(13));
+		Assertions.assertTrue(v2s.contains("李四"));
 	}
 
 	@Test
@@ -118,7 +118,7 @@ public class CollUtilTest {
 
 		Collection<String> union = CollUtil.union(list1, list2);
 
-		Assert.assertEquals(3, CollUtil.count(union, "b"::equals));
+		Assertions.assertEquals(3, CollUtil.count(union, "b"::equals));
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class CollUtilTest {
 		ArrayList<String> list2 = CollUtil.newArrayList("a", "b", "b", "b", "c", "d");
 
 		Collection<String> intersection = CollUtil.intersection(list1, list2);
-		Assert.assertEquals(2, CollUtil.count(intersection, "b"::equals));
+		Assertions.assertEquals(2, CollUtil.count(intersection, "b"::equals));
 	}
 
 	@Test
@@ -137,10 +137,10 @@ public class CollUtilTest {
 		ArrayList<String> list3 = CollUtil.newArrayList();
 
 		Collection<String> intersectionDistinct = CollUtil.intersectionDistinct(list1, list2);
-		Assert.assertEquals(CollUtil.newLinkedHashSet("a", "b", "c", "d"), intersectionDistinct);
+		Assertions.assertEquals(CollUtil.newLinkedHashSet("a", "b", "c", "d"), intersectionDistinct);
 
 		Collection<String> intersectionDistinct2 = CollUtil.intersectionDistinct(list1, list2, list3);
-		Assert.assertTrue(intersectionDistinct2.isEmpty());
+		Assertions.assertTrue(intersectionDistinct2.isEmpty());
 	}
 
 	@Test
@@ -149,14 +149,14 @@ public class CollUtilTest {
 		ArrayList<String> list2 = CollUtil.newArrayList("a", "b", "b", "b", "c", "d", "x2");
 
 		Collection<String> disjunction = CollUtil.disjunction(list1, list2);
-		Assert.assertTrue(disjunction.contains("b"));
-		Assert.assertTrue(disjunction.contains("x2"));
-		Assert.assertTrue(disjunction.contains("x"));
+		Assertions.assertTrue(disjunction.contains("b"));
+		Assertions.assertTrue(disjunction.contains("x2"));
+		Assertions.assertTrue(disjunction.contains("x"));
 
 		Collection<String> disjunction2 = CollUtil.disjunction(list2, list1);
-		Assert.assertTrue(disjunction2.contains("b"));
-		Assert.assertTrue(disjunction2.contains("x2"));
-		Assert.assertTrue(disjunction2.contains("x"));
+		Assertions.assertTrue(disjunction2.contains("b"));
+		Assertions.assertTrue(disjunction2.contains("x2"));
+		Assertions.assertTrue(disjunction2.contains("x"));
 	}
 
 	@Test
@@ -166,9 +166,9 @@ public class CollUtilTest {
 		ArrayList<String> list2 = CollUtil.newArrayList("a", "b", "b", "b", "c", "d", "x2");
 
 		Collection<String> disjunction = CollUtil.disjunction(list1, list2);
-		Assert.assertEquals(list2, disjunction);
+		Assertions.assertEquals(list2, disjunction);
 		Collection<String> disjunction2 = CollUtil.disjunction(list2, list1);
-		Assert.assertEquals(list2, disjunction2);
+		Assertions.assertEquals(list2, disjunction2);
 	}
 
 	@Test
@@ -178,19 +178,19 @@ public class CollUtilTest {
 		ArrayList<String> list2 = CollUtil.newArrayList("a", "b", "c");
 
 		Collection<String> disjunction = CollUtil.disjunction(list1, list2);
-		Assert.assertTrue(disjunction.contains("1"));
-		Assert.assertTrue(disjunction.contains("2"));
-		Assert.assertTrue(disjunction.contains("3"));
-		Assert.assertTrue(disjunction.contains("a"));
-		Assert.assertTrue(disjunction.contains("b"));
-		Assert.assertTrue(disjunction.contains("c"));
+		Assertions.assertTrue(disjunction.contains("1"));
+		Assertions.assertTrue(disjunction.contains("2"));
+		Assertions.assertTrue(disjunction.contains("3"));
+		Assertions.assertTrue(disjunction.contains("a"));
+		Assertions.assertTrue(disjunction.contains("b"));
+		Assertions.assertTrue(disjunction.contains("c"));
 		Collection<String> disjunction2 = CollUtil.disjunction(list2, list1);
-		Assert.assertTrue(disjunction2.contains("1"));
-		Assert.assertTrue(disjunction2.contains("2"));
-		Assert.assertTrue(disjunction2.contains("3"));
-		Assert.assertTrue(disjunction2.contains("a"));
-		Assert.assertTrue(disjunction2.contains("b"));
-		Assert.assertTrue(disjunction2.contains("c"));
+		Assertions.assertTrue(disjunction2.contains("1"));
+		Assertions.assertTrue(disjunction2.contains("2"));
+		Assertions.assertTrue(disjunction2.contains("3"));
+		Assertions.assertTrue(disjunction2.contains("a"));
+		Assertions.assertTrue(disjunction2.contains("b"));
+		Assertions.assertTrue(disjunction2.contains("c"));
 	}
 
 	@Test
@@ -198,8 +198,8 @@ public class CollUtilTest {
 		List<String> list1 = CollUtil.newArrayList("a", "b", "b", "c", "d", "x");
 		List<String> list2 = CollUtil.newArrayList("a", "b", "b", "b", "c", "d", "x2");
 		final Collection<String> subtract = CollUtil.subtract(list1, list2);
-		Assert.assertEquals(1, subtract.size());
-		Assert.assertEquals("x", subtract.iterator().next());
+		Assertions.assertEquals(1, subtract.size());
+		Assertions.assertEquals("x", subtract.iterator().next());
 	}
 
 	@Test
@@ -210,7 +210,7 @@ public class CollUtilTest {
 		map1.put("2", "v2");
 		map2.put("2", "v2");
 		Collection<String> r2 = CollUtil.subtract(map1.keySet(), map2.keySet());
-		Assert.assertEquals("[1]", r2.toString());
+		Assertions.assertEquals("[1]", r2.toString());
 	}
 
 	@Test
@@ -221,7 +221,7 @@ public class CollUtilTest {
 		map1.put("2", "v2");
 		map2.put("2", "v2");
 		List<String> r2 = CollUtil.subtractToList(map1.keySet(), map2.keySet());
-		Assert.assertEquals("[1]", r2.toString());
+		Assertions.assertEquals("[1]", r2.toString());
 	}
 
 	@Test
@@ -237,13 +237,13 @@ public class CollUtilTest {
 		// ----------------------------------------------------------------------------------------
 		ArrayList<HashMap<String, String>> list = CollUtil.newArrayList(map1, map2);
 		Map<String, List<String>> map = CollUtil.toListMap(list);
-		Assert.assertEquals("值1", map.get("a").get(0));
-		Assert.assertEquals("值2", map.get("a").get(1));
+		Assertions.assertEquals("值1", map.get("a").get(0));
+		Assertions.assertEquals("值2", map.get("a").get(1));
 
 		// ----------------------------------------------------------------------------------------
 		List<Map<String, String>> listMap = CollUtil.toMapList(map);
-		Assert.assertEquals("值1", listMap.get(0).get("a"));
-		Assert.assertEquals("值2", listMap.get(1).get("a"));
+		Assertions.assertEquals("值1", listMap.get(0).get("a"));
+		Assertions.assertEquals("值2", listMap.get(1).get("a"));
 	}
 
 	@Test
@@ -253,16 +253,16 @@ public class CollUtilTest {
 		ArrayList<Dict> list = CollUtil.newArrayList(v1, v2);
 
 		List<Object> fieldValues = CollUtil.getFieldValues(list, "name");
-		Assert.assertEquals("张三", fieldValues.get(0));
-		Assert.assertEquals("李四", fieldValues.get(1));
+		Assertions.assertEquals("张三", fieldValues.get(0));
+		Assertions.assertEquals("李四", fieldValues.get(1));
 	}
 
 	@Test
 	public void splitTest() {
 		final ArrayList<Integer> list = CollUtil.newArrayList(1, 2, 3, 4, 5, 6, 7, 8, 9);
 		List<List<Integer>> split = CollUtil.split(list, 3);
-		Assert.assertEquals(3, split.size());
-		Assert.assertEquals(3, split.get(0).size());
+		Assertions.assertEquals(3, split.size());
+		Assertions.assertEquals(3, split.get(0).size());
 	}
 
 	@Test
@@ -279,7 +279,7 @@ public class CollUtilTest {
 				result[0] = value;
 			}
 		});
-		Assert.assertEquals("1", result[0]);
+		Assertions.assertEquals("1", result[0]);
 	}
 
 	@Test
@@ -288,7 +288,7 @@ public class CollUtilTest {
 
 		Collection<String> filtered = CollUtil.edit(list, t -> t + 1);
 
-		Assert.assertEquals(CollUtil.newArrayList("a1", "b1", "c1"), filtered);
+		Assertions.assertEquals(CollUtil.newArrayList("a1", "b1", "c1"), filtered);
 	}
 
 	@Test
@@ -298,8 +298,8 @@ public class CollUtilTest {
 		ArrayList<String> filtered = CollUtil.filter(list, t -> false == "a".equals(t));
 
 		// 原地过滤
-		Assert.assertSame(list, filtered);
-		Assert.assertEquals(CollUtil.newArrayList("b", "c"), filtered);
+		Assertions.assertSame(list, filtered);
+		Assertions.assertEquals(CollUtil.newArrayList("b", "c"), filtered);
 	}
 
 	@Test
@@ -315,12 +315,12 @@ public class CollUtilTest {
 			return true;
 		});
 
-		Assert.assertEquals(1, removed.size());
-		Assert.assertEquals("a", removed.get(0));
+		Assertions.assertEquals(1, removed.size());
+		Assertions.assertEquals("a", removed.get(0));
 
 		// 原地过滤
-		Assert.assertSame(list, filtered);
-		Assert.assertEquals(CollUtil.newArrayList("b", "c"), filtered);
+		Assertions.assertSame(list, filtered);
+		Assertions.assertEquals(CollUtil.newArrayList("b", "c"), filtered);
 	}
 
 	@Test
@@ -330,8 +330,8 @@ public class CollUtilTest {
 		ArrayList<String> filtered = CollUtil.removeNull(list);
 
 		// 原地过滤
-		Assert.assertSame(list, filtered);
-		Assert.assertEquals(CollUtil.newArrayList("a", "b", "c", "", "  "), filtered);
+		Assertions.assertSame(list, filtered);
+		Assertions.assertEquals(CollUtil.newArrayList("a", "b", "c", "", "  "), filtered);
 	}
 
 	@Test
@@ -341,8 +341,8 @@ public class CollUtilTest {
 		ArrayList<String> filtered = CollUtil.removeEmpty(list);
 
 		// 原地过滤
-		Assert.assertSame(list, filtered);
-		Assert.assertEquals(CollUtil.newArrayList("a", "b", "c", "  "), filtered);
+		Assertions.assertSame(list, filtered);
+		Assertions.assertEquals(CollUtil.newArrayList("a", "b", "c", "  "), filtered);
 	}
 
 	@Test
@@ -352,32 +352,32 @@ public class CollUtilTest {
 		ArrayList<String> filtered = CollUtil.removeBlank(list);
 
 		// 原地过滤
-		Assert.assertSame(list, filtered);
-		Assert.assertEquals(CollUtil.newArrayList("a", "b", "c"), filtered);
+		Assertions.assertSame(list, filtered);
+		Assertions.assertEquals(CollUtil.newArrayList("a", "b", "c"), filtered);
 	}
 
 	@Test
 	public void groupTest() {
 		List<String> list = CollUtil.newArrayList("1", "2", "3", "4", "5", "6");
 		List<List<String>> group = CollUtil.group(list, null);
-		Assert.assertTrue(group.size() > 0);
+		Assertions.assertTrue(group.size() > 0);
 
 		List<List<String>> group2 = CollUtil.group(list, t -> {
 			// 按照奇数偶数分类
 			return Integer.parseInt(t) % 2;
 		});
-		Assert.assertEquals(CollUtil.newArrayList("2", "4", "6"), group2.get(0));
-		Assert.assertEquals(CollUtil.newArrayList("1", "3", "5"), group2.get(1));
+		Assertions.assertEquals(CollUtil.newArrayList("2", "4", "6"), group2.get(0));
+		Assertions.assertEquals(CollUtil.newArrayList("1", "3", "5"), group2.get(1));
 	}
 
 	@Test
 	public void groupByFieldTest() {
 		List<TestBean> list = CollUtil.newArrayList(new TestBean("张三", 12), new TestBean("李四", 13), new TestBean("王五", 12));
 		List<List<TestBean>> groupByField = CollUtil.groupByField(list, "age");
-		Assert.assertEquals("张三", groupByField.get(0).get(0).getName());
-		Assert.assertEquals("王五", groupByField.get(0).get(1).getName());
+		Assertions.assertEquals("张三", groupByField.get(0).get(0).getName());
+		Assertions.assertEquals("王五", groupByField.get(0).get(1).getName());
 
-		Assert.assertEquals("李四", groupByField.get(1).get(0).getName());
+		Assertions.assertEquals("李四", groupByField.get(1).get(0).getName());
 	}
 
 	@Test
@@ -389,9 +389,9 @@ public class CollUtilTest {
 		);
 
 		CollUtil.sortByProperty(list, "createTime");
-		Assert.assertEquals("李四", list.get(0).getName());
-		Assert.assertEquals("王五", list.get(1).getName());
-		Assert.assertEquals("张三", list.get(2).getName());
+		Assertions.assertEquals("李四", list.get(0).getName());
+		Assertions.assertEquals("王五", list.get(1).getName());
+		Assertions.assertEquals("张三", list.get(2).getName());
 	}
 
 	@Test
@@ -403,9 +403,9 @@ public class CollUtilTest {
 		);
 
 		CollUtil.sortByProperty(list, "age");
-		Assert.assertEquals("李四", list.get(0).getName());
-		Assert.assertEquals("张三", list.get(1).getName());
-		Assert.assertEquals("王五", list.get(2).getName());
+		Assertions.assertEquals("李四", list.get(0).getName());
+		Assertions.assertEquals("张三", list.get(1).getName());
+		Assertions.assertEquals("王五", list.get(2).getName());
 	}
 
 	@Test
@@ -416,9 +416,9 @@ public class CollUtilTest {
 		);
 
 		final Map<String, TestBean> map = CollUtil.fieldValueMap(list, "name");
-		Assert.assertEquals("李四", map.get("李四").getName());
-		Assert.assertEquals("王五", map.get("王五").getName());
-		Assert.assertEquals("张三", map.get("张三").getName());
+		Assertions.assertEquals("李四", map.get("李四").getName());
+		Assertions.assertEquals("王五", map.get("王五").getName());
+		Assertions.assertEquals("张三", map.get("张三").getName());
 	}
 
 	@Test
@@ -429,21 +429,21 @@ public class CollUtilTest {
 		);
 
 		final Map<String, Integer> map = CollUtil.fieldValueAsMap(list, "name", "age");
-		Assert.assertEquals(new Integer(12), map.get("张三"));
-		Assert.assertEquals(new Integer(13), map.get("李四"));
-		Assert.assertEquals(new Integer(14), map.get("王五"));
+		Assertions.assertEquals(new Integer(12), map.get("张三"));
+		Assertions.assertEquals(new Integer(13), map.get("李四"));
+		Assertions.assertEquals(new Integer(14), map.get("王五"));
 	}
 
 	@Test
 	public void emptyTest() {
 		final SortedSet<String> emptySortedSet = CollUtil.empty(SortedSet.class);
-		Assert.assertEquals(Collections.emptySortedSet(), emptySortedSet);
+		Assertions.assertEquals(Collections.emptySortedSet(), emptySortedSet);
 
 		final Set<String> emptySet = CollUtil.empty(Set.class);
-		Assert.assertEquals(Collections.emptySet(), emptySet);
+		Assertions.assertEquals(Collections.emptySet(), emptySet);
 
 		final List<String> emptyList = CollUtil.empty(List.class);
-		Assert.assertEquals(Collections.emptyList(), emptyList);
+		Assertions.assertEquals(Collections.emptyList(), emptyList);
 	}
 
 	@Data
@@ -464,16 +464,16 @@ public class CollUtilTest {
 		List<Object> list1 = CollUtil.list(false);
 		List<Object> list2 = CollUtil.list(true);
 
-		Assert.assertTrue(list1 instanceof ArrayList);
-		Assert.assertTrue(list2 instanceof LinkedList);
+		Assertions.assertTrue(list1 instanceof ArrayList);
+		Assertions.assertTrue(list2 instanceof LinkedList);
 	}
 
 	@Test
 	public void listTest2() {
 		List<String> list1 = CollUtil.list(false, "a", "b", "c");
 		List<String> list2 = CollUtil.list(true, "a", "b", "c");
-		Assert.assertEquals("[a, b, c]", list1.toString());
-		Assert.assertEquals("[a, b, c]", list2.toString());
+		Assertions.assertEquals("[a, b, c]", list1.toString());
+		Assertions.assertEquals("[a, b, c]", list2.toString());
 	}
 
 	@Test
@@ -485,18 +485,18 @@ public class CollUtilTest {
 
 		List<String> list1 = CollUtil.list(false, set);
 		List<String> list2 = CollUtil.list(true, set);
-		Assert.assertEquals("[a, b, c]", list1.toString());
-		Assert.assertEquals("[a, b, c]", list2.toString());
+		Assertions.assertEquals("[a, b, c]", list1.toString());
+		Assertions.assertEquals("[a, b, c]", list2.toString());
 	}
 
 	@Test
 	public void getTest() {
 		HashSet<String> set = CollUtil.set(true, "A", "B", "C", "D");
 		String str = CollUtil.get(set, 2);
-		Assert.assertEquals("C", str);
+		Assertions.assertEquals("C", str);
 
 		str = CollUtil.get(set, -1);
-		Assert.assertEquals("D", str);
+		Assertions.assertEquals("D", str);
 	}
 
 	@Test
@@ -509,10 +509,10 @@ public class CollUtilTest {
 		list2.add("3");
 		CollUtil.addAllIfNotContains(list1, list2);
 
-		Assert.assertEquals(3, list1.size());
-		Assert.assertEquals("1", list1.get(0));
-		Assert.assertEquals("2", list1.get(1));
-		Assert.assertEquals("3", list1.get(2));
+		Assertions.assertEquals(3, list1.size());
+		Assertions.assertEquals("1", list1.get(0));
+		Assertions.assertEquals("2", list1.get(1));
+		Assertions.assertEquals("3", list1.get(2));
 	}
 
 	@Test
@@ -528,7 +528,7 @@ public class CollUtilTest {
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
 		arrayList.add(null);
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -545,7 +545,7 @@ public class CollUtilTest {
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
 		arrayList.add(null);
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -560,7 +560,7 @@ public class CollUtilTest {
 
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -573,7 +573,7 @@ public class CollUtilTest {
 		// Act
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
-		Assert.assertTrue(retval.isEmpty());
+		Assertions.assertTrue(retval.isEmpty());
 	}
 
 	@Test
@@ -588,7 +588,7 @@ public class CollUtilTest {
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -603,21 +603,22 @@ public class CollUtilTest {
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class)
+	@Test
 	public void subInput1PositiveNegativePositiveOutputArrayIndexOutOfBoundsException() {
-		// Arrange
-		final List<Integer> list = new ArrayList<>();
-		list.add(null);
-		final int start = 2_147_483_643;
-		final int end = -2_147_483_648;
-		final int step = 2;
+		Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+			// Arrange
+			final List<Integer> list = new ArrayList<>();
+			list.add(null);
+			final int start = 2_147_483_643;
+			final int end = -2_147_483_648;
+			final int step = 2;
 
-		// Act
-		CollUtil.sub(list, start, end, step);
-		// Method is not expected to return due to exception thrown
+			// Act
+			CollUtil.sub(list, start, end, step);
+		});
 	}
 
 	@Test
@@ -630,7 +631,7 @@ public class CollUtilTest {
 		// Act
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
-		Assert.assertTrue(retval.isEmpty());
+		Assertions.assertTrue(retval.isEmpty());
 	}
 
 	@Test
@@ -645,7 +646,7 @@ public class CollUtilTest {
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -660,7 +661,7 @@ public class CollUtilTest {
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -675,7 +676,7 @@ public class CollUtilTest {
 		final List<Integer> retval = CollUtil.sub(list, start, end, step);
 		// Assert result
 		final List<Integer> arrayList = new ArrayList<>();
-		Assert.assertEquals(arrayList, retval);
+		Assertions.assertEquals(arrayList, retval);
 	}
 
 	@Test
@@ -687,7 +688,7 @@ public class CollUtilTest {
 		// Act
 		final List<Integer> retval = CollUtil.sub(list, start, end);
 		// Assert result
-		Assert.assertTrue(retval.isEmpty());
+		Assertions.assertTrue(retval.isEmpty());
 	}
 
 	@Test
@@ -695,7 +696,7 @@ public class CollUtilTest {
 		List<Integer> list = CollUtil.newArrayList(1, 2, 3, 4, 5, 6, 7, 8, 9);
 		List<Integer> sortPageAll = CollUtil.sortPageAll(1, 5, Comparator.reverseOrder(), list);
 
-		Assert.assertEquals(CollUtil.newArrayList(4, 3, 2, 1), sortPageAll);
+		Assertions.assertEquals(CollUtil.newArrayList(4, 3, 2, 1), sortPageAll);
 	}
 
 	@Test
@@ -703,18 +704,18 @@ public class CollUtilTest {
 		ArrayList<Integer> list1 = CollUtil.newArrayList(1, 2, 3, 4, 5);
 		ArrayList<Integer> list2 = CollUtil.newArrayList(5, 3, 1, 9, 11);
 
-		Assert.assertTrue(CollUtil.containsAny(list1, list2));
+		Assertions.assertTrue(CollUtil.containsAny(list1, list2));
 	}
 
 	@Test
 	public void containsAllTest() {
 		ArrayList<Integer> list1 = CollUtil.newArrayList(1, 2, 3, 4, 5);
 		ArrayList<Integer> list2 = CollUtil.newArrayList(5, 3, 1);
-		Assert.assertTrue(CollUtil.containsAll(list1, list2));
+		Assertions.assertTrue(CollUtil.containsAll(list1, list2));
 
 		ArrayList<Integer> list3 = CollUtil.newArrayList(1);
 		ArrayList<Integer> list4 = CollUtil.newArrayList();
-		Assert.assertTrue(CollUtil.containsAll(list3, list4));
+		Assertions.assertTrue(CollUtil.containsAll(list3, list4));
 	}
 
 	@Test
@@ -722,7 +723,7 @@ public class CollUtilTest {
 		// 测试：空数组返回null而不是报错
 		List<String> test = CollUtil.newArrayList();
 		String last = CollUtil.getLast(test);
-		Assert.assertNull(last);
+		Assertions.assertNull(last);
 	}
 
 	@Test
@@ -732,22 +733,22 @@ public class CollUtilTest {
 
 		Map<String, Integer> map = CollUtil.zip(keys, values);
 
-		Assert.assertEquals(4, Objects.requireNonNull(map).size());
+		Assertions.assertEquals(4, Objects.requireNonNull(map).size());
 
-		Assert.assertEquals(1, map.get("a").intValue());
-		Assert.assertEquals(2, map.get("b").intValue());
-		Assert.assertEquals(3, map.get("c").intValue());
-		Assert.assertEquals(4, map.get("d").intValue());
+		Assertions.assertEquals(1, map.get("a").intValue());
+		Assertions.assertEquals(2, map.get("b").intValue());
+		Assertions.assertEquals(3, map.get("c").intValue());
+		Assertions.assertEquals(4, map.get("d").intValue());
 	}
 
 	@Test
 	public void toMapTest() {
 		Collection<String> keys = CollUtil.newArrayList("a", "b", "c", "d");
 		final Map<String, String> map = CollUtil.toMap(keys, new HashMap<>(), (value) -> "key" + value);
-		Assert.assertEquals("a", map.get("keya"));
-		Assert.assertEquals("b", map.get("keyb"));
-		Assert.assertEquals("c", map.get("keyc"));
-		Assert.assertEquals("d", map.get("keyd"));
+		Assertions.assertEquals("a", map.get("keya"));
+		Assertions.assertEquals("b", map.get("keyb"));
+		Assertions.assertEquals("c", map.get("keyc"));
+		Assertions.assertEquals("d", map.get("keyd"));
 	}
 
 	@Test
@@ -762,9 +763,9 @@ public class CollUtilTest {
 				Map.Entry::getKey,
 				entry -> Long.parseLong(entry.getValue()));
 
-		Assert.assertEquals(1L, (long)map.get("a"));
-		Assert.assertEquals(12L, (long)map.get("b"));
-		Assert.assertEquals(134L, (long)map.get("c"));
+		Assertions.assertEquals(1L, (long)map.get("a"));
+		Assertions.assertEquals(12L, (long)map.get("b"));
+		Assertions.assertEquals(134L, (long)map.get("c"));
 	}
 
 	@Test
@@ -772,17 +773,17 @@ public class CollUtilTest {
 		ArrayList<String> list = CollUtil.newArrayList("a", "b", "c", "c", "a", "b", "d");
 		Map<String, Integer> countMap = CollUtil.countMap(list);
 
-		Assert.assertEquals(Integer.valueOf(2), countMap.get("a"));
-		Assert.assertEquals(Integer.valueOf(2), countMap.get("b"));
-		Assert.assertEquals(Integer.valueOf(2), countMap.get("c"));
-		Assert.assertEquals(Integer.valueOf(1), countMap.get("d"));
+		Assertions.assertEquals(Integer.valueOf(2), countMap.get("a"));
+		Assertions.assertEquals(Integer.valueOf(2), countMap.get("b"));
+		Assertions.assertEquals(Integer.valueOf(2), countMap.get("c"));
+		Assertions.assertEquals(Integer.valueOf(1), countMap.get("d"));
 	}
 
 	@Test
 	public void indexOfTest() {
 		ArrayList<String> list = CollUtil.newArrayList("a", "b", "c", "c", "a", "b", "d");
 		final int i = CollUtil.indexOf(list, (str) -> str.charAt(0) == 'c');
-		Assert.assertEquals(2, i);
+		Assertions.assertEquals(2, i);
 	}
 
 	@Test
@@ -790,7 +791,7 @@ public class CollUtilTest {
 		// List有优化
 		ArrayList<String> list = CollUtil.newArrayList("a", "b", "c", "c", "a", "b", "d");
 		final int i = CollUtil.lastIndexOf(list, (str) -> str.charAt(0) == 'c');
-		Assert.assertEquals(3, i);
+		Assertions.assertEquals(3, i);
 	}
 
 	@Test
@@ -798,7 +799,7 @@ public class CollUtilTest {
 		Set<String> list = CollUtil.set(true, "a", "b", "c", "c", "a", "b", "d");
 		// 去重后c排第三
 		final int i = CollUtil.lastIndexOf(list, (str) -> str.charAt(0) == 'c');
-		Assert.assertEquals(2, i);
+		Assertions.assertEquals(2, i);
 	}
 
 	@Test
@@ -808,7 +809,7 @@ public class CollUtilTest {
 			objects.add(Dict.create().set("name", "姓名：" + i));
 		}
 
-		Assert.assertEquals(0, CollUtil.page(3, 5, objects).size());
+		Assertions.assertEquals(0, CollUtil.page(3, 5, objects).size());
 	}
 
 	@Test
@@ -817,15 +818,15 @@ public class CollUtilTest {
 		List<Long> list2 = Arrays.asList(2L, 3L);
 
 		List<Long> result = CollUtil.subtractToList(list1, list2);
-		Assert.assertEquals(1, result.size());
-		Assert.assertEquals(1L, result.get(0), 1);
+		Assertions.assertEquals(1, result.size());
+		Assertions.assertEquals(1L, result.get(0), 1);
 	}
 
 	@Test
 	public void sortComparableTest() {
 		final List<String> of = ListUtil.toList("a", "c", "b");
 		final List<String> sort = CollUtil.sort(of, new ComparableComparator<>());
-		Assert.assertEquals("a,b,c", CollUtil.join(sort, ","));
+		Assertions.assertEquals("a,b,c", CollUtil.join(sort, ","));
 	}
 
 	@Test
@@ -848,9 +849,9 @@ public class CollUtilTest {
 		genderMap.put(5, "小孩");
 		genderMap.put(6, "男");
 
-		Assert.assertEquals(people.get(1).getGender(), "woman");
+		Assertions.assertEquals(people.get(1).getGender(), "woman");
 		CollUtil.setValueByMap(people, genderMap, Person::getId, Person::setGender);
-		Assert.assertEquals(people.get(1).getGender(), "妇女");
+		Assertions.assertEquals(people.get(1).getGender(), "妇女");
 
 		Map<Integer, Person> personMap = new HashMap<>();
 		personMap.put(1, new Person("AA", 21, "男", 1));
@@ -866,7 +867,7 @@ public class CollUtilTest {
 			x.setAge(y.getAge());
 		});
 
-		Assert.assertEquals(people.get(1).getGender(), "小孩");
+		Assertions.assertEquals(people.get(1).getGender(), "小孩");
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/collection/IterUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/IterUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.collection;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,7 +22,7 @@ public class IterUtilTest {
 	@Test
 	public void getFirstNonNullTest(){
 		final ArrayList<String> strings = CollUtil.newArrayList(null, null, "123", "456", null);
-		Assert.assertEquals("123", IterUtil.getFirstNoneNull(strings));
+		Assertions.assertEquals("123", IterUtil.getFirstNoneNull(strings));
 	}
 
 	@Test
@@ -30,39 +30,39 @@ public class IterUtilTest {
 		ArrayList<Car> carList = CollUtil.newArrayList(new Car("123", "大众"), new Car("345", "奔驰"), new Car("567", "路虎"));
 		Map<String, Car> carNameMap = IterUtil.fieldValueMap(carList.iterator(), "carNumber");
 
-		Assert.assertEquals("大众", carNameMap.get("123").getCarName());
-		Assert.assertEquals("奔驰", carNameMap.get("345").getCarName());
-		Assert.assertEquals("路虎", carNameMap.get("567").getCarName());
+		Assertions.assertEquals("大众", carNameMap.get("123").getCarName());
+		Assertions.assertEquals("奔驰", carNameMap.get("345").getCarName());
+		Assertions.assertEquals("路虎", carNameMap.get("567").getCarName());
 	}
 
 	@Test
 	public void joinTest() {
 		ArrayList<String> list = CollUtil.newArrayList("1", "2", "3", "4");
 		String join = IterUtil.join(list.iterator(), ":");
-		Assert.assertEquals("1:2:3:4", join);
+		Assertions.assertEquals("1:2:3:4", join);
 
 		ArrayList<Integer> list1 = CollUtil.newArrayList(1, 2, 3, 4);
 		String join1 = IterUtil.join(list1.iterator(), ":");
-		Assert.assertEquals("1:2:3:4", join1);
+		Assertions.assertEquals("1:2:3:4", join1);
 
 		// 包装每个节点
 		ArrayList<String> list2 = CollUtil.newArrayList("1", "2", "3", "4");
 		String join2 = IterUtil.join(list2.iterator(), ":", "\"", "\"");
-		Assert.assertEquals("\"1\":\"2\":\"3\":\"4\"", join2);
+		Assertions.assertEquals("\"1\":\"2\":\"3\":\"4\"", join2);
 	}
 
 	@Test
 	public void joinWithFuncTest() {
 		ArrayList<String> list = CollUtil.newArrayList("1", "2", "3", "4");
 		String join = IterUtil.join(list.iterator(), ":", String::valueOf);
-		Assert.assertEquals("1:2:3:4", join);
+		Assertions.assertEquals("1:2:3:4", join);
 	}
 
 	@Test
 	public void joinWithNullTest() {
 		ArrayList<String> list = CollUtil.newArrayList("1", null, "3", "4");
 		String join = IterUtil.join(list.iterator(), ":", String::valueOf);
-		Assert.assertEquals("1:null:3:4", join);
+		Assertions.assertEquals("1:null:3:4", join);
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class IterUtilTest {
 
 		Map<String, List<String>> testMap = IterUtil.toListMap(Arrays.asList("and", "brave", "back"),
 				v -> v.substring(0, 1));
-		Assert.assertEquals(testMap, expectedMap);
+		Assertions.assertEquals(testMap, expectedMap);
 	}
 
 	@Test
@@ -87,7 +87,7 @@ public class IterUtilTest {
 		expectedMap.put("456", benz);
 
 		Map<String, Car> testMap = IterUtil.toMap(Arrays.asList(bmw, benz), Car::getCarNumber);
-		Assert.assertEquals(expectedMap, testMap);
+		Assertions.assertEquals(expectedMap, testMap);
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/collection/ListUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/ListUtilTest.java
@@ -6,9 +6,9 @@ import cn.hutool.core.util.PageUtil;
 import cn.hutool.core.util.RandomUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,22 +21,22 @@ public class ListUtilTest {
 	@Test
 	public void splitTest(){
 		List<List<Object>> lists = ListUtil.split(null, 3);
-		Assert.assertEquals(ListUtil.empty(), lists);
+		Assertions.assertEquals(ListUtil.empty(), lists);
 
 		lists = ListUtil.split(Arrays.asList(1, 2, 3, 4), 1);
-		Assert.assertEquals("[[1], [2], [3], [4]]", lists.toString());
+		Assertions.assertEquals("[[1], [2], [3], [4]]", lists.toString());
 		lists = ListUtil.split(Arrays.asList(1, 2, 3, 4), 2);
-		Assert.assertEquals("[[1, 2], [3, 4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2], [3, 4]]", lists.toString());
 		lists = ListUtil.split(Arrays.asList(1, 2, 3, 4), 3);
-		Assert.assertEquals("[[1, 2, 3], [4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2, 3], [4]]", lists.toString());
 		lists = ListUtil.split(Arrays.asList(1, 2, 3, 4), 4);
-		Assert.assertEquals("[[1, 2, 3, 4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2, 3, 4]]", lists.toString());
 		lists = ListUtil.split(Arrays.asList(1, 2, 3, 4), 5);
-		Assert.assertEquals("[[1, 2, 3, 4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2, 3, 4]]", lists.toString());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void splitBenchTest() {
 		List<String> list = new ArrayList<>();
 		CollUtil.padRight(list, RandomUtil.randomInt(1000_0000, 1_0000_0000), "test");
@@ -54,7 +54,7 @@ public class ListUtilTest {
 		List<List<String>> ListSplitResult = ListUtil.split(list, size);
 		stopWatch.stop();
 
-		Assert.assertEquals(CollSplitResult, ListSplitResult);
+		Assertions.assertEquals(CollSplitResult, ListSplitResult);
 
 		Console.log(stopWatch.prettyPrint());
 	}
@@ -62,45 +62,47 @@ public class ListUtilTest {
 	@Test
 	public void splitAvgTest(){
 		List<List<Object>> lists = ListUtil.splitAvg(null, 3);
-		Assert.assertEquals(ListUtil.empty(), lists);
+		Assertions.assertEquals(ListUtil.empty(), lists);
 
 		lists = ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 1);
-		Assert.assertEquals("[[1, 2, 3, 4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2, 3, 4]]", lists.toString());
 		lists = ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 2);
-		Assert.assertEquals("[[1, 2], [3, 4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2], [3, 4]]", lists.toString());
 		lists = ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 3);
-		Assert.assertEquals("[[1, 2], [3], [4]]", lists.toString());
+		Assertions.assertEquals("[[1, 2], [3], [4]]", lists.toString());
 		lists = ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 4);
-		Assert.assertEquals("[[1], [2], [3], [4]]", lists.toString());
+		Assertions.assertEquals("[[1], [2], [3], [4]]", lists.toString());
 
 		lists = ListUtil.splitAvg(Arrays.asList(1, 2, 3), 5);
-		Assert.assertEquals("[[1], [2], [3], [], []]", lists.toString());
+		Assertions.assertEquals("[[1], [2], [3], [], []]", lists.toString());
 		lists = ListUtil.splitAvg(Arrays.asList(1, 2, 3), 2);
-		Assert.assertEquals("[[1, 2], [3]]", lists.toString());
+		Assertions.assertEquals("[[1, 2], [3]]", lists.toString());
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void splitAvgNotZero(){
-		// limit不能小于等于0
-		ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 0);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			// limit不能小于等于0
+			ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 0);
+		});
 	}
 
 	@Test
 	public void editTest(){
 		List<String> a = ListUtil.toLinkedList("1", "2", "3");
 		final List<String> filter = (List<String>) CollUtil.edit(a, str -> "edit" + str);
-		Assert.assertEquals("edit1", filter.get(0));
-		Assert.assertEquals("edit2", filter.get(1));
-		Assert.assertEquals("edit3", filter.get(2));
+		Assertions.assertEquals("edit1", filter.get(0));
+		Assertions.assertEquals("edit2", filter.get(1));
+		Assertions.assertEquals("edit3", filter.get(2));
 	}
 
 	@Test
 	public void indexOfAll() {
 		List<String> a = ListUtil.toLinkedList("1", "2", "3", "4", "3", "2", "1");
 		final int[] indexArray = ListUtil.indexOfAll(a, "2"::equals);
-		Assert.assertArrayEquals(new int[]{1,5}, indexArray);
+		Assertions.assertArrayEquals(new int[]{1,5}, indexArray);
 		final int[] indexArray2 = ListUtil.indexOfAll(a, "1"::equals);
-		Assert.assertArrayEquals(new int[]{0,6}, indexArray2);
+		Assertions.assertArrayEquals(new int[]{0,6}, indexArray2);
 	}
 
 	@Test
@@ -113,11 +115,11 @@ public class ListUtilTest {
 		int[] a2 = ListUtil.page(2,2,a).stream().mapToInt(Integer::valueOf).toArray();
 		int[] a3 = ListUtil.page(3,2,a).stream().mapToInt(Integer::valueOf).toArray();
 		int[] a4 = ListUtil.page(4,2,a).stream().mapToInt(Integer::valueOf).toArray();
-		Assert.assertArrayEquals(new int[]{1,2},a_1);
-		Assert.assertArrayEquals(new int[]{1,2},a1);
-		Assert.assertArrayEquals(new int[]{3,4},a2);
-		Assert.assertArrayEquals(new int[]{5},a3);
-		Assert.assertArrayEquals(new int[]{},a4);
+		Assertions.assertArrayEquals(new int[]{1,2},a_1);
+		Assertions.assertArrayEquals(new int[]{1,2},a1);
+		Assertions.assertArrayEquals(new int[]{3,4},a2);
+		Assertions.assertArrayEquals(new int[]{5},a3);
+		Assertions.assertArrayEquals(new int[]{},a4);
 
 
 		PageUtil.setFirstPageNo(2);
@@ -126,11 +128,11 @@ public class ListUtilTest {
 		int[] b2 = ListUtil.page(3,2,a).stream().mapToInt(Integer::valueOf).toArray();
 		int[] b3 = ListUtil.page(4,2,a).stream().mapToInt(Integer::valueOf).toArray();
 		int[] b4 = ListUtil.page(5,2,a).stream().mapToInt(Integer::valueOf).toArray();
-		Assert.assertArrayEquals(new int[]{1,2},b_1);
-		Assert.assertArrayEquals(new int[]{1,2},b1);
-		Assert.assertArrayEquals(new int[]{3,4},b2);
-		Assert.assertArrayEquals(new int[]{5},b3);
-		Assert.assertArrayEquals(new int[]{},b4);
+		Assertions.assertArrayEquals(new int[]{1,2},b_1);
+		Assertions.assertArrayEquals(new int[]{1,2},b1);
+		Assertions.assertArrayEquals(new int[]{3,4},b2);
+		Assertions.assertArrayEquals(new int[]{5},b3);
+		Assertions.assertArrayEquals(new int[]{},b4);
 
 		PageUtil.setFirstPageNo(0);
 		int[] c_1 = ListUtil.page(-1,2,a).stream().mapToInt(Integer::valueOf).toArray();
@@ -138,23 +140,23 @@ public class ListUtilTest {
 		int[] c2 = ListUtil.page(1,2,a).stream().mapToInt(Integer::valueOf).toArray();
 		int[] c3 = ListUtil.page(2,2,a).stream().mapToInt(Integer::valueOf).toArray();
 		int[] c4 = ListUtil.page(3,2,a).stream().mapToInt(Integer::valueOf).toArray();
-		Assert.assertArrayEquals(new int[]{1,2},c_1);
-		Assert.assertArrayEquals(new int[]{1,2},c1);
-		Assert.assertArrayEquals(new int[]{3,4},c2);
-		Assert.assertArrayEquals(new int[]{5},c3);
-		Assert.assertArrayEquals(new int[]{},c4);
+		Assertions.assertArrayEquals(new int[]{1,2},c_1);
+		Assertions.assertArrayEquals(new int[]{1,2},c1);
+		Assertions.assertArrayEquals(new int[]{3,4},c2);
+		Assertions.assertArrayEquals(new int[]{5},c3);
+		Assertions.assertArrayEquals(new int[]{},c4);
 
 
 		PageUtil.setFirstPageNo(1);
 		int[] d1 = ListUtil.page(0,8,a).stream().mapToInt(Integer::valueOf).toArray();
-		Assert.assertArrayEquals(new int[]{1,2,3,4,5},d1);
+		Assertions.assertArrayEquals(new int[]{1,2,3,4,5},d1);
 
 		// page with consumer
 		List<List<Integer>> pageListData = new ArrayList<>();
 		ListUtil.page(a, 2, pageListData::add);
-		Assert.assertArrayEquals(new int[]{1, 2}, pageListData.get(0).stream().mapToInt(Integer::valueOf).toArray());
-		Assert.assertArrayEquals(new int[]{3, 4}, pageListData.get(1).stream().mapToInt(Integer::valueOf).toArray());
-		Assert.assertArrayEquals(new int[]{5}, pageListData.get(2).stream().mapToInt(Integer::valueOf).toArray());
+		Assertions.assertArrayEquals(new int[]{1, 2}, pageListData.get(0).stream().mapToInt(Integer::valueOf).toArray());
+		Assertions.assertArrayEquals(new int[]{3, 4}, pageListData.get(1).stream().mapToInt(Integer::valueOf).toArray());
+		Assertions.assertArrayEquals(new int[]{5}, pageListData.get(2).stream().mapToInt(Integer::valueOf).toArray());
 
 
 		pageListData.clear();
@@ -164,9 +166,9 @@ public class ListUtilTest {
 				pageList.clear();
 			}
 		});
-		Assert.assertArrayEquals(new int[]{}, pageListData.get(0).stream().mapToInt(Integer::valueOf).toArray());
-		Assert.assertArrayEquals(new int[]{3, 4}, pageListData.get(1).stream().mapToInt(Integer::valueOf).toArray());
-		Assert.assertArrayEquals(new int[]{5}, pageListData.get(2).stream().mapToInt(Integer::valueOf).toArray());
+		Assertions.assertArrayEquals(new int[]{}, pageListData.get(0).stream().mapToInt(Integer::valueOf).toArray());
+		Assertions.assertArrayEquals(new int[]{3, 4}, pageListData.get(1).stream().mapToInt(Integer::valueOf).toArray());
+		Assertions.assertArrayEquals(new int[]{5}, pageListData.get(2).stream().mapToInt(Integer::valueOf).toArray());
 	}
 
 	@Test
@@ -176,8 +178,8 @@ public class ListUtilTest {
 		sub.remove(0);
 
 		// 对子列表操作不影响原列表
-		Assert.assertEquals(4, of.size());
-		Assert.assertEquals(1, sub.size());
+		Assertions.assertEquals(4, of.size());
+		Assertions.assertEquals(1, sub.size());
 	}
 
 	@Test
@@ -198,18 +200,18 @@ public class ListUtilTest {
 				);
 
 		final List<TestBean> order = ListUtil.sortByProperty(beanList, "order");
-		Assert.assertEquals("test1", order.get(0).getName());
-		Assert.assertEquals("test2", order.get(1).getName());
-		Assert.assertEquals("test3", order.get(2).getName());
-		Assert.assertEquals("test4", order.get(3).getName());
-		Assert.assertEquals("test5", order.get(4).getName());
+		Assertions.assertEquals("test1", order.get(0).getName());
+		Assertions.assertEquals("test2", order.get(1).getName());
+		Assertions.assertEquals("test3", order.get(2).getName());
+		Assertions.assertEquals("test4", order.get(3).getName());
+		Assertions.assertEquals("test5", order.get(4).getName());
 	}
 
 	@Test
 	public void swapIndex() {
 		List<Integer> list = Arrays.asList(7, 2, 8, 9);
 		ListUtil.swapTo(list, 8, 1);
-		Assert.assertEquals(8, (int) list.get(1));
+		Assertions.assertEquals(8, (int) list.get(1));
 	}
 
 	@Test
@@ -223,6 +225,6 @@ public class ListUtilTest {
 		List<Map<String, String>> list = Arrays.asList(map1, map2, map3);
 		ListUtil.swapElement(list, map2, map3);
 		Map<String, String> map = list.get(2);
-		Assert.assertEquals("李四", map.get("2"));
+		Assertions.assertEquals("李四", map.get("2"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/collection/MapProxyTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/MapProxyTest.java
@@ -5,8 +5,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.map.MapProxy;
 
@@ -20,13 +20,13 @@ public class MapProxyTest {
 
 		MapProxy mapProxy = new MapProxy(map);
 		Integer b = mapProxy.getInt("b");
-		Assert.assertEquals(new Integer(2), b);
+		Assertions.assertEquals(new Integer(2), b);
 
 		Set<Object> keys = mapProxy.keySet();
-		Assert.assertFalse(keys.isEmpty());
+		Assertions.assertFalse(keys.isEmpty());
 
 		Set<Entry<Object,Object>> entrys = mapProxy.entrySet();
-		Assert.assertFalse(entrys.isEmpty());
+		Assertions.assertFalse(entrys.isEmpty());
 	}
 
 	private interface Student {
@@ -41,7 +41,7 @@ public class MapProxyTest {
 	public void classProxyTest() {
 		Student student = MapProxy.create(new HashMap<>()).toProxyBean(Student.class);
 		student.setName("小明").setAge(18);
-		Assert.assertEquals(student.getAge(), 18);
-		Assert.assertEquals(student.getName(), "小明");
+		Assertions.assertEquals(student.getAge(), 18);
+		Assertions.assertEquals(student.getName(), "小明");
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/collection/PartitionIterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/PartitionIterTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.collection;
 
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.util.NumberUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -14,7 +14,7 @@ public class PartitionIterTest {
 		final LineIter lineIter = new LineIter(ResourceUtil.getUtf8Reader("test_lines.csv"));
 		final PartitionIter<String> iter = new PartitionIter<>(lineIter, 3);
 		for (List<String> lines : iter) {
-			Assert.assertTrue(lines.size() > 0);
+			Assertions.assertTrue(lines.size() > 0);
 		}
 	}
 
@@ -26,6 +26,6 @@ public class PartitionIterTest {
 		for (List<Integer> lines : iter) {
 			max = NumberUtil.max(max, NumberUtil.max(lines.toArray(new Integer[0])));
 		}
-		Assert.assertEquals(45, max);
+		Assertions.assertEquals(45, max);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/collection/RingIndexUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/RingIndexUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.collection;
 
-import cn.hutool.core.lang.Assert;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,7 +27,7 @@ public class RingIndexUtilTest {
 		ThreadUtil.concurrencyTest(strList.size(), () -> {
 			final int index = RingIndexUtil.ringNextIntByObj(strList, atomicInteger);
 			final String s = strList.get(index);
-			Assert.notNull(s);
+			Assertions.assertNotNull(s);
 		});
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/comparator/CompareUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/comparator/CompareUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.comparator;
 
 import cn.hutool.core.collection.ListUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -11,10 +11,10 @@ public class CompareUtilTest {
 	@Test
 	public void compareTest(){
 		int compare = CompareUtil.compare(null, "a", true);
-		Assert.assertTrue(compare > 0);
+		Assertions.assertTrue(compare > 0);
 
 		compare = CompareUtil.compare(null, "a", false);
-		Assert.assertTrue(compare < 0);
+		Assertions.assertTrue(compare < 0);
 	}
 
 	@Test
@@ -26,10 +26,10 @@ public class CompareUtilTest {
 
 		// 正序
 		list.sort(CompareUtil.comparingPinyin(e -> e));
-		Assert.assertEquals(list, ascendingOrderResult);
+		Assertions.assertEquals(list, ascendingOrderResult);
 
 		// 反序
 		list.sort(CompareUtil.comparingPinyin(e -> e, true));
-		Assert.assertEquals(list, descendingOrderResult);
+		Assertions.assertEquals(list, descendingOrderResult);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/comparator/VersionComparatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/comparator/VersionComparatorTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.comparator;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 版本比较单元测试
@@ -14,43 +14,43 @@ public class VersionComparatorTest {
 	@Test
 	public void versionComparatorTest1() {
 		int compare = VersionComparator.INSTANCE.compare("1.2.1", "1.12.1");
-		Assert.assertTrue(compare < 0);
+		Assertions.assertTrue(compare < 0);
 	}
 
 	@Test
 	public void versionComparatorTest2() {
 		int compare = VersionComparator.INSTANCE.compare("1.12.1", "1.12.1c");
-		Assert.assertTrue(compare < 0);
+		Assertions.assertTrue(compare < 0);
 	}
 
 	@Test
 	public void versionComparatorTest3() {
 		int compare = VersionComparator.INSTANCE.compare(null, "1.12.1c");
-		Assert.assertTrue(compare < 0);
+		Assertions.assertTrue(compare < 0);
 	}
 
 	@Test
 	public void versionComparatorTest4() {
 		int compare = VersionComparator.INSTANCE.compare("1.13.0", "1.12.1c");
-		Assert.assertTrue(compare > 0);
+		Assertions.assertTrue(compare > 0);
 	}
 
 	@Test
 	public void versionComparatorTest5() {
 		int compare = VersionComparator.INSTANCE.compare("V1.2", "V1.1");
-		Assert.assertTrue(compare > 0);
+		Assertions.assertTrue(compare > 0);
 	}
 
 	@Test
 	public void versionComparatorTes6() {
 		int compare = VersionComparator.INSTANCE.compare("V0.0.20170102", "V0.0.20170101");
-		Assert.assertTrue(compare > 0);
+		Assertions.assertTrue(compare > 0);
 	}
 
 	@Test
 	public void equalsTest(){
 		VersionComparator first = new VersionComparator();
 		VersionComparator other = new VersionComparator();
-		Assert.assertNotEquals(first, other);
+		Assertions.assertNotEquals(first, other);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/compiler/JavaSourceCompilerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/compiler/JavaSourceCompilerTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.compiler;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.ReflectUtil;
 import cn.hutool.core.util.ZipUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.InputStream;
@@ -37,7 +37,7 @@ public class JavaSourceCompilerTest {
 				.compile();
 		final Class<?> clazz = classLoader.loadClass("c.C");
 		Object obj = ReflectUtil.newInstance(clazz);
-		Assert.assertTrue(String.valueOf(obj).startsWith("c.C@"));
+		Assertions.assertTrue(String.valueOf(obj).startsWith("c.C@"));
 	}
 
 }

--- a/hutool-core/src/test/java/cn/hutool/core/compress/ZipReaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/compress/ZipReaderTest.java
@@ -2,15 +2,15 @@ package cn.hutool.core.compress;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.ZipUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 public class ZipReaderTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void unzipTest() {
 		File unzip = ZipUtil.unzip("d:/java.zip", "d:/test/java");
 		Console.log(unzip);

--- a/hutool-core/src/test/java/cn/hutool/core/compress/ZipWriterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/compress/ZipWriterTest.java
@@ -4,21 +4,21 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.resource.FileResource;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.ZipUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 public class ZipWriterTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipDirTest() {
 		ZipUtil.zip(new File("d:/test"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void addTest(){
 		final ZipWriter writer = ZipWriter.of(FileUtil.file("d:/test/test.zip"), CharsetUtil.CHARSET_UTF_8);
 		writer.add(new FileResource("d:/test/qr_c.png"));

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertOtherTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertOtherTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.convert;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
@@ -16,10 +16,10 @@ public class ConvertOtherTest {
 	public void hexTest() {
 		String a = "我是一个小小的可爱的字符串";
 		String hex = Convert.toHex(a, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("e68891e698afe4b880e4b8aae5b08fe5b08fe79a84e58fafe788b1e79a84e5ad97e7aca6e4b8b2", hex);
+		Assertions.assertEquals("e68891e698afe4b880e4b8aae5b08fe5b08fe79a84e58fafe788b1e79a84e5ad97e7aca6e4b8b2", hex);
 
 		String raw = Convert.hexToStr(hex, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(a, raw);
+		Assertions.assertEquals(a, raw);
 	}
 
 	@Test
@@ -27,18 +27,18 @@ public class ConvertOtherTest {
 		String a = "我是一个小小的可爱的字符串";
 
 		String unicode = Convert.strToUnicode(a);
-		Assert.assertEquals("\\u6211\\u662f\\u4e00\\u4e2a\\u5c0f\\u5c0f\\u7684\\u53ef\\u7231\\u7684\\u5b57\\u7b26\\u4e32", unicode);
+		Assertions.assertEquals("\\u6211\\u662f\\u4e00\\u4e2a\\u5c0f\\u5c0f\\u7684\\u53ef\\u7231\\u7684\\u5b57\\u7b26\\u4e32", unicode);
 
 		String raw = Convert.unicodeToStr(unicode);
-		Assert.assertEquals(raw, a);
+		Assertions.assertEquals(raw, a);
 
 		// 针对有特殊空白符的Unicode
 		String str = "你 好";
 		String unicode2 = Convert.strToUnicode(str);
-		Assert.assertEquals("\\u4f60\\u00a0\\u597d", unicode2);
+		Assertions.assertEquals("\\u4f60\\u00a0\\u597d", unicode2);
 
 		String str2 = Convert.unicodeToStr(unicode2);
-		Assert.assertEquals(str, str2);
+		Assertions.assertEquals(str, str2);
 	}
 
 	@Test
@@ -47,14 +47,14 @@ public class ConvertOtherTest {
 		// 转换后result为乱码
 		String result = Convert.convertCharset(a, CharsetUtil.UTF_8, CharsetUtil.ISO_8859_1);
 		String raw = Convert.convertCharset(result, CharsetUtil.ISO_8859_1, "UTF-8");
-		Assert.assertEquals(raw, a);
+		Assertions.assertEquals(raw, a);
 	}
 
 	@Test
 	public void convertTimeTest() {
 		long a = 4535345;
 		long minutes = Convert.convertTime(a, TimeUnit.MILLISECONDS, TimeUnit.MINUTES);
-		Assert.assertEquals(75, minutes);
+		Assertions.assertEquals(75, minutes);
 	}
 
 	@Test
@@ -62,11 +62,11 @@ public class ConvertOtherTest {
 		// 去包装
 		Class<?> wrapClass = Integer.class;
 		Class<?> unWraped = Convert.unWrap(wrapClass);
-		Assert.assertEquals(int.class, unWraped);
+		Assertions.assertEquals(int.class, unWraped);
 
 		// 包装
 		Class<?> primitiveClass = long.class;
 		Class<?> wraped = Convert.wrap(primitiveClass);
-		Assert.assertEquals(Long.class, wraped);
+		Assertions.assertEquals(Long.class, wraped);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertTest.java
@@ -10,8 +10,8 @@ import cn.hutool.core.util.HexUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -36,7 +36,7 @@ public class ConvertTest {
 	@Test
 	public void toObjectTest() {
 		Object result = Convert.convert(Object.class, "aaaa");
-		Assert.assertEquals("aaaa", result);
+		Assertions.assertEquals("aaaa", result);
 	}
 
 	@Test
@@ -44,118 +44,118 @@ public class ConvertTest {
 		int a = 1;
 		long[] b = { 1, 2, 3, 4, 5 };
 
-		Assert.assertEquals("[1, 2, 3, 4, 5]", Convert.convert(String.class, b));
+		Assertions.assertEquals("[1, 2, 3, 4, 5]", Convert.convert(String.class, b));
 
 		String aStr = Convert.toStr(a);
-		Assert.assertEquals("1", aStr);
+		Assertions.assertEquals("1", aStr);
 		String bStr = Convert.toStr(b);
-		Assert.assertEquals("[1, 2, 3, 4, 5]", Convert.toStr(bStr));
+		Assertions.assertEquals("[1, 2, 3, 4, 5]", Convert.toStr(bStr));
 	}
 
 	@Test
 	public void toStrTest2() {
 		String result = Convert.convert(String.class, "aaaa");
-		Assert.assertEquals("aaaa", result);
+		Assertions.assertEquals("aaaa", result);
 	}
 
 	@Test
 	public void toStrTest3() {
 		char a = 'a';
 		String result = Convert.convert(String.class, a);
-		Assert.assertEquals("a", result);
+		Assertions.assertEquals("a", result);
 	}
 
 	@Test
 	public void toIntTest() {
 		String a = " 34232";
 		Integer aInteger = Convert.toInt(a);
-		Assert.assertEquals(Integer.valueOf(34232), aInteger);
+		Assertions.assertEquals(Integer.valueOf(34232), aInteger);
 		int aInt = ConverterRegistry.getInstance().convert(int.class, a);
-		Assert.assertEquals(34232, aInt);
+		Assertions.assertEquals(34232, aInt);
 
 		// 带小数测试
 		String b = " 34232.00";
 		Integer bInteger = Convert.toInt(b);
-		Assert.assertEquals(Integer.valueOf(34232), bInteger);
+		Assertions.assertEquals(Integer.valueOf(34232), bInteger);
 		int bInt = ConverterRegistry.getInstance().convert(int.class, b);
-		Assert.assertEquals(34232, bInt);
+		Assertions.assertEquals(34232, bInt);
 
 		// boolean测试
 		boolean c = true;
 		Integer cInteger = Convert.toInt(c);
-		Assert.assertEquals(Integer.valueOf(1), cInteger);
+		Assertions.assertEquals(Integer.valueOf(1), cInteger);
 		int cInt = ConverterRegistry.getInstance().convert(int.class, c);
-		Assert.assertEquals(1, cInt);
+		Assertions.assertEquals(1, cInt);
 
 		// boolean测试
 		String d = "08";
 		Integer dInteger = Convert.toInt(d);
-		Assert.assertEquals(Integer.valueOf(8), dInteger);
+		Assertions.assertEquals(Integer.valueOf(8), dInteger);
 		int dInt = ConverterRegistry.getInstance().convert(int.class, d);
-		Assert.assertEquals(8, dInt);
+		Assertions.assertEquals(8, dInt);
 	}
 
 	@Test
 	public void toIntTest2() {
 		ArrayList<String> array = new ArrayList<>();
 		Integer aInt = Convert.convertQuietly(Integer.class, array, -1);
-		Assert.assertEquals(Integer.valueOf(-1), aInt);
+		Assertions.assertEquals(Integer.valueOf(-1), aInt);
 	}
 
 	@Test
 	public void toLongTest() {
 		String a = " 342324545435435";
 		Long aLong = Convert.toLong(a);
-		Assert.assertEquals(Long.valueOf(342324545435435L), aLong);
+		Assertions.assertEquals(Long.valueOf(342324545435435L), aLong);
 		long aLong2 = ConverterRegistry.getInstance().convert(long.class, a);
-		Assert.assertEquals(342324545435435L, aLong2);
+		Assertions.assertEquals(342324545435435L, aLong2);
 
 		// 带小数测试
 		String b = " 342324545435435.245435435";
 		Long bLong = Convert.toLong(b);
-		Assert.assertEquals(Long.valueOf(342324545435435L), bLong);
+		Assertions.assertEquals(Long.valueOf(342324545435435L), bLong);
 		long bLong2 = ConverterRegistry.getInstance().convert(long.class, b);
-		Assert.assertEquals(342324545435435L, bLong2);
+		Assertions.assertEquals(342324545435435L, bLong2);
 
 		// boolean测试
 		boolean c = true;
 		Long cLong = Convert.toLong(c);
-		Assert.assertEquals(Long.valueOf(1), cLong);
+		Assertions.assertEquals(Long.valueOf(1), cLong);
 		long cLong2 = ConverterRegistry.getInstance().convert(long.class, c);
-		Assert.assertEquals(1, cLong2);
+		Assertions.assertEquals(1, cLong2);
 
 		// boolean测试
 		String d = "08";
 		Long dLong = Convert.toLong(d);
-		Assert.assertEquals(Long.valueOf(8), dLong);
+		Assertions.assertEquals(Long.valueOf(8), dLong);
 		long dLong2 = ConverterRegistry.getInstance().convert(long.class, d);
-		Assert.assertEquals(8, dLong2);
+		Assertions.assertEquals(8, dLong2);
 	}
 
 	@Test
 	public void toCharTest() {
 		String str = "aadfdsfs";
 		Character c = Convert.toChar(str);
-		Assert.assertEquals(Character.valueOf('a'), c);
+		Assertions.assertEquals(Character.valueOf('a'), c);
 
 		// 转换失败
 		Object str2 = "";
 		Character c2 = Convert.toChar(str2);
-		Assert.assertNull(c2);
+		Assertions.assertNull(c2);
 	}
 
 	@Test
 	public void toNumberTest() {
 		Object a = "12.45";
 		Number number = Convert.toNumber(a);
-		Assert.assertEquals(12.45D, number.doubleValue(), 2);
+		Assertions.assertEquals(12.45D, number.doubleValue(), 2);
 	}
 
 	@Test
 	public void emptyToNumberTest() {
 		Object a = "";
 		Number number = Convert.toNumber(a);
-		Assert.assertNull(number);
+		Assertions.assertNull(number);
 	}
 
 	@Test
@@ -163,10 +163,10 @@ public class ConvertTest {
 		// 测试 int 转 byte
 		int int0 = 234;
 		byte byte0 = Convert.intToByte(int0);
-		Assert.assertEquals(-22, byte0);
+		Assertions.assertEquals(-22, byte0);
 
 		int int1 = Convert.byteToUnsignedInt(byte0);
-		Assert.assertEquals(int0, int1);
+		Assertions.assertEquals(int0, int1);
 	}
 
 	@Test
@@ -177,7 +177,7 @@ public class ConvertTest {
 
 		// 测试 byte 数组转 int
 		int int3 = Convert.bytesToInt(bytesInt);
-		Assert.assertEquals(int2, int3);
+		Assertions.assertEquals(int2, int3);
 	}
 
 	@Test
@@ -188,7 +188,7 @@ public class ConvertTest {
 		byte[] bytesLong = Convert.longToBytes(long1);
 		long long2 = Convert.bytesToLong(bytesLong);
 
-		Assert.assertEquals(long1, long2);
+		Assertions.assertEquals(long1, long2);
 	}
 
 	@Test
@@ -197,7 +197,7 @@ public class ConvertTest {
 		byte[] bytes = Convert.shortToBytes(short1);
 		short short2 = Convert.bytesToShort(bytes);
 
-		Assert.assertEquals(short2, short1);
+		Assertions.assertEquals(short2, short1);
 	}
 
 	@Test
@@ -205,63 +205,63 @@ public class ConvertTest {
 		List<String> list = Arrays.asList("1", "2");
 		String str = Convert.toStr(list);
 		List<String> list2 = Convert.toList(String.class, str);
-		Assert.assertEquals("1", list2.get(0));
-		Assert.assertEquals("2", list2.get(1));
+		Assertions.assertEquals("1", list2.get(0));
+		Assertions.assertEquals("2", list2.get(1));
 
 		List<Integer> list3 = Convert.toList(Integer.class, str);
-		Assert.assertEquals(1, list3.get(0).intValue());
-		Assert.assertEquals(2, list3.get(1).intValue());
+		Assertions.assertEquals(1, list3.get(0).intValue());
+		Assertions.assertEquals(2, list3.get(1).intValue());
 	}
 
 	@Test
 	public void toListTest2(){
 		String str = "1,2";
 		List<String> list2 = Convert.toList(String.class, str);
-		Assert.assertEquals("1", list2.get(0));
-		Assert.assertEquals("2", list2.get(1));
+		Assertions.assertEquals("1", list2.get(0));
+		Assertions.assertEquals("2", list2.get(1));
 
 		List<Integer> list3 = Convert.toList(Integer.class, str);
-		Assert.assertEquals(1, list3.get(0).intValue());
-		Assert.assertEquals(2, list3.get(1).intValue());
+		Assertions.assertEquals(1, list3.get(0).intValue());
+		Assertions.assertEquals(2, list3.get(1).intValue());
 	}
 
 	@Test
 	public void toByteArrayTest(){
 		// 测试Serializable转换为bytes，调用序列化转换
 		final byte[] bytes = Convert.toPrimitiveByteArray(new Product("zhangsan", "张三", "5.1.1"));
-		Assert.assertNotNull(bytes);
+		Assertions.assertNotNull(bytes);
 
 		final Product product = Convert.convert(Product.class, bytes);
-		Assert.assertEquals("zhangsan", product.getName());
-		Assert.assertEquals("张三", product.getCName());
-		Assert.assertEquals("5.1.1", product.getVersion());
+		Assertions.assertEquals("zhangsan", product.getName());
+		Assertions.assertEquals("张三", product.getCName());
+		Assertions.assertEquals("5.1.1", product.getVersion());
 	}
 
 	@Test
 	public void numberToByteArrayTest(){
 		// 测试Serializable转换为bytes，调用序列化转换
 		final byte[] bytes = Convert.toPrimitiveByteArray(12L);
-		Assert.assertArrayEquals(ByteUtil.longToBytes(12L), bytes);
+		Assertions.assertArrayEquals(ByteUtil.longToBytes(12L), bytes);
 	}
 
 	@Test
 	public void toAtomicIntegerArrayTest(){
 		String str = "1,2";
 		final AtomicIntegerArray atomicIntegerArray = Convert.convert(AtomicIntegerArray.class, str);
-		Assert.assertEquals("[1, 2]", atomicIntegerArray.toString());
+		Assertions.assertEquals("[1, 2]", atomicIntegerArray.toString());
 	}
 
 	@Test
 	public void toAtomicLongArrayTest(){
 		String str = "1,2";
 		final AtomicLongArray atomicLongArray = Convert.convert(AtomicLongArray.class, str);
-		Assert.assertEquals("[1, 2]", atomicLongArray.toString());
+		Assertions.assertEquals("[1, 2]", atomicLongArray.toString());
 	}
 
 	@Test
 	public void toClassTest(){
 		final Class<?> convert = Convert.convert(Class.class, "cn.hutool.core.convert.ConvertTest.Product");
-		Assert.assertSame(Product.class, convert);
+		Assertions.assertSame(Product.class, convert);
 	}
 
 	@Data
@@ -277,14 +277,14 @@ public class ConvertTest {
 	@Test
 	public void enumToIntTest(){
 		final Integer integer = Convert.toInt(BuildingType.CUO);
-		Assert.assertEquals(1, integer.intValue());
+		Assertions.assertEquals(1, integer.intValue());
 	}
 
 	@Test
 	public void toSetTest(){
 		final Set<Integer> result = Convert.convert(new TypeReference<Set<Integer>>() {
 		}, "1,2,3");
-		Assert.assertEquals(CollUtil.set(false, 1,2,3), result);
+		Assertions.assertEquals(CollUtil.set(false, 1,2,3), result);
 	}
 
 	@Getter
@@ -305,22 +305,24 @@ public class ConvertTest {
 		}
 	}
 
-	@Test(expected = DateException.class)
+	@Test
 	public void toDateTest(){
-		// 默认转换失败报错而不是返回null
-		Convert.convert(Date.class, "aaaa");
+		Assertions.assertThrows(DateException.class, () -> {
+			// 默认转换失败报错而不是返回null
+			Convert.convert(Date.class, "aaaa");
+		});
 	}
 
 	@Test
 	public void toDateTest2(){
 		final Date date = Convert.toDate("2021-01");
-		Assert.assertNull(date);
+		Assertions.assertNull(date);
 	}
 
 	@Test
 	public void toSqlDateTest(){
 		final java.sql.Date date = Convert.convert(java.sql.Date.class, DateUtil.parse("2021-07-28"));
-		Assert.assertEquals("2021-07-28", date.toString());
+		Assertions.assertEquals("2021-07-28", date.toString());
 	}
 
 	@Test
@@ -332,9 +334,9 @@ public class ConvertTest {
 
 		@SuppressWarnings("unchecked")
 		final Hashtable<String, String> hashtable = Convert.convert(Hashtable.class, map);
-		Assert.assertEquals("v1", hashtable.get("a1"));
-		Assert.assertEquals("v2", hashtable.get("a2"));
-		Assert.assertEquals("v3", hashtable.get("a3"));
+		Assertions.assertEquals("v1", hashtable.get("a1"));
+		Assertions.assertEquals("v2", hashtable.get("a2"));
+		Assertions.assertEquals("v3", hashtable.get("a3"));
 	}
 
 	@Test
@@ -342,7 +344,7 @@ public class ConvertTest {
 		// https://github.com/dromara/hutool/issues/1818
 		String str = "33020000210909112800000124";
 		final BigDecimal bigDecimal = Convert.toBigDecimal(str);
-		Assert.assertEquals(str, bigDecimal.toPlainString());
+		Assertions.assertEquals(str, bigDecimal.toPlainString());
 	}
 
 	@Test
@@ -351,6 +353,6 @@ public class ConvertTest {
 		String hex2 = "CD0CCB43";
 		final byte[] value = HexUtil.decodeHex(hex2);
 		final float f = Convert.toFloat(value);
-		Assert.assertEquals(406.1F, f, 2);
+		Assertions.assertEquals(406.1F, f, 2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToArrayTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToArrayTest.java
@@ -3,9 +3,9 @@ package cn.hutool.core.convert;
 import cn.hutool.core.convert.impl.ArrayConverter;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URL;
@@ -25,14 +25,14 @@ public class ConvertToArrayTest {
 		String[] b = { "1", "2", "3", "4" };
 
 		Integer[] integerArray = Convert.toIntArray(b);
-		Assert.assertArrayEquals(integerArray, new Integer[]{1,2,3,4});
+		Assertions.assertArrayEquals(integerArray, new Integer[]{1,2,3,4});
 
 		int[] intArray = Convert.convert(int[].class, b);
-		Assert.assertArrayEquals(intArray, new int[]{1,2,3,4});
+		Assertions.assertArrayEquals(intArray, new int[]{1,2,3,4});
 
 		long[] c = {1,2,3,4,5};
 		Integer[] intArray2 = Convert.toIntArray(c);
-		Assert.assertArrayEquals(intArray2, new Integer[]{1,2,3,4,5});
+		Assertions.assertArrayEquals(intArray2, new Integer[]{1,2,3,4,5});
 	}
 
 	@Test
@@ -41,7 +41,7 @@ public class ConvertToArrayTest {
 
 		final ArrayConverter arrayConverter = new ArrayConverter(Integer[].class, true);
 		Integer[] integerArray = (Integer[]) arrayConverter.convert(b, null);
-		Assert.assertArrayEquals(integerArray, new Integer[]{null, 1});
+		Assertions.assertArrayEquals(integerArray, new Integer[]{null, 1});
 	}
 
 	@Test
@@ -49,14 +49,14 @@ public class ConvertToArrayTest {
 		String[] b = { "1", "2", "3", "4" };
 
 		Long[] longArray = Convert.toLongArray(b);
-		Assert.assertArrayEquals(longArray, new Long[]{1L,2L,3L,4L});
+		Assertions.assertArrayEquals(longArray, new Long[]{1L,2L,3L,4L});
 
 		long[] longArray2 = Convert.convert(long[].class, b);
-		Assert.assertArrayEquals(longArray2, new long[]{1L,2L,3L,4L});
+		Assertions.assertArrayEquals(longArray2, new long[]{1L,2L,3L,4L});
 
 		int[] c = {1,2,3,4,5};
 		Long[] intArray2 = Convert.toLongArray(c);
-		Assert.assertArrayEquals(intArray2, new Long[]{1L,2L,3L,4L,5L});
+		Assertions.assertArrayEquals(intArray2, new Long[]{1L,2L,3L,4L,5L});
 	}
 
 	@Test
@@ -64,14 +64,14 @@ public class ConvertToArrayTest {
 		String[] b = { "1", "2", "3", "4" };
 
 		Double[] doubleArray = Convert.toDoubleArray(b);
-		Assert.assertArrayEquals(doubleArray, new Double[]{1D,2D,3D,4D});
+		Assertions.assertArrayEquals(doubleArray, new Double[]{1D,2D,3D,4D});
 
 		double[] doubleArray2 = Convert.convert(double[].class, b);
-		Assert.assertArrayEquals(doubleArray2, new double[]{1D,2D,3D,4D}, 2);
+		Assertions.assertArrayEquals(doubleArray2, new double[]{1D,2D,3D,4D}, 2);
 
 		int[] c = {1,2,3,4,5};
 		Double[] intArray2 = Convert.toDoubleArray(c);
-		Assert.assertArrayEquals(intArray2, new Double[]{1D,2D,3D,4D,5D});
+		Assertions.assertArrayEquals(intArray2, new Double[]{1D,2D,3D,4D,5D});
 	}
 
 	@Test
@@ -80,18 +80,18 @@ public class ConvertToArrayTest {
 		//数组转数组测试
 		int[] a = new int[]{1,2,3,4};
 		long[] result = ConverterRegistry.getInstance().convert(long[].class, a);
-		Assert.assertArrayEquals(new long[]{1L, 2L, 3L, 4L}, result);
+		Assertions.assertArrayEquals(new long[]{1L, 2L, 3L, 4L}, result);
 
 		//数组转数组测试
 		byte[] resultBytes = ConverterRegistry.getInstance().convert(byte[].class, a);
-		Assert.assertArrayEquals(new byte[]{1, 2, 3, 4}, resultBytes);
+		Assertions.assertArrayEquals(new byte[]{1, 2, 3, 4}, resultBytes);
 
 		//字符串转数组
 		String arrayStr = "1,2,3,4,5";
 		//获取Converter类的方法2，自己实例化相应Converter对象
 		ArrayConverter c3 = new ArrayConverter(int[].class);
 		int[] result3 = (int[]) c3.convert(arrayStr, null);
-		Assert.assertArrayEquals(new int[]{1,2,3,4,5}, result3);
+		Assertions.assertArrayEquals(new int[]{1,2,3,4,5}, result3);
 	}
 
 	@Test
@@ -102,9 +102,9 @@ public class ConvertToArrayTest {
 		list.add("c");
 
 		String[] result = Convert.toStrArray(list);
-		Assert.assertEquals(list.get(0), result[0]);
-		Assert.assertEquals(list.get(1), result[1]);
-		Assert.assertEquals(list.get(2), result[2]);
+		Assertions.assertEquals(list.get(0), result[0]);
+		Assertions.assertEquals(list.get(1), result[1]);
+		Assertions.assertEquals(list.get(2), result[2]);
 	}
 
 	@Test
@@ -113,24 +113,24 @@ public class ConvertToArrayTest {
 		Character[] array = Convert.toCharArray(testStr);
 
 		//包装类型数组
-		Assert.assertEquals(new Character('a'), array[0]);
-		Assert.assertEquals(new Character('b'), array[1]);
-		Assert.assertEquals(new Character('c'), array[2]);
-		Assert.assertEquals(new Character('d'), array[3]);
-		Assert.assertEquals(new Character('e'), array[4]);
+		Assertions.assertEquals(new Character('a'), array[0]);
+		Assertions.assertEquals(new Character('b'), array[1]);
+		Assertions.assertEquals(new Character('c'), array[2]);
+		Assertions.assertEquals(new Character('d'), array[3]);
+		Assertions.assertEquals(new Character('e'), array[4]);
 
 		//原始类型数组
 		char[] array2 = Convert.convert(char[].class, testStr);
-		Assert.assertEquals('a', array2[0]);
-		Assert.assertEquals('b', array2[1]);
-		Assert.assertEquals('c', array2[2]);
-		Assert.assertEquals('d', array2[3]);
-		Assert.assertEquals('e', array2[4]);
+		Assertions.assertEquals('a', array2[0]);
+		Assertions.assertEquals('b', array2[1]);
+		Assertions.assertEquals('c', array2[2]);
+		Assertions.assertEquals('d', array2[3]);
+		Assertions.assertEquals('e', array2[4]);
 
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void toUrlArrayTest() {
 		File[] files = FileUtil.file("D:\\workspace").listFiles();
 

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToBeanTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToBeanTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.convert;
 
 import cn.hutool.core.bean.BeanUtilTest.SubPerson;
 import cn.hutool.core.lang.TypeReference;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -27,9 +27,9 @@ public class ConvertToBeanTest {
 		person.setSubName("sub名字");
 
 		Map<?, ?> map = Convert.convert(Map.class, person);
-		Assert.assertEquals(map.get("name"), "测试A11");
-		Assert.assertEquals(map.get("age"), 14);
-		Assert.assertEquals("11213232", map.get("openid"));
+		Assertions.assertEquals(map.get("name"), "测试A11");
+		Assertions.assertEquals(map.get("age"), 14);
+		Assertions.assertEquals("11213232", map.get("openid"));
 	}
 
 	@Test
@@ -41,15 +41,15 @@ public class ConvertToBeanTest {
 		person.setSubName("sub名字");
 
 		Map<String, String> map = Convert.toMap(String.class, String.class, person);
-		Assert.assertEquals("测试A11", map.get("name"));
-		Assert.assertEquals("14", map.get("age"));
-		Assert.assertEquals("11213232", map.get("openid"));
+		Assertions.assertEquals("测试A11", map.get("name"));
+		Assertions.assertEquals("14", map.get("age"));
+		Assertions.assertEquals("11213232", map.get("openid"));
 
 		final LinkedHashMap<String, String> map2 = Convert.convert(
 				new TypeReference<LinkedHashMap<String, String>>() {}, person);
-		Assert.assertEquals("测试A11", map2.get("name"));
-		Assert.assertEquals("14", map2.get("age"));
-		Assert.assertEquals("11213232", map2.get("openid"));
+		Assertions.assertEquals("测试A11", map2.get("name"));
+		Assertions.assertEquals("14", map2.get("age"));
+		Assertions.assertEquals("11213232", map2.get("openid"));
 	}
 
 	@Test
@@ -62,10 +62,10 @@ public class ConvertToBeanTest {
 
 		Map<String, String> map2 = Convert.toMap(String.class, String.class, map1);
 
-		Assert.assertEquals("1", map2.get("key1"));
-		Assert.assertEquals("2", map2.get("key2"));
-		Assert.assertEquals("3", map2.get("key3"));
-		Assert.assertEquals("4", map2.get("key4"));
+		Assertions.assertEquals("1", map2.get("key1"));
+		Assertions.assertEquals("2", map2.get("key2"));
+		Assertions.assertEquals("3", map2.get("key3"));
+		Assertions.assertEquals("4", map2.get("key4"));
 	}
 
 	@Test
@@ -78,17 +78,17 @@ public class ConvertToBeanTest {
 		map.put("subName", "sub名字");
 
 		SubPerson subPerson = Convert.convert(SubPerson.class, map);
-		Assert.assertEquals("88dc4b28-91b1-4a1a-bab5-444b795c7ecd", subPerson.getId().toString());
-		Assert.assertEquals(14, subPerson.getAge());
-		Assert.assertEquals("11213232", subPerson.getOpenid());
-		Assert.assertEquals("测试A11", subPerson.getName());
-		Assert.assertEquals("11213232", subPerson.getOpenid());
+		Assertions.assertEquals("88dc4b28-91b1-4a1a-bab5-444b795c7ecd", subPerson.getId().toString());
+		Assertions.assertEquals(14, subPerson.getAge());
+		Assertions.assertEquals("11213232", subPerson.getOpenid());
+		Assertions.assertEquals("测试A11", subPerson.getName());
+		Assertions.assertEquals("11213232", subPerson.getOpenid());
 	}
 
 	@Test
 	public void nullStrToBeanTest(){
 		String nullStr = "null";
 		final SubPerson subPerson = Convert.convertQuietly(SubPerson.class, nullStr);
-		Assert.assertNull(subPerson);
+		Assertions.assertNull(subPerson);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToBooleanTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToBooleanTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ConvertToBooleanTest {
 
@@ -9,10 +9,10 @@ public class ConvertToBooleanTest {
 	public void intToBooleanTest(){
 		int a = 100;
 		final Boolean aBoolean = Convert.toBool(a);
-		Assert.assertTrue(aBoolean);
+		Assertions.assertTrue(aBoolean);
 
 		int b = 0;
 		final Boolean bBoolean = Convert.toBool(b);
-		Assert.assertFalse(bBoolean);
+		Assertions.assertFalse(bBoolean);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToCollectionTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToCollectionTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.convert;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.lang.TypeReference;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -24,104 +24,104 @@ public class ConvertToCollectionTest {
 	public void toCollectionTest() {
 		Object[] a = { "a", "你", "好", "", 1 };
 		List<?> list = (List<?>) Convert.convert(Collection.class, a);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals(1, list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals(1, list.get(4));
 	}
 
 	@Test
 	public void toListTest() {
 		Object[] a = { "a", "你", "好", "", 1 };
 		List<?> list = Convert.toList(a);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals(1, list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals(1, list.get(4));
 	}
 
 	@Test
 	public void toListTest2() {
 		Object[] a = { "a", "你", "好", "", 1 };
 		List<String> list = Convert.toList(String.class, a);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals("1", list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals("1", list.get(4));
 	}
 
 	@Test
 	public void toListTest3() {
 		Object[] a = { "a", "你", "好", "", 1 };
 		List<String> list = Convert.toList(String.class, a);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals("1", list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals("1", list.get(4));
 	}
 
 	@Test
 	public void toListTest4() {
 		Object[] a = { "a", "你", "好", "", 1 };
 		List<String> list = Convert.convert(new TypeReference<List<String>>() {}, a);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals("1", list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals("1", list.get(4));
 	}
 
 	@Test
 	public void strToListTest() {
 		String a = "a,你,好,123";
 		List<?> list = Convert.toList(a);
-		Assert.assertEquals(4, list.size());
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("123", list.get(3));
+		Assertions.assertEquals(4, list.size());
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("123", list.get(3));
 
 		String b = "a";
 		List<?> list2 = Convert.toList(b);
-		Assert.assertEquals(1, list2.size());
-		Assert.assertEquals("a", list2.get(0));
+		Assertions.assertEquals(1, list2.size());
+		Assertions.assertEquals("a", list2.get(0));
 	}
 
 	@Test
 	public void strToListTest2() {
 		String a = "a,你,好,123";
 		List<String> list = Convert.toList(String.class, a);
-		Assert.assertEquals(4, list.size());
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("123", list.get(3));
+		Assertions.assertEquals(4, list.size());
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("123", list.get(3));
 	}
 
 	@Test
 	public void numberToListTest() {
 		Integer i = 1;
 		ArrayList<?> list = Convert.convert(ArrayList.class, i);
-		Assert.assertSame(i, list.get(0));
+		Assertions.assertSame(i, list.get(0));
 
 		BigDecimal b = BigDecimal.ONE;
 		ArrayList<?> list2 = Convert.convert(ArrayList.class, b);
-		Assert.assertEquals(b, list2.get(0));
+		Assertions.assertEquals(b, list2.get(0));
 	}
 
 	@Test
 	public void toLinkedListTest() {
 		Object[] a = { "a", "你", "好", "", 1 };
 		List<?> list = Convert.convert(LinkedList.class, a);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals(1, list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals(1, list.get(4));
 	}
 
 	@Test
@@ -129,10 +129,10 @@ public class ConvertToCollectionTest {
 		Object[] a = { "a", "你", "好", "", 1 };
 		LinkedHashSet<?> set = Convert.convert(LinkedHashSet.class, a);
 		ArrayList<?> list = CollUtil.newArrayList(set);
-		Assert.assertEquals("a", list.get(0));
-		Assert.assertEquals("你", list.get(1));
-		Assert.assertEquals("好", list.get(2));
-		Assert.assertEquals("", list.get(3));
-		Assert.assertEquals(1, list.get(4));
+		Assertions.assertEquals("a", list.get(0));
+		Assertions.assertEquals("你", list.get(1));
+		Assertions.assertEquals("好", list.get(2));
+		Assertions.assertEquals("", list.get(3));
+		Assertions.assertEquals(1, list.get(4));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToNumberTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToNumberTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.convert;
 
 import cn.hutool.core.date.DateTime;
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.concurrent.atomic.AtomicLong;
@@ -14,7 +14,7 @@ public class ConvertToNumberTest {
 		final DateTime date = DateUtil.parse("2020-05-17 12:32:00");
 		final Long dateLong = Convert.toLong(date);
 		assert date != null;
-		Assert.assertEquals(date.getTime(), dateLong.longValue());
+		Assertions.assertEquals(date.getTime(), dateLong.longValue());
 	}
 
 	@Test
@@ -22,7 +22,7 @@ public class ConvertToNumberTest {
 		final DateTime date = DateUtil.parse("2020-05-17 12:32:00");
 		final Integer dateInt = Convert.toInt(date);
 		assert date != null;
-		Assert.assertEquals((int)date.getTime(), dateInt.intValue());
+		Assertions.assertEquals((int)date.getTime(), dateInt.intValue());
 	}
 
 	@Test
@@ -30,15 +30,15 @@ public class ConvertToNumberTest {
 		final DateTime date = DateUtil.parse("2020-05-17 12:32:00");
 		final AtomicLong dateLong = Convert.convert(AtomicLong.class, date);
 		assert date != null;
-		Assert.assertEquals(date.getTime(), dateLong.longValue());
+		Assertions.assertEquals(date.getTime(), dateLong.longValue());
 	}
 
 	@Test
 	public void toBigDecimalTest(){
 		BigDecimal bigDecimal = Convert.toBigDecimal("1.1f");
-		Assert.assertEquals(1.1f, bigDecimal.floatValue(), 1);
+		Assertions.assertEquals(1.1f, bigDecimal.floatValue(), 1);
 
 		bigDecimal = Convert.toBigDecimal("1L");
-		Assert.assertEquals(1L, bigDecimal.longValue());
+		Assertions.assertEquals(1L, bigDecimal.longValue());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToSBCAndDBCTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConvertToSBCAndDBCTest.java
@@ -1,12 +1,12 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 类型转换工具单元测试
  * 全角半角转换
- * 
+ *
  * @author Looly
  *
  */
@@ -16,13 +16,13 @@ public class ConvertToSBCAndDBCTest {
 	public void toSBCTest() {
 		String a = "123456789";
 		String sbc = Convert.toSBC(a);
-		Assert.assertEquals("１２３４５６７８９", sbc);
+		Assertions.assertEquals("１２３４５６７８９", sbc);
 	}
-	
+
 	@Test
 	public void toDBCTest() {
 		String a = "１２３４５６７８９";
 		String dbc = Convert.toDBC(a);
-		Assert.assertEquals("123456789", dbc);
+		Assertions.assertEquals("123456789", dbc);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/ConverterRegistryTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/ConverterRegistryTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * ConverterRegistry 单元测试
@@ -9,28 +9,28 @@ import org.junit.Test;
  *
  */
 public class ConverterRegistryTest {
-	
+
 	@Test
 	public void getConverterTest() {
 		Converter<Object> converter = ConverterRegistry.getInstance().getConverter(CharSequence.class, false);
-		Assert.assertNotNull(converter);
+		Assertions.assertNotNull(converter);
 	}
-	
+
 	@Test
 	public void customTest(){
 		int a = 454553;
 		ConverterRegistry converterRegistry = ConverterRegistry.getInstance();
-		
+
 		CharSequence result = converterRegistry.convert(CharSequence.class, a);
-		Assert.assertEquals("454553", result);
-		
+		Assertions.assertEquals("454553", result);
+
 		//此处做为示例自定义CharSequence转换，因为Hutool中已经提供CharSequence转换，请尽量不要替换
 		//替换可能引发关联转换异常（例如覆盖CharSequence转换会影响全局）
 		converterRegistry.putCustom(CharSequence.class, CustomConverter.class);
 		result = converterRegistry.convert(CharSequence.class, a);
-		Assert.assertEquals("Custom: 454553", result);
+		Assertions.assertEquals("Custom: 454553", result);
 	}
-	
+
 	public static class CustomConverter implements Converter<CharSequence>{
 		@Override
 		public CharSequence convert(Object value, CharSequence defaultValue) throws IllegalArgumentException {

--- a/hutool-core/src/test/java/cn/hutool/core/convert/DateConvertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/DateConvertTest.java
@@ -5,8 +5,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.date.DateUtil;
 
@@ -16,57 +16,57 @@ public class DateConvertTest {
 	public void toDateTest() {
 		String a = "2017-05-06";
 		Date value = Convert.toDate(a);
-		Assert.assertEquals(a, DateUtil.formatDate(value));
+		Assertions.assertEquals(a, DateUtil.formatDate(value));
 
 		long timeLong = DateUtil.date().getTime();
 		Date value2 = Convert.toDate(timeLong);
-		Assert.assertEquals(timeLong, value2.getTime());
+		Assertions.assertEquals(timeLong, value2.getTime());
 	}
 
 	@Test
 	public void toDateFromIntTest() {
 		int dateLong = -1497600000;
 		Date value = Convert.toDate(dateLong);
-		Assert.assertNotNull(value);
-		Assert.assertEquals("Mon Dec 15 00:00:00 CST 1969", value.toString());
+		Assertions.assertNotNull(value);
+		Assertions.assertEquals("Mon Dec 15 00:00:00 CST 1969", value.toString());
 
 		final java.sql.Date sqlDate = Convert.convert(java.sql.Date.class, dateLong);
-		Assert.assertNotNull(sqlDate);
-		Assert.assertEquals("1969-12-15", sqlDate.toString());
+		Assertions.assertNotNull(sqlDate);
+		Assertions.assertEquals("1969-12-15", sqlDate.toString());
 	}
 
 	@Test
 	public void toDateFromLocalDateTimeTest() {
 		LocalDateTime localDateTime = LocalDateTime.parse("2017-05-06T08:30:00", DateTimeFormatter.ISO_DATE_TIME);
 		Date value = Convert.toDate(localDateTime);
-		Assert.assertNotNull(value);
-		Assert.assertEquals("2017-05-06", DateUtil.formatDate(value));
+		Assertions.assertNotNull(value);
+		Assertions.assertEquals("2017-05-06", DateUtil.formatDate(value));
 	}
 
 	@Test
 	public void toSqlDateTest() {
 		String a = "2017-05-06";
 		java.sql.Date value = Convert.convert(java.sql.Date.class, a);
-		Assert.assertEquals("2017-05-06", value.toString());
+		Assertions.assertEquals("2017-05-06", value.toString());
 
 		long timeLong = DateUtil.date().getTime();
 		java.sql.Date value2 = Convert.convert(java.sql.Date.class, timeLong);
-		Assert.assertEquals(timeLong, value2.getTime());
+		Assertions.assertEquals(timeLong, value2.getTime());
 	}
-	
+
 	@Test
 	public void toLocalDateTimeTest() {
 		Date src = new Date();
-		
+
 		LocalDateTime ldt = Convert.toLocalDateTime(src);
-		Assert.assertEquals(ldt, DateUtil.toLocalDateTime(src));
-		
+		Assertions.assertEquals(ldt, DateUtil.toLocalDateTime(src));
+
 		Timestamp ts = Timestamp.from(src.toInstant());
 		ldt = Convert.toLocalDateTime(ts);
-		Assert.assertEquals(ldt, DateUtil.toLocalDateTime(src));
-		
+		Assertions.assertEquals(ldt, DateUtil.toLocalDateTime(src));
+
 		String str = "2020-12-12 12:12:12.0";
 		ldt = Convert.toLocalDateTime(str);
-		Assert.assertEquals(ldt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S")), str);
+		Assertions.assertEquals(ldt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S")), str);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/EnumConvertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/EnumConvertTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Enum转换单元测试
@@ -11,19 +11,19 @@ public class EnumConvertTest {
 	@Test
 	public void convertTest(){
 		TestEnum bbb = Convert.convert(TestEnum.class, "BBB");
-		Assert.assertEquals(TestEnum.B, bbb);
+		Assertions.assertEquals(TestEnum.B, bbb);
 
 		bbb = Convert.convert(TestEnum.class, 22);
-		Assert.assertEquals(TestEnum.B, bbb);
+		Assertions.assertEquals(TestEnum.B, bbb);
 	}
 
 	@Test
 	public void toEnumTest(){
 		TestEnum ccc = Convert.toEnum(TestEnum.class, "CCC");
-		Assert.assertEquals(TestEnum.C, ccc);
+		Assertions.assertEquals(TestEnum.C, ccc);
 
 		ccc = Convert.toEnum(TestEnum.class, 33);
-		Assert.assertEquals(TestEnum.C, ccc);
+		Assertions.assertEquals(TestEnum.C, ccc);
 	}
 
 	enum TestEnum {

--- a/hutool-core/src/test/java/cn/hutool/core/convert/MapConvertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/MapConvertTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.convert;
 
 import cn.hutool.core.map.MapBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -10,7 +10,7 @@ import java.util.Map;
 
 /**
  * Map转换单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -23,8 +23,8 @@ public class MapConvertTest {
 		user.setAge(45);
 
 		HashMap<?, ?> map = Convert.convert(HashMap.class, user);
-		Assert.assertEquals("AAA", map.get("name"));
-		Assert.assertEquals(45, map.get("age"));
+		Assertions.assertEquals("AAA", map.get("name"));
+		Assertions.assertEquals(45, map.get("age"));
 	}
 
 	@Test
@@ -35,8 +35,8 @@ public class MapConvertTest {
 				.put("age", 45).map();
 
 		LinkedHashMap<?, ?> map = Convert.convert(LinkedHashMap.class, srcMap);
-		Assert.assertEquals("AAA", map.get("name"));
-		Assert.assertEquals(45, map.get("age"));
+		Assertions.assertEquals("AAA", map.get("name"));
+		Assertions.assertEquals(45, map.get("age"));
 	}
 
 	public static class User {

--- a/hutool-core/src/test/java/cn/hutool/core/convert/NumberChineseFormatterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/NumberChineseFormatterTest.java
@@ -1,8 +1,5 @@
 package cn.hutool.core.convert;
 
-import java.security.SecureRandom;
-
-import cn.hutool.core.lang.id.NanoId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/hutool-core/src/test/java/cn/hutool/core/convert/NumberChineseFormatterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/NumberChineseFormatterTest.java
@@ -1,7 +1,10 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.security.SecureRandom;
+
+import cn.hutool.core.lang.id.NanoId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NumberChineseFormatterTest {
 
@@ -9,252 +12,252 @@ public class NumberChineseFormatterTest {
 	@Test
 	public void formatThousandLongTest(){
 		String f = NumberChineseFormatter.format(0, false);
-		Assert.assertEquals("零", f);
+		Assertions.assertEquals("零", f);
 		f = NumberChineseFormatter.format(1, false);
-		Assert.assertEquals("一", f);
+		Assertions.assertEquals("一", f);
 		f = NumberChineseFormatter.format(10, false);
-		Assert.assertEquals("一十", f);
+		Assertions.assertEquals("一十", f);
 		f = NumberChineseFormatter.format(12, false);
-		Assert.assertEquals("一十二", f);
+		Assertions.assertEquals("一十二", f);
 		f = NumberChineseFormatter.format(100, false);
-		Assert.assertEquals("一百", f);
+		Assertions.assertEquals("一百", f);
 		f = NumberChineseFormatter.format(101, false);
-		Assert.assertEquals("一百零一", f);
+		Assertions.assertEquals("一百零一", f);
 		f = NumberChineseFormatter.format(110, false);
-		Assert.assertEquals("一百一十", f);
+		Assertions.assertEquals("一百一十", f);
 		f = NumberChineseFormatter.format(112, false);
-		Assert.assertEquals("一百一十二", f);
+		Assertions.assertEquals("一百一十二", f);
 		f = NumberChineseFormatter.format(1000, false);
-		Assert.assertEquals("一千", f);
+		Assertions.assertEquals("一千", f);
 		f = NumberChineseFormatter.format(1001, false);
-		Assert.assertEquals("一千零一", f);
+		Assertions.assertEquals("一千零一", f);
 		f = NumberChineseFormatter.format(1010, false);
-		Assert.assertEquals("一千零一十", f);
+		Assertions.assertEquals("一千零一十", f);
 		f = NumberChineseFormatter.format(1100, false);
-		Assert.assertEquals("一千一百", f);
+		Assertions.assertEquals("一千一百", f);
 		f = NumberChineseFormatter.format(1101, false);
-		Assert.assertEquals("一千一百零一", f);
+		Assertions.assertEquals("一千一百零一", f);
 		f = NumberChineseFormatter.format(9999, false);
-		Assert.assertEquals("九千九百九十九", f);
+		Assertions.assertEquals("九千九百九十九", f);
 	}
 
 	// 测试万
 	@Test
 	public void formatTenThousandLongTest(){
 		String f = NumberChineseFormatter.format(1_0000, false);
-		Assert.assertEquals("一万", f);
+		Assertions.assertEquals("一万", f);
 		f = NumberChineseFormatter.format(1_0001, false);
-		Assert.assertEquals("一万零一", f);
+		Assertions.assertEquals("一万零一", f);
 		f = NumberChineseFormatter.format(1_0010, false);
-		Assert.assertEquals("一万零一十", f);
+		Assertions.assertEquals("一万零一十", f);
 		f = NumberChineseFormatter.format(1_0100, false);
-		Assert.assertEquals("一万零一百", f);
+		Assertions.assertEquals("一万零一百", f);
 		f = NumberChineseFormatter.format(1_1000, false);
-		Assert.assertEquals("一万一千", f);
+		Assertions.assertEquals("一万一千", f);
 		f = NumberChineseFormatter.format(10_1000, false);
-		Assert.assertEquals("一十万零一千", f);
+		Assertions.assertEquals("一十万零一千", f);
 		f = NumberChineseFormatter.format(10_0100, false);
-		Assert.assertEquals("一十万零一百", f);
+		Assertions.assertEquals("一十万零一百", f);
 		f = NumberChineseFormatter.format(100_1000, false);
-		Assert.assertEquals("一百万零一千", f);
+		Assertions.assertEquals("一百万零一千", f);
 		f = NumberChineseFormatter.format(100_0100, false);
-		Assert.assertEquals("一百万零一百", f);
+		Assertions.assertEquals("一百万零一百", f);
 		f = NumberChineseFormatter.format(1000_1000, false);
-		Assert.assertEquals("一千万零一千", f);
+		Assertions.assertEquals("一千万零一千", f);
 		f = NumberChineseFormatter.format(1000_0100, false);
-		Assert.assertEquals("一千万零一百", f);
+		Assertions.assertEquals("一千万零一百", f);
 		f = NumberChineseFormatter.format(9999_0000, false);
-		Assert.assertEquals("九千九百九十九万", f);
+		Assertions.assertEquals("九千九百九十九万", f);
 	}
 
 	// 测试亿
 	@Test
 	public void formatHundredMillionLongTest(){
 		String f = NumberChineseFormatter.format(1_0000_0000L, false);
-		Assert.assertEquals("一亿", f);
+		Assertions.assertEquals("一亿", f);
 		f = NumberChineseFormatter.format(1_0000_0001L, false);
-		Assert.assertEquals("一亿零一", f);
+		Assertions.assertEquals("一亿零一", f);
 		f = NumberChineseFormatter.format(1_0000_1000L, false);
-		Assert.assertEquals("一亿零一千", f);
+		Assertions.assertEquals("一亿零一千", f);
 		f = NumberChineseFormatter.format(1_0001_0000L, false);
-		Assert.assertEquals("一亿零一万", f);
+		Assertions.assertEquals("一亿零一万", f);
 		f = NumberChineseFormatter.format(1_0010_0000L, false);
-		Assert.assertEquals("一亿零一十万", f);
+		Assertions.assertEquals("一亿零一十万", f);
 		f = NumberChineseFormatter.format(1_0010_0000L, false);
-		Assert.assertEquals("一亿零一十万", f);
+		Assertions.assertEquals("一亿零一十万", f);
 		f = NumberChineseFormatter.format(1_0100_0000L, false);
-		Assert.assertEquals("一亿零一百万", f);
+		Assertions.assertEquals("一亿零一百万", f);
 		f = NumberChineseFormatter.format(1_1000_0000L, false);
-		Assert.assertEquals("一亿一千万", f);
+		Assertions.assertEquals("一亿一千万", f);
 		f = NumberChineseFormatter.format(10_1000_0000L, false);
-		Assert.assertEquals("一十亿零一千万", f);
+		Assertions.assertEquals("一十亿零一千万", f);
 		f = NumberChineseFormatter.format(100_1000_0000L, false);
-		Assert.assertEquals("一百亿零一千万", f);
+		Assertions.assertEquals("一百亿零一千万", f);
 		f = NumberChineseFormatter.format(1000_1000_0000L, false);
-		Assert.assertEquals("一千亿零一千万", f);
+		Assertions.assertEquals("一千亿零一千万", f);
 		f = NumberChineseFormatter.format(1100_1000_0000L, false);
-		Assert.assertEquals("一千一百亿零一千万", f);
+		Assertions.assertEquals("一千一百亿零一千万", f);
 		f = NumberChineseFormatter.format(9999_0000_0000L, false);
-		Assert.assertEquals("九千九百九十九亿", f);
+		Assertions.assertEquals("九千九百九十九亿", f);
 	}
 
 	// 测试万亿
 	@Test
 	public void formatTrillionsLongTest(){
 		String f = NumberChineseFormatter.format(1_0000_0000_0000L, false);
-		Assert.assertEquals("一万亿", f);
+		Assertions.assertEquals("一万亿", f);
 		f = NumberChineseFormatter.format(1_0000_1000_0000L, false);
-		Assert.assertEquals("一万亿零一千万", f);
+		Assertions.assertEquals("一万亿零一千万", f);
 		f = NumberChineseFormatter.format(1_0010_0000_0000L, false);
-		Assert.assertEquals("一万零一十亿", f);
+		Assertions.assertEquals("一万零一十亿", f);
 	}
 
 	@Test
 	public void formatTest() {
 		String f0 = NumberChineseFormatter.format(5000_8000, false);
-		Assert.assertEquals("五千万零八千", f0);
+		Assertions.assertEquals("五千万零八千", f0);
 		String f1 = NumberChineseFormatter.format(1_0889.72356, false);
-		Assert.assertEquals("一万零八百八十九点七二", f1);
+		Assertions.assertEquals("一万零八百八十九点七二", f1);
 		f1 = NumberChineseFormatter.format(12653, false);
-		Assert.assertEquals("一万二千六百五十三", f1);
+		Assertions.assertEquals("一万二千六百五十三", f1);
 		f1 = NumberChineseFormatter.format(215.6387, false);
-		Assert.assertEquals("二百一十五点六四", f1);
+		Assertions.assertEquals("二百一十五点六四", f1);
 		f1 = NumberChineseFormatter.format(1024, false);
-		Assert.assertEquals("一千零二十四", f1);
+		Assertions.assertEquals("一千零二十四", f1);
 		f1 = NumberChineseFormatter.format(100350089, false);
-		Assert.assertEquals("一亿零三十五万零八十九", f1);
+		Assertions.assertEquals("一亿零三十五万零八十九", f1);
 		f1 = NumberChineseFormatter.format(1200, false);
-		Assert.assertEquals("一千二百", f1);
+		Assertions.assertEquals("一千二百", f1);
 		f1 = NumberChineseFormatter.format(12, false);
-		Assert.assertEquals("一十二", f1);
+		Assertions.assertEquals("一十二", f1);
 		f1 = NumberChineseFormatter.format(0.05, false);
-		Assert.assertEquals("零点零五", f1);
+		Assertions.assertEquals("零点零五", f1);
 	}
 
 	@Test
 	public void formatTest2() {
 		String f1 = NumberChineseFormatter.format(-0.3, false, false);
-		Assert.assertEquals("负零点三", f1);
+		Assertions.assertEquals("负零点三", f1);
 
 		f1 = NumberChineseFormatter.format(10, false, false);
-		Assert.assertEquals("一十", f1);
+		Assertions.assertEquals("一十", f1);
 	}
 
 	@Test
 	public void formatTest3() {
 //		String f1 = NumberChineseFormatter.format(5000_8000, false, false);
-//		Assert.assertEquals("五千万零八千", f1);
+//		Assertions.assertEquals("五千万零八千", f1);
 
 		String f2 = NumberChineseFormatter.format(1_0035_0089, false, false);
-		Assert.assertEquals("一亿零三十五万零八十九", f2);
+		Assertions.assertEquals("一亿零三十五万零八十九", f2);
 	}
 
 	@Test
 	public void formatMaxTest() {
 		String f3 = NumberChineseFormatter.format(99_9999_9999_9999L, false, false);
-		Assert.assertEquals("九十九万九千九百九十九亿九千九百九十九万九千九百九十九", f3);
+		Assertions.assertEquals("九十九万九千九百九十九亿九千九百九十九万九千九百九十九", f3);
 	}
 
 	@Test
 	public void formatTraditionalTest() {
 		String f1 = NumberChineseFormatter.format(10889.72356, true);
-		Assert.assertEquals("壹万零捌佰捌拾玖点柒贰", f1);
+		Assertions.assertEquals("壹万零捌佰捌拾玖点柒贰", f1);
 		f1 = NumberChineseFormatter.format(12653, true);
-		Assert.assertEquals("壹万贰仟陆佰伍拾叁", f1);
+		Assertions.assertEquals("壹万贰仟陆佰伍拾叁", f1);
 		f1 = NumberChineseFormatter.format(215.6387, true);
-		Assert.assertEquals("贰佰壹拾伍点陆肆", f1);
+		Assertions.assertEquals("贰佰壹拾伍点陆肆", f1);
 		f1 = NumberChineseFormatter.format(1024, true);
-		Assert.assertEquals("壹仟零贰拾肆", f1);
+		Assertions.assertEquals("壹仟零贰拾肆", f1);
 		f1 = NumberChineseFormatter.format(100350089, true);
-		Assert.assertEquals("壹亿零叁拾伍万零捌拾玖", f1);
+		Assertions.assertEquals("壹亿零叁拾伍万零捌拾玖", f1);
 		f1 = NumberChineseFormatter.format(1200, true);
-		Assert.assertEquals("壹仟贰佰", f1);
+		Assertions.assertEquals("壹仟贰佰", f1);
 		f1 = NumberChineseFormatter.format(12, true);
-		Assert.assertEquals("壹拾贰", f1);
+		Assertions.assertEquals("壹拾贰", f1);
 		f1 = NumberChineseFormatter.format(0.05, true);
-		Assert.assertEquals("零点零伍", f1);
+		Assertions.assertEquals("零点零伍", f1);
 	}
 
 	@Test
 	public void digitToChineseTest() {
 		String digitToChinese = Convert.digitToChinese(12_4124_1241_2421.12);
-		Assert.assertEquals("壹拾贰万肆仟壹佰贰拾肆亿壹仟贰佰肆拾壹万贰仟肆佰贰拾壹元壹角贰分", digitToChinese);
+		Assertions.assertEquals("壹拾贰万肆仟壹佰贰拾肆亿壹仟贰佰肆拾壹万贰仟肆佰贰拾壹元壹角贰分", digitToChinese);
 
 		digitToChinese = Convert.digitToChinese(12_0000_1241_2421L);
-		Assert.assertEquals("壹拾贰万亿零壹仟贰佰肆拾壹万贰仟肆佰贰拾壹元整", digitToChinese);
+		Assertions.assertEquals("壹拾贰万亿零壹仟贰佰肆拾壹万贰仟肆佰贰拾壹元整", digitToChinese);
 
 		digitToChinese = Convert.digitToChinese(12_0000_0000_2421L);
-		Assert.assertEquals("壹拾贰万亿零贰仟肆佰贰拾壹元整", digitToChinese);
+		Assertions.assertEquals("壹拾贰万亿零贰仟肆佰贰拾壹元整", digitToChinese);
 
 		digitToChinese = Convert.digitToChinese(12_4124_1241_2421D);
-		Assert.assertEquals("壹拾贰万肆仟壹佰贰拾肆亿壹仟贰佰肆拾壹万贰仟肆佰贰拾壹元整", digitToChinese);
+		Assertions.assertEquals("壹拾贰万肆仟壹佰贰拾肆亿壹仟贰佰肆拾壹万贰仟肆佰贰拾壹元整", digitToChinese);
 
 		digitToChinese = Convert.digitToChinese(2421.02);
-		Assert.assertEquals("贰仟肆佰贰拾壹元零贰分", digitToChinese);
+		Assertions.assertEquals("贰仟肆佰贰拾壹元零贰分", digitToChinese);
 	}
 
 	@Test
 	public void digitToChineseTest2() {
 		double a = 67556.32;
 		String digitUppercase = Convert.digitToChinese(a);
-		Assert.assertEquals("陆万柒仟伍佰伍拾陆元叁角贰分", digitUppercase);
+		Assertions.assertEquals("陆万柒仟伍佰伍拾陆元叁角贰分", digitUppercase);
 
 		a = 1024.00;
 		digitUppercase = Convert.digitToChinese(a);
-		Assert.assertEquals("壹仟零贰拾肆元整", digitUppercase);
+		Assertions.assertEquals("壹仟零贰拾肆元整", digitUppercase);
 
 		double b = 1024;
 		digitUppercase = Convert.digitToChinese(b);
-		Assert.assertEquals("壹仟零贰拾肆元整", digitUppercase);
+		Assertions.assertEquals("壹仟零贰拾肆元整", digitUppercase);
 	}
 
 	@Test
 	public void digitToChineseTest3() {
 		String digitToChinese = Convert.digitToChinese(2_0000_0000.00);
-		Assert.assertEquals("贰亿元整", digitToChinese);
+		Assertions.assertEquals("贰亿元整", digitToChinese);
 		digitToChinese = Convert.digitToChinese(2_0000.00);
-		Assert.assertEquals("贰万元整", digitToChinese);
+		Assertions.assertEquals("贰万元整", digitToChinese);
 		digitToChinese = Convert.digitToChinese(2_0000_0000_0000.00);
-		Assert.assertEquals("贰万亿元整", digitToChinese);
+		Assertions.assertEquals("贰万亿元整", digitToChinese);
 	}
 
 	@Test
 	public void digitToChineseTest4() {
 		String digitToChinese = Convert.digitToChinese(400_0000.00);
-		Assert.assertEquals("肆佰万元整", digitToChinese);
+		Assertions.assertEquals("肆佰万元整", digitToChinese);
 	}
 
 	@Test
 	public void numberCharToChineseTest(){
 		String s = NumberChineseFormatter.numberCharToChinese('1', false);
-		Assert.assertEquals("一", s);
+		Assertions.assertEquals("一", s);
 		s = NumberChineseFormatter.numberCharToChinese('2', false);
-		Assert.assertEquals("二", s);
+		Assertions.assertEquals("二", s);
 		s = NumberChineseFormatter.numberCharToChinese('0', false);
-		Assert.assertEquals("零", s);
+		Assertions.assertEquals("零", s);
 
 		// 非数字字符原样返回
 		s = NumberChineseFormatter.numberCharToChinese('A', false);
-		Assert.assertEquals("A", s);
+		Assertions.assertEquals("A", s);
 	}
 
 	@Test
 	public void chineseToNumberTest(){
-		Assert.assertEquals(0, NumberChineseFormatter.chineseToNumber("零"));
-		Assert.assertEquals(102, NumberChineseFormatter.chineseToNumber("一百零二"));
-		Assert.assertEquals(112, NumberChineseFormatter.chineseToNumber("一百一十二"));
-		Assert.assertEquals(1012, NumberChineseFormatter.chineseToNumber("一千零一十二"));
-		Assert.assertEquals(1000000, NumberChineseFormatter.chineseToNumber("一百万"));
-		Assert.assertEquals(2000100112, NumberChineseFormatter.chineseToNumber("二十亿零一十万零一百一十二"));
+		Assertions.assertEquals(0, NumberChineseFormatter.chineseToNumber("零"));
+		Assertions.assertEquals(102, NumberChineseFormatter.chineseToNumber("一百零二"));
+		Assertions.assertEquals(112, NumberChineseFormatter.chineseToNumber("一百一十二"));
+		Assertions.assertEquals(1012, NumberChineseFormatter.chineseToNumber("一千零一十二"));
+		Assertions.assertEquals(1000000, NumberChineseFormatter.chineseToNumber("一百万"));
+		Assertions.assertEquals(2000100112, NumberChineseFormatter.chineseToNumber("二十亿零一十万零一百一十二"));
 	}
 
 	@Test
 	public void chineseToNumberTest2(){
-		Assert.assertEquals(120, NumberChineseFormatter.chineseToNumber("一百二"));
-		Assert.assertEquals(1200, NumberChineseFormatter.chineseToNumber("一千二"));
-		Assert.assertEquals(22000, NumberChineseFormatter.chineseToNumber("两万二"));
-		Assert.assertEquals(22003, NumberChineseFormatter.chineseToNumber("两万二零三"));
-		Assert.assertEquals(22010, NumberChineseFormatter.chineseToNumber("两万二零一十"));
+		Assertions.assertEquals(120, NumberChineseFormatter.chineseToNumber("一百二"));
+		Assertions.assertEquals(1200, NumberChineseFormatter.chineseToNumber("一千二"));
+		Assertions.assertEquals(22000, NumberChineseFormatter.chineseToNumber("两万二"));
+		Assertions.assertEquals(22003, NumberChineseFormatter.chineseToNumber("两万二零三"));
+		Assertions.assertEquals(22010, NumberChineseFormatter.chineseToNumber("两万二零一十"));
 	}
 
 	@Test
@@ -262,54 +265,58 @@ public class NumberChineseFormatterTest {
 		// issue#1726，对于单位开头的数组，默认赋予1
 		// 十二 -> 一十二
 		// 百二 -> 一百二
-		Assert.assertEquals(12, NumberChineseFormatter.chineseToNumber("十二"));
-		Assert.assertEquals(120, NumberChineseFormatter.chineseToNumber("百二"));
-		Assert.assertEquals(1300, NumberChineseFormatter.chineseToNumber("千三"));
+		Assertions.assertEquals(12, NumberChineseFormatter.chineseToNumber("十二"));
+		Assertions.assertEquals(120, NumberChineseFormatter.chineseToNumber("百二"));
+		Assertions.assertEquals(1300, NumberChineseFormatter.chineseToNumber("千三"));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void badNumberTest(){
-		// 连续数字检查
-		NumberChineseFormatter.chineseToNumber("一百一二三");
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			// 连续数字检查
+			NumberChineseFormatter.chineseToNumber("一百一二三");
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void badNumberTest2(){
-		// 非法字符
-		NumberChineseFormatter.chineseToNumber("一百你三");
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			// 非法字符
+			NumberChineseFormatter.chineseToNumber("一百你三");
+		});
 	}
 
 	@Test
 	public void singleMoneyTest(){
 		String format = NumberChineseFormatter.format(0.01, false, true);
-		Assert.assertEquals("一分", format);
+		Assertions.assertEquals("一分", format);
 		format = NumberChineseFormatter.format(0.10, false, true);
-		Assert.assertEquals("一角", format);
+		Assertions.assertEquals("一角", format);
 		format = NumberChineseFormatter.format(0.12, false, true);
-		Assert.assertEquals("一角二分", format);
+		Assertions.assertEquals("一角二分", format);
 
 		format = NumberChineseFormatter.format(1.00, false, true);
-		Assert.assertEquals("一元整", format);
+		Assertions.assertEquals("一元整", format);
 		format = NumberChineseFormatter.format(1.10, false, true);
-		Assert.assertEquals("一元一角", format);
+		Assertions.assertEquals("一元一角", format);
 		format = NumberChineseFormatter.format(1.02, false, true);
-		Assert.assertEquals("一元零二分", format);
+		Assertions.assertEquals("一元零二分", format);
 	}
 
 	@Test
 	public void singleNumberTest(){
 		String format = NumberChineseFormatter.format(0.01, false, false);
-		Assert.assertEquals("零点零一", format);
+		Assertions.assertEquals("零点零一", format);
 		format = NumberChineseFormatter.format(0.10, false, false);
-		Assert.assertEquals("零点一", format);
+		Assertions.assertEquals("零点一", format);
 		format = NumberChineseFormatter.format(0.12, false, false);
-		Assert.assertEquals("零点一二", format);
+		Assertions.assertEquals("零点一二", format);
 
 		format = NumberChineseFormatter.format(1.00, false, false);
-		Assert.assertEquals("一", format);
+		Assertions.assertEquals("一", format);
 		format = NumberChineseFormatter.format(1.10, false, false);
-		Assert.assertEquals("一点一", format);
+		Assertions.assertEquals("一点一", format);
 		format = NumberChineseFormatter.format(1.02, false, false);
-		Assert.assertEquals("一点零二", format);
+		Assertions.assertEquals("一点零二", format);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/NumberConverterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/NumberConverterTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.convert;
 
 import cn.hutool.core.convert.impl.NumberConverter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NumberConverterTest {
 
@@ -10,13 +10,13 @@ public class NumberConverterTest {
 	public void toDoubleTest(){
 		final NumberConverter numberConverter = new NumberConverter(Double.class);
 		final Number convert = numberConverter.convert("1,234.55", null);
-		Assert.assertEquals(1234.55D, convert);
+		Assertions.assertEquals(1234.55D, convert);
 	}
 
 	@Test
 	public void toIntegerTest(){
 		final NumberConverter numberConverter = new NumberConverter(Integer.class);
 		final Number convert = numberConverter.convert("1,234.55", null);
-		Assert.assertEquals(1234, convert);
+		Assertions.assertEquals(1234, convert);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/NumberWordFormatTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/NumberWordFormatTest.java
@@ -1,34 +1,34 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NumberWordFormatTest {
 
 	@Test
 	public void formatTest() {
 		String format = NumberWordFormatter.format(100.23);
-		Assert.assertEquals("ONE HUNDRED AND CENTS TWENTY THREE ONLY", format);
+		Assertions.assertEquals("ONE HUNDRED AND CENTS TWENTY THREE ONLY", format);
 
 		String format2 = NumberWordFormatter.format("2100.00");
-		Assert.assertEquals("TWO THOUSAND ONE HUNDRED AND CENTS  ONLY", format2);
+		Assertions.assertEquals("TWO THOUSAND ONE HUNDRED AND CENTS  ONLY", format2);
 	}
 
 	@Test
 	public void formatSimpleTest() {
 		String format1 = NumberWordFormatter.formatSimple(1200, false);
-		Assert.assertEquals("1.2k", format1);
+		Assertions.assertEquals("1.2k", format1);
 
 		String format2 = NumberWordFormatter.formatSimple(4384324, false);
-		Assert.assertEquals("4.38m", format2);
+		Assertions.assertEquals("4.38m", format2);
 
 		String format3 = NumberWordFormatter.formatSimple(4384324, true);
-		Assert.assertEquals("438.43w", format3);
+		Assertions.assertEquals("438.43w", format3);
 
 		String format4 = NumberWordFormatter.formatSimple(4384324);
-		Assert.assertEquals("438.43w", format4);
+		Assertions.assertEquals("438.43w", format4);
 
 		String format5 = NumberWordFormatter.formatSimple(438);
-		Assert.assertEquals("438", format5);
+		Assertions.assertEquals("438", format5);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/PrimitiveConvertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/PrimitiveConvertTest.java
@@ -1,18 +1,20 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PrimitiveConvertTest {
 
 	@Test
 	public void toIntTest(){
 		final int convert = Convert.convert(int.class, "123");
-		Assert.assertEquals(123, convert);
+		Assertions.assertEquals(123, convert);
 	}
 
-	@Test(expected = NumberFormatException.class)
+	@Test
 	public void toIntErrorTest(){
-		final int convert = Convert.convert(int.class, "aaaa");
+		Assertions.assertThrows(NumberFormatException.class, () -> {
+			Convert.convert(int.class, "aaaa");
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/StringConvertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/StringConvertTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.convert;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.TimeZone;
 
@@ -10,6 +10,6 @@ public class StringConvertTest {
 	@Test
 	public void timezoneToStrTest(){
 		final String s = Convert.toStr(TimeZone.getTimeZone("Asia/Shanghai"));
-		Assert.assertEquals("Asia/Shanghai", s);
+		Assertions.assertEquals("Asia/Shanghai", s);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/convert/TemporalAccessorConverterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/TemporalAccessorConverterTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.convert;
 
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -21,42 +21,42 @@ public class TemporalAccessorConverterTest {
 		// 通过转换获取的Instant为UTC时间
 		Instant instant = Convert.convert(Instant.class, dateStr);
 		Instant instant1 = DateUtil.parse(dateStr).toInstant();
-		Assert.assertEquals(instant1, instant);
+		Assertions.assertEquals(instant1, instant);
 	}
 
 	@Test
 	public void toLocalDateTimeTest(){
 		LocalDateTime localDateTime = Convert.convert(LocalDateTime.class, "2019-02-18");
-		Assert.assertEquals("2019-02-18T00:00", localDateTime.toString());
+		Assertions.assertEquals("2019-02-18T00:00", localDateTime.toString());
 	}
 
 	@Test
 	public void toLocalDateTest(){
 		LocalDate localDate = Convert.convert(LocalDate.class, "2019-02-18");
-		Assert.assertEquals("2019-02-18", localDate.toString());
+		Assertions.assertEquals("2019-02-18", localDate.toString());
 	}
 
 	@Test
 	public void toLocalTimeTest(){
 		LocalTime localTime = Convert.convert(LocalTime.class, "2019-02-18");
-		Assert.assertEquals("00:00", localTime.toString());
+		Assertions.assertEquals("00:00", localTime.toString());
 	}
 
 	@Test
 	public void toZonedDateTimeTest(){
 		ZonedDateTime zonedDateTime = Convert.convert(ZonedDateTime.class, "2019-02-18");
-		Assert.assertEquals("2019-02-18T00:00+08:00", zonedDateTime.toString().substring(0, 22));
+		Assertions.assertEquals("2019-02-18T00:00+08:00", zonedDateTime.toString().substring(0, 22));
 	}
 
 	@Test
 	public void toOffsetDateTimeTest(){
 		OffsetDateTime zonedDateTime = Convert.convert(OffsetDateTime.class, "2019-02-18");
-		Assert.assertEquals("2019-02-18T00:00+08:00", zonedDateTime.toString());
+		Assertions.assertEquals("2019-02-18T00:00+08:00", zonedDateTime.toString());
 	}
 
 	@Test
 	public void toOffsetTimeTest(){
 		OffsetTime offsetTime = Convert.convert(OffsetTime.class, "2019-02-18");
-		Assert.assertEquals("00:00+08:00", offsetTime.toString());
+		Assertions.assertEquals("00:00+08:00", offsetTime.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/BetweenFormatterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/BetweenFormatterTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.date;
 
 import cn.hutool.core.date.BetweenFormatter.Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BetweenFormatterTest {
 
@@ -10,26 +10,26 @@ public class BetweenFormatterTest {
 	public void formatTest(){
 		long betweenMs = DateUtil.betweenMs(DateUtil.parse("2017-01-01 22:59:59"), DateUtil.parse("2017-01-02 23:59:58"));
 		BetweenFormatter formater = new BetweenFormatter(betweenMs, Level.MILLISECOND, 1);
-		Assert.assertEquals(formater.toString(), "1天");
+		Assertions.assertEquals(formater.toString(), "1天");
 	}
 
 	@Test
 	public void formatBetweenTest(){
 		long betweenMs = DateUtil.betweenMs(DateUtil.parse("2018-07-16 11:23:19"), DateUtil.parse("2018-07-16 11:23:20"));
 		BetweenFormatter formater = new BetweenFormatter(betweenMs, Level.SECOND, 1);
-		Assert.assertEquals(formater.toString(), "1秒");
+		Assertions.assertEquals(formater.toString(), "1秒");
 	}
 
 	@Test
 	public void formatBetweenTest2(){
 		long betweenMs = DateUtil.betweenMs(DateUtil.parse("2018-07-16 12:25:23"), DateUtil.parse("2018-07-16 11:23:20"));
 		BetweenFormatter formater = new BetweenFormatter(betweenMs, Level.SECOND, 5);
-		Assert.assertEquals(formater.toString(), "1小时2分3秒");
+		Assertions.assertEquals(formater.toString(), "1小时2分3秒");
 	}
 
 	@Test
 	public void formatTest2(){
 		BetweenFormatter formater = new BetweenFormatter(584, Level.SECOND, 1);
-		Assert.assertEquals(formater.toString(), "0秒");
+		Assertions.assertEquals(formater.toString(), "0秒");
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/CalendarUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/CalendarUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Calendar;
 import java.util.Objects;
@@ -9,21 +9,23 @@ import java.util.Objects;
 public class CalendarUtilTest {
 
 	@Test
-	public void formatChineseDate(){
+	public void formatChineseDate() {
 		Calendar calendar = Objects.requireNonNull(DateUtil.parse("2018-02-24 12:13:14")).toCalendar();
 		final String chineseDate = CalendarUtil.formatChineseDate(calendar, false);
-		Assert.assertEquals("二〇一八年二月二十四日", chineseDate);
+		Assertions.assertEquals("二〇一八年二月二十四日", chineseDate);
 		final String chineseDateTime = CalendarUtil.formatChineseDate(calendar, true);
-		Assert.assertEquals("二〇一八年二月二十四日十二时十三分十四秒", chineseDateTime);
+		Assertions.assertEquals("二〇一八年二月二十四日十二时十三分十四秒", chineseDateTime);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void parseTest(){
-		final Calendar calendar = CalendarUtil.parse("2021-09-27 00:00:112323", false,
-				DatePattern.NORM_DATETIME_FORMAT);
+	@Test
+	public void parseTest() {
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			final Calendar calendar = CalendarUtil.parse("2021-09-27 00:00:112323", false,
+					DatePattern.NORM_DATETIME_FORMAT);
 
-		// https://github.com/dromara/hutool/issues/1849
-		// 在使用严格模式时，秒不正确，抛出异常
-		DateUtil.date(calendar);
+			// https://github.com/dromara/hutool/issues/1849
+			// 在使用严格模式时，秒不正确，抛出异常
+			DateUtil.date(calendar);
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/ChineseDateTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/ChineseDateTest.java
@@ -1,71 +1,71 @@
 package cn.hutool.core.date;
 
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ChineseDateTest {
 
 	@Test
 	public void chineseDateTest() {
 		ChineseDate date = new ChineseDate(DateUtil.parseDate("2020-01-25"));
-		Assert.assertEquals("2020-01-25 00:00:00", date.getGregorianDate().toString());
-		Assert.assertEquals(2020, date.getChineseYear());
+		Assertions.assertEquals("2020-01-25 00:00:00", date.getGregorianDate().toString());
+		Assertions.assertEquals(2020, date.getChineseYear());
 
-		Assert.assertEquals(1, date.getMonth());
-		Assert.assertEquals("一月", date.getChineseMonth());
-		Assert.assertEquals("正月", date.getChineseMonthName());
+		Assertions.assertEquals(1, date.getMonth());
+		Assertions.assertEquals("一月", date.getChineseMonth());
+		Assertions.assertEquals("正月", date.getChineseMonthName());
 
 
-		Assert.assertEquals(1, date.getDay());
-		Assert.assertEquals("初一", date.getChineseDay());
+		Assertions.assertEquals(1, date.getDay());
+		Assertions.assertEquals("初一", date.getChineseDay());
 
-		Assert.assertEquals("庚子", date.getCyclical());
-		Assert.assertEquals("鼠", date.getChineseZodiac());
-		Assert.assertEquals("春节", date.getFestivals());
-		Assert.assertEquals("庚子鼠年 正月初一", date.toString());
+		Assertions.assertEquals("庚子", date.getCyclical());
+		Assertions.assertEquals("鼠", date.getChineseZodiac());
+		Assertions.assertEquals("春节", date.getFestivals());
+		Assertions.assertEquals("庚子鼠年 正月初一", date.toString());
 
 		date = new ChineseDate(DateUtil.parseDate("2020-01-14"));
-		Assert.assertEquals("己亥猪年 腊月二十", date.toString());
+		Assertions.assertEquals("己亥猪年 腊月二十", date.toString());
 		date = new ChineseDate(DateUtil.parseDate("2020-01-24"));
-		Assert.assertEquals("己亥猪年 腊月三十", date.toString());
+		Assertions.assertEquals("己亥猪年 腊月三十", date.toString());
 
-		Assert.assertEquals("2019-12-30", date.toStringNormal());
+		Assertions.assertEquals("2019-12-30", date.toStringNormal());
 	}
 
 	@Test
 	public void toStringNormalTest(){
 		ChineseDate date = new ChineseDate(DateUtil.parseDate("2020-03-1"));
-		Assert.assertEquals("2020-02-08", date.toStringNormal());
+		Assertions.assertEquals("2020-02-08", date.toStringNormal());
 	}
 
 	@Test
 	public void parseTest(){
 		ChineseDate date = new ChineseDate(DateUtil.parseDate("1996-07-14"));
-		Assert.assertEquals("丙子鼠年 五月廿九", date.toString());
+		Assertions.assertEquals("丙子鼠年 五月廿九", date.toString());
 
 		date = new ChineseDate(DateUtil.parseDate("1996-07-15"));
-		Assert.assertEquals("丙子鼠年 五月三十", date.toString());
+		Assertions.assertEquals("丙子鼠年 五月三十", date.toString());
 	}
 
 	@Test
 	public void getChineseMonthTest(){
 		ChineseDate chineseDate = new ChineseDate(2020,6,15);
-		Assert.assertEquals("2020-08-04 00:00:00", chineseDate.getGregorianDate().toString());
-		Assert.assertEquals("六月", chineseDate.getChineseMonth());
+		Assertions.assertEquals("2020-08-04 00:00:00", chineseDate.getGregorianDate().toString());
+		Assertions.assertEquals("六月", chineseDate.getChineseMonth());
 
 		chineseDate = new ChineseDate(2020,4,15);
-		Assert.assertEquals("四月", chineseDate.getChineseMonth());
+		Assertions.assertEquals("四月", chineseDate.getChineseMonth());
 
 		chineseDate = new ChineseDate(2020,5,15);
-		Assert.assertEquals("闰四月", chineseDate.getChineseMonth());
+		Assertions.assertEquals("闰四月", chineseDate.getChineseMonth());
 	}
 
 	@Test
 	public void getFestivalsTest(){
 		// issue#I1XHSF@Gitee，2023-01-20对应农历腊月29，非除夕
 		ChineseDate chineseDate = new ChineseDate(DateUtil.parseDate("2023-01-20"));
-		Assert.assertTrue(StrUtil.isEmpty(chineseDate.getFestivals()));
+		Assertions.assertTrue(StrUtil.isEmpty(chineseDate.getFestivals()));
 	}
 
 	@Test
@@ -73,28 +73,28 @@ public class ChineseDateTest {
 		// 修复这两个日期不正确的问题
 		// 问题出在计算与1900-01-31相差天数的问题上了，相差天数非整天
 		ChineseDate date = new ChineseDate(DateUtil.parseDate("1991-09-14"));
-		Assert.assertEquals("辛未羊年 八月初七", date.toString());
+		Assertions.assertEquals("辛未羊年 八月初七", date.toString());
 		date = new ChineseDate(DateUtil.parseDate("1991-09-15"));
-		Assert.assertEquals("辛未羊年 八月初八", date.toString());
+		Assertions.assertEquals("辛未羊年 八月初八", date.toString());
 	}
 
 	@Test
 	public void dateTest2(){
 		ChineseDate date = new ChineseDate(DateUtil.parse("2020-10-19"));
-		Assert.assertEquals("庚子鼠年 九月初三", date.toString());
+		Assertions.assertEquals("庚子鼠年 九月初三", date.toString());
 	}
 
 	@Test
 	public void dateTest2_2(){
 		ChineseDate date = new ChineseDate(DateUtil.parse("2020-07-20"));
-		Assert.assertEquals("庚子鼠年 五月三十", date.toString());
+		Assertions.assertEquals("庚子鼠年 五月三十", date.toString());
 	}
 
 	@Test
 	public void dateTest3(){
 		// 初一，offset为0测试
 		ChineseDate date = new ChineseDate(DateUtil.parse("2099-03-22"));
-		Assert.assertEquals("己未羊年 闰二月初一", date.toString());
+		Assertions.assertEquals("己未羊年 闰二月初一", date.toString());
 	}
 
 	@Test
@@ -102,7 +102,7 @@ public class ChineseDateTest {
 		final ChineseDate c1 = new ChineseDate(DateUtil.parse("2028-05-28"));
 		final ChineseDate c2 = new ChineseDate(DateUtil.parse("2028-06-27"));
 
-		Assert.assertEquals("戊申猴年 五月初五", c1.toString());
-		Assert.assertEquals("戊申猴年 闰五月初五", c2.toString());
+		Assertions.assertEquals("戊申猴年 五月初五", c1.toString());
+		Assertions.assertEquals("戊申猴年 闰五月初五", c2.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateBetweenTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateBetweenTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.date;
 
 import cn.hutool.core.date.BetweenFormatter.Level;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -14,18 +14,18 @@ public class DateBetweenTest {
 		Date start = DateUtil.parse("2017-02-01 12:23:46");
 		Date end = DateUtil.parse("2018-02-01 12:23:46");
 		long betweenYear = new DateBetween(start, end).betweenYear(false);
-		Assert.assertEquals(1, betweenYear);
+		Assertions.assertEquals(1, betweenYear);
 
 		Date start1 = DateUtil.parse("2017-02-01 12:23:46");
 		Date end1 = DateUtil.parse("2018-03-01 12:23:46");
 		long betweenYear1 = new DateBetween(start1, end1).betweenYear(false);
-		Assert.assertEquals(1, betweenYear1);
+		Assertions.assertEquals(1, betweenYear1);
 
 		// 不足1年
 		Date start2 = DateUtil.parse("2017-02-01 12:23:46");
 		Date end2 = DateUtil.parse("2018-02-01 11:23:46");
 		long betweenYear2 = new DateBetween(start2, end2).betweenYear(false);
-		Assert.assertEquals(0, betweenYear2);
+		Assertions.assertEquals(0, betweenYear2);
 	}
 
 	@Test
@@ -33,7 +33,7 @@ public class DateBetweenTest {
 		Date start = DateUtil.parse("2000-02-29");
 		Date end = DateUtil.parse("2018-02-28");
 		long betweenYear = new DateBetween(start, end).betweenYear(false);
-		Assert.assertEquals(18, betweenYear);
+		Assertions.assertEquals(18, betweenYear);
 	}
 
 	@Test
@@ -41,26 +41,26 @@ public class DateBetweenTest {
 		Date start = DateUtil.parse("2017-02-01 12:23:46");
 		Date end = DateUtil.parse("2018-02-01 12:23:46");
 		long betweenMonth = new DateBetween(start, end).betweenMonth(false);
-		Assert.assertEquals(12, betweenMonth);
+		Assertions.assertEquals(12, betweenMonth);
 
 		Date start1 = DateUtil.parse("2017-02-01 12:23:46");
 		Date end1 = DateUtil.parse("2018-03-01 12:23:46");
 		long betweenMonth1 = new DateBetween(start1, end1).betweenMonth(false);
-		Assert.assertEquals(13, betweenMonth1);
+		Assertions.assertEquals(13, betweenMonth1);
 
 		// 不足
 		Date start2 = DateUtil.parse("2017-02-01 12:23:46");
 		Date end2 = DateUtil.parse("2018-02-01 11:23:46");
 		long betweenMonth2 = new DateBetween(start2, end2).betweenMonth(false);
-		Assert.assertEquals(11, betweenMonth2);
+		Assertions.assertEquals(11, betweenMonth2);
 	}
-	
+
 	@Test
 	public void betweenMinuteTest() {
 		Date date1 = DateUtil.parse("2017-03-01 20:33:23");
 		Date date2 = DateUtil.parse("2017-03-01 23:33:23");
 		String formatBetween = DateUtil.formatBetween(date1, date2, Level.SECOND);
-		Assert.assertEquals("3小时", formatBetween);
+		Assertions.assertEquals("3小时", formatBetween);
 	}
 
 	@Test
@@ -73,6 +73,6 @@ public class DateBetweenTest {
 				LocalDateTimeUtil.parse("2020-11-21", "yyy-MM-dd"),
 				LocalDateTimeUtil.parse("2020-11-23", "yyy-MM-dd"),
 				ChronoUnit.WEEKS);
-		Assert.assertEquals(betweenWeek, betweenWeek2);
+		Assertions.assertEquals(betweenWeek, betweenWeek2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateFieldTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateFieldTest.java
@@ -1,15 +1,15 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DateFieldTest {
-	
+
 	@Test
 	public void ofTest() {
 		DateField field = DateField.of(11);
-		Assert.assertEquals(DateField.HOUR_OF_DAY, field);
+		Assertions.assertEquals(DateField.HOUR_OF_DAY, field);
 		field = DateField.of(12);
-		Assert.assertEquals(DateField.MINUTE, field);
+		Assertions.assertEquals(DateField.MINUTE, field);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateModifierTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateModifierTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.date;
 
 import java.util.Date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DateModifierTest {
 
@@ -14,49 +14,49 @@ public class DateModifierTest {
 
 		// 毫秒
 		DateTime begin = DateUtil.truncate(date, DateField.MILLISECOND);
-		Assert.assertEquals(dateStr, begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals(dateStr, begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 秒
 		begin = DateUtil.truncate(date, DateField.SECOND);
-		Assert.assertEquals("2017-03-01 22:33:23.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:33:23.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 分
 		begin = DateUtil.truncate(date, DateField.MINUTE);
-		Assert.assertEquals("2017-03-01 22:33:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:33:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 小时
 		begin = DateUtil.truncate(date, DateField.HOUR);
-		Assert.assertEquals("2017-03-01 22:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.truncate(date, DateField.HOUR_OF_DAY);
-		Assert.assertEquals("2017-03-01 22:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 上下午，原始日期是22点，上下午的起始就是12点
 		begin = DateUtil.truncate(date, DateField.AM_PM);
-		Assert.assertEquals("2017-03-01 12:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 12:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 天，day of xxx按照day处理
 		begin = DateUtil.truncate(date, DateField.DAY_OF_WEEK_IN_MONTH);
-		Assert.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.truncate(date, DateField.DAY_OF_WEEK);
-		Assert.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.truncate(date, DateField.DAY_OF_MONTH);
-		Assert.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 星期
 		begin = DateUtil.truncate(date, DateField.WEEK_OF_MONTH);
-		Assert.assertEquals("2017-02-27 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-02-27 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.truncate(date, DateField.WEEK_OF_YEAR);
-		Assert.assertEquals("2017-02-27 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-02-27 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 月
 		begin = DateUtil.truncate(date, DateField.MONTH);
-		Assert.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
-		
+		Assertions.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+
 		// 年
 		begin = DateUtil.truncate(date, DateField.YEAR);
-		Assert.assertEquals("2017-01-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-01-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 	}
-	
+
 	@Test
 	public void truncateDayOfWeekInMonthTest() {
 		String dateStr = "2017-03-01 22:33:23.123";
@@ -64,7 +64,7 @@ public class DateModifierTest {
 
 		// 天，day of xxx按照day处理
 		DateTime begin = DateUtil.truncate(date, DateField.DAY_OF_WEEK_IN_MONTH);
-		Assert.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 00:00:00.000", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 	}
 
 	@Test
@@ -74,46 +74,46 @@ public class DateModifierTest {
 
 		// 毫秒
 		DateTime begin = DateUtil.ceiling(date, DateField.MILLISECOND);
-		Assert.assertEquals(dateStr, begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals(dateStr, begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 秒
 		begin = DateUtil.ceiling(date, DateField.SECOND);
-		Assert.assertEquals("2017-03-01 22:33:23.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:33:23.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 分
 		begin = DateUtil.ceiling(date, DateField.MINUTE);
-		Assert.assertEquals("2017-03-01 22:33:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:33:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 小时
 		begin = DateUtil.ceiling(date, DateField.HOUR);
-		Assert.assertEquals("2017-03-01 22:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.ceiling(date, DateField.HOUR_OF_DAY);
-		Assert.assertEquals("2017-03-01 22:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 22:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 上下午，原始日期是22点，上下午的结束就是23点
 		begin = DateUtil.ceiling(date, DateField.AM_PM);
-		Assert.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 天，day of xxx按照day处理
 		begin = DateUtil.ceiling(date, DateField.DAY_OF_WEEK_IN_MONTH);
-		Assert.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.ceiling(date, DateField.DAY_OF_WEEK);
-		Assert.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.ceiling(date, DateField.DAY_OF_MONTH);
-		Assert.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-01 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 星期
 		begin = DateUtil.ceiling(date, DateField.WEEK_OF_MONTH);
-		Assert.assertEquals("2017-03-05 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-05 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 		begin = DateUtil.ceiling(date, DateField.WEEK_OF_YEAR);
-		Assert.assertEquals("2017-03-05 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-03-05 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		// 月
 		begin = DateUtil.ceiling(date, DateField.MONTH);
-		Assert.assertEquals("2017-03-31 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
-		
+		Assertions.assertEquals("2017-03-31 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+
 		// 年
 		begin = DateUtil.ceiling(date, DateField.YEAR);
-		Assert.assertEquals("2017-12-31 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2017-12-31 23:59:59.999", begin.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateTimeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateTimeTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * DateTime单元测试
@@ -17,19 +17,19 @@ public class DateTimeTest {
 
 		// 年
 		int year = dateTime.year();
-		Assert.assertEquals(2017, year);
+		Assertions.assertEquals(2017, year);
 
 		// 季度（非季节）
 		Quarter season = dateTime.quarterEnum();
-		Assert.assertEquals(Quarter.Q1, season);
+		Assertions.assertEquals(Quarter.Q1, season);
 
 		// 月份
 		Month month = dateTime.monthEnum();
-		Assert.assertEquals(Month.JANUARY, month);
+		Assertions.assertEquals(Month.JANUARY, month);
 
 		// 日
 		int day = dateTime.dayOfMonth();
-		Assert.assertEquals(5, day);
+		Assertions.assertEquals(5, day);
 	}
 
 	@Test
@@ -38,48 +38,48 @@ public class DateTimeTest {
 
 		// 年
 		int year = dateTime.year();
-		Assert.assertEquals(2017, year);
+		Assertions.assertEquals(2017, year);
 
 		// 季度（非季节）
 		Quarter season = dateTime.quarterEnum();
-		Assert.assertEquals(Quarter.Q1, season);
+		Assertions.assertEquals(Quarter.Q1, season);
 
 		// 月份
 		Month month = dateTime.monthEnum();
-		Assert.assertEquals(Month.JANUARY, month);
+		Assertions.assertEquals(Month.JANUARY, month);
 
 		// 日
 		int day = dateTime.dayOfMonth();
-		Assert.assertEquals(5, day);
+		Assertions.assertEquals(5, day);
 	}
 
 	@Test
 	public void quarterTest() {
 		DateTime dateTime = new DateTime("2017-01-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		Quarter quarter = dateTime.quarterEnum();
-		Assert.assertEquals(Quarter.Q1, quarter);
+		Assertions.assertEquals(Quarter.Q1, quarter);
 
 		dateTime = new DateTime("2017-04-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		quarter = dateTime.quarterEnum();
-		Assert.assertEquals(Quarter.Q2, quarter);
+		Assertions.assertEquals(Quarter.Q2, quarter);
 
 		dateTime = new DateTime("2017-07-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		quarter = dateTime.quarterEnum();
-		Assert.assertEquals(Quarter.Q3, quarter);
+		Assertions.assertEquals(Quarter.Q3, quarter);
 
 		dateTime = new DateTime("2017-10-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 		quarter = dateTime.quarterEnum();
-		Assert.assertEquals(Quarter.Q4, quarter);
+		Assertions.assertEquals(Quarter.Q4, quarter);
 
 		// 精确到毫秒
 		DateTime beginTime = new DateTime("2017-10-01 00:00:00.000", DatePattern.NORM_DATETIME_MS_FORMAT);
 		dateTime = DateUtil.beginOfQuarter(dateTime);
-		Assert.assertEquals(beginTime, dateTime);
+		Assertions.assertEquals(beginTime, dateTime);
 
 		// 精确到毫秒
 		DateTime endTime = new DateTime("2017-12-31 23:59:59.999", DatePattern.NORM_DATETIME_MS_FORMAT);
 		dateTime = DateUtil.endOfQuarter(dateTime);
-		Assert.assertEquals(endTime, dateTime);
+		Assertions.assertEquals(endTime, dateTime);
 	}
 
 	@Test
@@ -88,21 +88,21 @@ public class DateTimeTest {
 
 		// 默认情况下DateTime为可变对象
 		DateTime offsite = dateTime.offset(DateField.YEAR, 0);
-		Assert.assertSame(offsite, dateTime);
+		Assertions.assertSame(offsite, dateTime);
 
 		// 设置为不可变对象后变动将返回新对象
 		dateTime.setMutable(false);
 		offsite = dateTime.offset(DateField.YEAR, 0);
-		Assert.assertNotSame(offsite, dateTime);
+		Assertions.assertNotSame(offsite, dateTime);
 	}
 
 	@Test
 	public void toStringTest() {
 		DateTime dateTime = new DateTime("2017-01-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
-		Assert.assertEquals("2017-01-05 12:34:23", dateTime.toString());
+		Assertions.assertEquals("2017-01-05 12:34:23", dateTime.toString());
 
 		String dateStr = dateTime.toString("yyyy/MM/dd");
-		Assert.assertEquals("2017/01/05", dateStr);
+		Assertions.assertEquals("2017/01/05", dateStr);
 	}
 
 	@Test
@@ -110,34 +110,36 @@ public class DateTimeTest {
 		DateTime dateTime = new DateTime("2017-01-05 12:34:23", DatePattern.NORM_DATETIME_FORMAT);
 
 		String dateStr = dateTime.toString(DatePattern.UTC_WITH_ZONE_OFFSET_PATTERN);
-		Assert.assertEquals("2017-01-05T12:34:23+0800", dateStr);
+		Assertions.assertEquals("2017-01-05T12:34:23+0800", dateStr);
 
 		dateStr = dateTime.toString(DatePattern.UTC_WITH_XXX_OFFSET_PATTERN);
-		Assert.assertEquals("2017-01-05T12:34:23+08:00", dateStr);
+		Assertions.assertEquals("2017-01-05T12:34:23+08:00", dateStr);
 	}
 
 	@Test
 	public void monthTest() {
 		//noinspection ConstantConditions
 		int month = DateUtil.parse("2017-07-01").month();
-		Assert.assertEquals(6, month);
+		Assertions.assertEquals(6, month);
 	}
 
 	@Test
 	public void weekOfYearTest() {
 		DateTime date = DateUtil.parse("2016-12-27");
 		//noinspection ConstantConditions
-		Assert.assertEquals(2016, date.year());
+		Assertions.assertEquals(2016, date.year());
 		//跨年的周返回的总是1
-		Assert.assertEquals(1, date.weekOfYear());
+		Assertions.assertEquals(1, date.weekOfYear());
 	}
 
 	/**
 	 * 严格模式下，不允许非常规的数字，如秒部分最多59，99则报错
 	 */
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void ofTest(){
-		String a = "2021-09-27 00:00:99";
-		new DateTime(a, DatePattern.NORM_DATETIME_FORMAT, false);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			String a = "2021-09-27 00:00:99";
+			new DateTime(a, DatePattern.NORM_DATETIME_FORMAT, false);
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
@@ -5,8 +5,8 @@ import cn.hutool.core.date.BetweenFormatter.Level;
 import cn.hutool.core.date.format.FastDateFormat;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.RandomUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -40,20 +40,20 @@ public class DateUtilTest {
 	public void nowTest() {
 		// 当前时间
 		Date date = DateUtil.date();
-		Assert.assertNotNull(date);
+		Assertions.assertNotNull(date);
 		// 当前时间
 		Date date2 = DateUtil.date(Calendar.getInstance());
-		Assert.assertNotNull(date2);
+		Assertions.assertNotNull(date2);
 		// 当前时间
 		Date date3 = DateUtil.date(System.currentTimeMillis());
-		Assert.assertNotNull(date3);
+		Assertions.assertNotNull(date3);
 
 		// 当前日期字符串，格式：yyyy-MM-dd HH:mm:ss
 		String now = DateUtil.now();
-		Assert.assertNotNull(now);
+		Assertions.assertNotNull(now);
 		// 当前日期字符串，格式：yyyy-MM-dd
 		String today = DateUtil.today();
-		Assert.assertNotNull(today);
+		Assertions.assertNotNull(today);
 	}
 
 	@Test
@@ -62,15 +62,15 @@ public class DateUtilTest {
 		Date date = DateUtil.parse(dateStr);
 
 		String format = DateUtil.format(date, "yyyy/MM/dd");
-		Assert.assertEquals("2017/03/01", format);
+		Assertions.assertEquals("2017/03/01", format);
 
 		// 常用格式的格式化
 		String formatDate = DateUtil.formatDate(date);
-		Assert.assertEquals("2017-03-01", formatDate);
+		Assertions.assertEquals("2017-03-01", formatDate);
 		String formatDateTime = DateUtil.formatDateTime(date);
-		Assert.assertEquals("2017-03-01 00:00:00", formatDateTime);
+		Assertions.assertEquals("2017-03-01 00:00:00", formatDateTime);
 		String formatTime = DateUtil.formatTime(date);
-		Assert.assertEquals("00:00:00", formatTime);
+		Assertions.assertEquals("00:00:00", formatTime);
 	}
 
 	@Test
@@ -79,10 +79,10 @@ public class DateUtilTest {
 		Date date = DateUtil.parse(dateStr);
 
 		String format = DateUtil.format(date, "#sss");
-		Assert.assertEquals("1488297600", format);
+		Assertions.assertEquals("1488297600", format);
 
 		final DateTime parse = DateUtil.parse(format, "#sss");
-		Assert.assertEquals(date, parse);
+		Assertions.assertEquals(date, parse);
 	}
 
 	@Test
@@ -91,10 +91,10 @@ public class DateUtilTest {
 		Date date = DateUtil.parse(dateStr);
 
 		String format = DateUtil.format(date, "#SSS");
-		Assert.assertEquals("1488297600000", format);
+		Assertions.assertEquals("1488297600000", format);
 
 		final DateTime parse = DateUtil.parse(format, "#SSS");
-		Assert.assertEquals(date, parse);
+		Assertions.assertEquals(date, parse);
 	}
 
 	@Test
@@ -104,16 +104,16 @@ public class DateUtilTest {
 
 		// 一天的开始
 		Date beginOfDay = DateUtil.beginOfDay(date);
-		Assert.assertEquals("2017-03-01 00:00:00", beginOfDay.toString());
+		Assertions.assertEquals("2017-03-01 00:00:00", beginOfDay.toString());
 		// 一天的结束
 		Date endOfDay = DateUtil.endOfDay(date);
-		Assert.assertEquals("2017-03-01 23:59:59", endOfDay.toString());
+		Assertions.assertEquals("2017-03-01 23:59:59", endOfDay.toString());
 	}
 
 	@Test
 	public void endOfDayTest() {
 		final DateTime parse = DateUtil.parse("2020-05-31 00:00:00");
-		Assert.assertEquals("2020-05-31 23:59:59", DateUtil.endOfDay(parse).toString());
+		Assertions.assertEquals("2020-05-31 23:59:59", DateUtil.endOfDay(parse).toString());
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class DateUtilTest {
 		String dateStr2 = "2020-02-29 12:59:34";
 		Date date2 = DateUtil.parse(dateStr2);
 		final DateTime dateTime = DateUtil.truncate(date2, DateField.MINUTE);
-		Assert.assertEquals("2020-02-29 12:59:00", dateTime.toString());
+		Assertions.assertEquals("2020-02-29 12:59:00", dateTime.toString());
 	}
 
 	@Test
@@ -131,10 +131,10 @@ public class DateUtilTest {
 
 
 		DateTime dateTime = DateUtil.ceiling(date2, DateField.MINUTE);
-		Assert.assertEquals("2020-02-29 12:59:59.999", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2020-02-29 12:59:59.999", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		dateTime = DateUtil.ceiling(date2, DateField.MINUTE, true);
-		Assert.assertEquals("2020-02-29 12:59:59.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2020-02-29 12:59:59.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 	}
 
 	@Test
@@ -144,10 +144,10 @@ public class DateUtilTest {
 
 
 		DateTime dateTime = DateUtil.ceiling(date2, DateField.DAY_OF_MONTH);
-		Assert.assertEquals("2020-02-29 23:59:59.999", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2020-02-29 23:59:59.999", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		dateTime = DateUtil.ceiling(date2, DateField.DAY_OF_MONTH, true);
-		Assert.assertEquals("2020-02-29 23:59:59.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertEquals("2020-02-29 23:59:59.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 	}
 
 	@Test
@@ -158,18 +158,18 @@ public class DateUtilTest {
 
 		// 一周的开始
 		Date beginOfWeek = DateUtil.beginOfWeek(date);
-		Assert.assertEquals("2017-02-27 00:00:00", beginOfWeek.toString());
+		Assertions.assertEquals("2017-02-27 00:00:00", beginOfWeek.toString());
 		// 一周的结束
 		Date endOfWeek = DateUtil.endOfWeek(date);
-		Assert.assertEquals("2017-03-05 23:59:59", endOfWeek.toString());
+		Assertions.assertEquals("2017-03-05 23:59:59", endOfWeek.toString());
 
 		Calendar calendar = DateUtil.calendar(date);
 		// 一周的开始
 		Calendar begin = DateUtil.beginOfWeek(calendar);
-		Assert.assertEquals("2017-02-27 00:00:00", DateUtil.date(begin).toString());
+		Assertions.assertEquals("2017-02-27 00:00:00", DateUtil.date(begin).toString());
 		// 一周的结束
 		Calendar end = DateUtil.endOfWeek(calendar);
-		Assert.assertEquals("2017-03-05 23:59:59", DateUtil.date(end).toString());
+		Assertions.assertEquals("2017-03-05 23:59:59", DateUtil.date(end).toString());
 	}
 
 	@Test
@@ -178,11 +178,11 @@ public class DateUtilTest {
 		DateTime date = DateUtil.parseDate(beginStr);
 		Calendar calendar = date.toCalendar();
 		final Calendar begin = DateUtil.beginOfWeek(calendar, false);
-		Assert.assertEquals("2020-03-08 00:00:00", DateUtil.date(begin).toString());
+		Assertions.assertEquals("2020-03-08 00:00:00", DateUtil.date(begin).toString());
 
 		Calendar calendar2 = date.toCalendar();
 		final Calendar end = DateUtil.endOfWeek(calendar2, false);
-		Assert.assertEquals("2020-03-14 23:59:59", DateUtil.date(end).toString());
+		Assertions.assertEquals("2020-03-14 23:59:59", DateUtil.date(end).toString());
 	}
 
 	@Test
@@ -191,19 +191,19 @@ public class DateUtilTest {
 		Date date = DateUtil.parse(dateStr);
 
 		Date newDate = DateUtil.offset(date, DateField.DAY_OF_MONTH, 2);
-		Assert.assertEquals("2017-03-03 22:33:23", newDate.toString());
+		Assertions.assertEquals("2017-03-03 22:33:23", newDate.toString());
 
 		// 偏移天
 		DateTime newDate2 = DateUtil.offsetDay(date, 3);
-		Assert.assertEquals("2017-03-04 22:33:23", newDate2.toString());
+		Assertions.assertEquals("2017-03-04 22:33:23", newDate2.toString());
 
 		// 偏移小时
 		DateTime newDate3 = DateUtil.offsetHour(date, -3);
-		Assert.assertEquals("2017-03-01 19:33:23", newDate3.toString());
+		Assertions.assertEquals("2017-03-01 19:33:23", newDate3.toString());
 
 		// 偏移月
 		DateTime offsetMonth = DateUtil.offsetMonth(date, -1);
-		Assert.assertEquals("2017-02-01 22:33:23", offsetMonth.toString());
+		Assertions.assertEquals("2017-02-01 22:33:23", offsetMonth.toString());
 	}
 
 	@Test
@@ -213,10 +213,10 @@ public class DateUtilTest {
 		for (int i = 0; i < 4; i++) {
 			list.add(DateUtil.offsetMonth(st, i));
 		}
-		Assert.assertEquals("2018-05-31 00:00:00", list.get(0).toString());
-		Assert.assertEquals("2018-06-30 00:00:00", list.get(1).toString());
-		Assert.assertEquals("2018-07-31 00:00:00", list.get(2).toString());
-		Assert.assertEquals("2018-08-31 00:00:00", list.get(3).toString());
+		Assertions.assertEquals("2018-05-31 00:00:00", list.get(0).toString());
+		Assertions.assertEquals("2018-06-30 00:00:00", list.get(1).toString());
+		Assertions.assertEquals("2018-07-31 00:00:00", list.get(2).toString());
+		Assertions.assertEquals("2018-08-31 00:00:00", list.get(3).toString());
 	}
 
 	@Test
@@ -229,66 +229,66 @@ public class DateUtilTest {
 
 		// 相差月
 		long betweenMonth = DateUtil.betweenMonth(date1, date2, false);
-		Assert.assertEquals(1, betweenMonth);// 相差一个月
+		Assertions.assertEquals(1, betweenMonth);// 相差一个月
 		// 反向
 		betweenMonth = DateUtil.betweenMonth(date2, date1, false);
-		Assert.assertEquals(1, betweenMonth);// 相差一个月
+		Assertions.assertEquals(1, betweenMonth);// 相差一个月
 
 		// 相差天
 		long betweenDay = DateUtil.between(date1, date2, DateUnit.DAY);
-		Assert.assertEquals(31, betweenDay);// 相差一个月，31天
+		Assertions.assertEquals(31, betweenDay);// 相差一个月，31天
 		// 反向
 		betweenDay = DateUtil.between(date2, date1, DateUnit.DAY);
-		Assert.assertEquals(31, betweenDay);// 相差一个月，31天
+		Assertions.assertEquals(31, betweenDay);// 相差一个月，31天
 
 		// 相差小时
 		long betweenHour = DateUtil.between(date1, date2, DateUnit.HOUR);
-		Assert.assertEquals(745, betweenHour);
+		Assertions.assertEquals(745, betweenHour);
 		// 反向
 		betweenHour = DateUtil.between(date2, date1, DateUnit.HOUR);
-		Assert.assertEquals(745, betweenHour);
+		Assertions.assertEquals(745, betweenHour);
 
 		// 相差分
 		long betweenMinute = DateUtil.between(date1, date2, DateUnit.MINUTE);
-		Assert.assertEquals(44721, betweenMinute);
+		Assertions.assertEquals(44721, betweenMinute);
 		// 反向
 		betweenMinute = DateUtil.between(date2, date1, DateUnit.MINUTE);
-		Assert.assertEquals(44721, betweenMinute);
+		Assertions.assertEquals(44721, betweenMinute);
 
 		// 相差秒
 		long betweenSecond = DateUtil.between(date1, date2, DateUnit.SECOND);
-		Assert.assertEquals(2683311, betweenSecond);
+		Assertions.assertEquals(2683311, betweenSecond);
 		// 反向
 		betweenSecond = DateUtil.between(date2, date1, DateUnit.SECOND);
-		Assert.assertEquals(2683311, betweenSecond);
+		Assertions.assertEquals(2683311, betweenSecond);
 
 		// 相差秒
 		long betweenMS = DateUtil.between(date1, date2, DateUnit.MS);
-		Assert.assertEquals(2683311000L, betweenMS);
+		Assertions.assertEquals(2683311000L, betweenMS);
 		// 反向
 		betweenMS = DateUtil.between(date2, date1, DateUnit.MS);
-		Assert.assertEquals(2683311000L, betweenMS);
+		Assertions.assertEquals(2683311000L, betweenMS);
 	}
 
 	@Test
 	public void betweenTest2() {
 		long between = DateUtil.between(DateUtil.parse("2019-05-06 02:15:00"), DateUtil.parse("2019-05-06 02:20:00"), DateUnit.HOUR);
-		Assert.assertEquals(0, between);
+		Assertions.assertEquals(0, between);
 	}
 
 	@Test
 	public void formatChineseDateTest() {
 		String formatChineseDate = DateUtil.formatChineseDate(DateUtil.parse("2018-02-24"), true, false);
-		Assert.assertEquals("二〇一八年二月二十四日", formatChineseDate);
+		Assertions.assertEquals("二〇一八年二月二十四日", formatChineseDate);
 
 		formatChineseDate = DateUtil.formatChineseDate(DateUtil.parse("2018-02-14"), true, false);
-		Assert.assertEquals("二〇一八年二月十四日", formatChineseDate);
+		Assertions.assertEquals("二〇一八年二月十四日", formatChineseDate);
 	}
 
 	@Test
 	public void formatChineseDateTimeTest() {
 		String formatChineseDateTime = DateUtil.formatChineseDate(DateUtil.parse("2018-02-24 12:13:14"), true, true);
-		Assert.assertEquals("二〇一八年二月二十四日十二时十三分十四秒", formatChineseDateTime);
+		Assertions.assertEquals("二〇一八年二月二十四日十二时十三分十四秒", formatChineseDateTime);
 	}
 
 	@Test
@@ -301,7 +301,7 @@ public class DateUtilTest {
 
 		long between = DateUtil.between(date1, date2, DateUnit.MS);
 		String formatBetween = DateUtil.formatBetween(between, Level.MINUTE);
-		Assert.assertEquals("31天1小时21分", formatBetween);
+		Assertions.assertEquals("31天1小时21分", formatBetween);
 	}
 
 	@Test
@@ -321,46 +321,46 @@ public class DateUtilTest {
 	public void currentTest() {
 		long current = DateUtil.current();
 		String currentStr = String.valueOf(current);
-		Assert.assertEquals(13, currentStr.length());
+		Assertions.assertEquals(13, currentStr.length());
 
 		long currentNano = DateUtil.current();
 		String currentNanoStr = String.valueOf(currentNano);
-		Assert.assertNotNull(currentNanoStr);
+		Assertions.assertNotNull(currentNanoStr);
 	}
 
 	@Test
 	public void weekOfYearTest() {
 		// 第一周周日
 		int weekOfYear1 = DateUtil.weekOfYear(DateUtil.parse("2016-01-03"));
-		Assert.assertEquals(1, weekOfYear1);
+		Assertions.assertEquals(1, weekOfYear1);
 
 		// 第二周周四
 		int weekOfYear2 = DateUtil.weekOfYear(DateUtil.parse("2016-01-07"));
-		Assert.assertEquals(2, weekOfYear2);
+		Assertions.assertEquals(2, weekOfYear2);
 	}
 
 	@Test
 	public void timeToSecondTest() {
 		int second = DateUtil.timeToSecond("00:01:40");
-		Assert.assertEquals(100, second);
+		Assertions.assertEquals(100, second);
 		second = DateUtil.timeToSecond("00:00:40");
-		Assert.assertEquals(40, second);
+		Assertions.assertEquals(40, second);
 		second = DateUtil.timeToSecond("01:00:00");
-		Assert.assertEquals(3600, second);
+		Assertions.assertEquals(3600, second);
 		second = DateUtil.timeToSecond("00:00:00");
-		Assert.assertEquals(0, second);
+		Assertions.assertEquals(0, second);
 	}
 
 	@Test
 	public void secondToTimeTest() {
 		String time = DateUtil.secondToTime(3600);
-		Assert.assertEquals("01:00:00", time);
+		Assertions.assertEquals("01:00:00", time);
 		time = DateUtil.secondToTime(3800);
-		Assert.assertEquals("01:03:20", time);
+		Assertions.assertEquals("01:03:20", time);
 		time = DateUtil.secondToTime(0);
-		Assert.assertEquals("00:00:00", time);
+		Assertions.assertEquals("00:00:00", time);
 		time = DateUtil.secondToTime(30);
-		Assert.assertEquals("00:00:30", time);
+		Assertions.assertEquals("00:00:30", time);
 	}
 
 	@Test
@@ -369,7 +369,7 @@ public class DateUtilTest {
 		String s2 = "55:00:50";
 		int i = DateUtil.timeToSecond(s1) + DateUtil.timeToSecond(s2);
 		String s = DateUtil.secondToTime(i);
-		Assert.assertEquals("110:03:08", s);
+		Assertions.assertEquals("110:03:08", s);
 	}
 
 	@Test
@@ -379,7 +379,7 @@ public class DateUtilTest {
 		Date birthDate = DateUtil.parse(birthday, "yyMMdd");
 		// 获取出生年(完全表现形式,如：2010)
 		int sYear = DateUtil.year(birthDate);
-		Assert.assertEquals(1970, sYear);
+		Assertions.assertEquals(1970, sYear);
 	}
 
 	@Test
@@ -387,13 +387,13 @@ public class DateUtilTest {
 		String dateStr = "2018-10-10 12:11:11";
 		Date date = DateUtil.parse(dateStr);
 		String format = DateUtil.format(date, DatePattern.NORM_DATETIME_PATTERN);
-		Assert.assertEquals(dateStr, format);
+		Assertions.assertEquals(dateStr, format);
 	}
 
 	@Test
 	public void parseTest4() {
 		String ymd = DateUtil.parse("2019-3-21 12:20:15", "yyyy-MM-dd").toString(DatePattern.PURE_DATE_PATTERN);
-		Assert.assertEquals("20190321", ymd);
+		Assertions.assertEquals("20190321", ymd);
 	}
 
 	@Test
@@ -401,33 +401,33 @@ public class DateUtilTest {
 		// 测试时间解析
 		//noinspection ConstantConditions
 		String time = DateUtil.parse("22:12:12").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("22:12:12", time);
+		Assertions.assertEquals("22:12:12", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("2:12:12").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("02:12:12", time);
+		Assertions.assertEquals("02:12:12", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("2:2:12").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("02:02:12", time);
+		Assertions.assertEquals("02:02:12", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("2:2:1").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("02:02:01", time);
+		Assertions.assertEquals("02:02:01", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("22:2:1").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("22:02:01", time);
+		Assertions.assertEquals("22:02:01", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("2:22:1").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("02:22:01", time);
+		Assertions.assertEquals("02:22:01", time);
 
 		// 测试两位时间解析
 		//noinspection ConstantConditions
 		time = DateUtil.parse("2:22").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("02:22:00", time);
+		Assertions.assertEquals("02:22:00", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("12:22").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("12:22:00", time);
+		Assertions.assertEquals("12:22:00", time);
 		//noinspection ConstantConditions
 		time = DateUtil.parse("12:2").toString(DatePattern.NORM_TIME_FORMAT);
-		Assert.assertEquals("12:02:00", time);
+		Assertions.assertEquals("12:02:00", time);
 
 	}
 
@@ -436,7 +436,7 @@ public class DateUtilTest {
 		String str = "Tue Jun 4 16:25:15 +0800 2019";
 		DateTime dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2019-06-04 16:25:15", dateTime.toString());
+		Assertions.assertEquals("2019-06-04 16:25:15", dateTime.toString());
 	}
 
 	@Test
@@ -444,12 +444,12 @@ public class DateUtilTest {
 		String str = "2019-06-01T19:45:43.000 +0800";
 		DateTime dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2019-06-01 19:45:43", dateTime.toString());
+		Assertions.assertEquals("2019-06-01 19:45:43", dateTime.toString());
 
 		str = "2019-06-01T19:45:43 +08:00";
 		dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2019-06-01 19:45:43", dateTime.toString());
+		Assertions.assertEquals("2019-06-01 19:45:43", dateTime.toString());
 	}
 
 	@Test
@@ -457,7 +457,7 @@ public class DateUtilTest {
 		String str = "2020-06-28T02:14:13.000Z";
 		DateTime dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2020-06-28 02:14:13", dateTime.toString());
+		Assertions.assertEquals("2020-06-28 02:14:13", dateTime.toString());
 	}
 
 	/**
@@ -467,23 +467,23 @@ public class DateUtilTest {
 	public void parseNormFullTest() {
 		String str = "2020-02-06 01:58:00.000020";
 		DateTime dateTime = DateUtil.parse(str);
-		Assert.assertNotNull(dateTime);
-		Assert.assertEquals("2020-02-06 01:58:00.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertNotNull(dateTime);
+		Assertions.assertEquals("2020-02-06 01:58:00.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		str = "2020-02-06 01:58:00.00002";
 		dateTime = DateUtil.parse(str);
-		Assert.assertNotNull(dateTime);
-		Assert.assertEquals("2020-02-06 01:58:00.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertNotNull(dateTime);
+		Assertions.assertEquals("2020-02-06 01:58:00.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		str = "2020-02-06 01:58:00.111000";
 		dateTime = DateUtil.parse(str);
-		Assert.assertNotNull(dateTime);
-		Assert.assertEquals("2020-02-06 01:58:00.111", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertNotNull(dateTime);
+		Assertions.assertEquals("2020-02-06 01:58:00.111", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 
 		str = "2020-02-06 01:58:00.111";
 		dateTime = DateUtil.parse(str);
-		Assert.assertNotNull(dateTime);
-		Assert.assertEquals("2020-02-06 01:58:00.111", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+		Assertions.assertNotNull(dateTime);
+		Assertions.assertEquals("2020-02-06 01:58:00.111", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
 	}
 
 	/**
@@ -493,7 +493,7 @@ public class DateUtilTest {
 	public void parseEmptyTest() {
 		String str = " ";
 		DateTime dateTime = DateUtil.parse(str);
-		Assert.assertNull(dateTime);
+		Assertions.assertNull(dateTime);
 	}
 
 	@Test
@@ -502,12 +502,12 @@ public class DateUtilTest {
 		String str = "2019-06-01T19:45:43+08:00";
 		DateTime dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2019-06-01 19:45:43", dateTime.toString());
+		Assertions.assertEquals("2019-06-01 19:45:43", dateTime.toString());
 
 		str = "2019-06-01T19:45:43 +08:00";
 		dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2019-06-01 19:45:43", dateTime.toString());
+		Assertions.assertEquals("2019-06-01 19:45:43", dateTime.toString());
 	}
 
 	@Test
@@ -516,10 +516,10 @@ public class DateUtilTest {
 		String str = "2019-09-17T13:26:17.948Z";
 		DateTime dateTime = DateUtil.parse(str);
 		assert dateTime != null;
-		Assert.assertEquals("2019-09-17 13:26:17", dateTime.toString());
+		Assertions.assertEquals("2019-09-17 13:26:17", dateTime.toString());
 
 		DateTime offset = DateUtil.offsetHour(dateTime, 8);
-		Assert.assertEquals("2019-09-17 21:26:17", offset.toString());
+		Assertions.assertEquals("2019-09-17 21:26:17", offset.toString());
 	}
 
 	@Test
@@ -527,7 +527,7 @@ public class DateUtilTest {
 		String dateStr = "2018-4-10";
 		Date date = DateUtil.parseDate(dateStr);
 		String format = DateUtil.format(date, DatePattern.NORM_DATE_PATTERN);
-		Assert.assertEquals("2018-04-10", format);
+		Assertions.assertEquals("2018-04-10", format);
 	}
 
 	@Test
@@ -541,9 +541,9 @@ public class DateUtilTest {
 		DateTime dt2 = DateUtil.parse(dateStr2);
 		DateTime dt3 = DateUtil.parse(dateStr3);
 		DateTime dt4 = DateUtil.parse(dateStr4);
-		Assert.assertEquals(dt1, dt2);
-		Assert.assertEquals(dt2, dt3);
-		Assert.assertEquals(dt3, dt4);
+		Assertions.assertEquals(dt1, dt2);
+		Assertions.assertEquals(dt2, dt3);
+		Assertions.assertEquals(dt3, dt4);
 	}
 
 	@Test
@@ -557,9 +557,9 @@ public class DateUtilTest {
 		DateTime dt2 = DateUtil.parse(dateStr2);
 		DateTime dt3 = DateUtil.parse(dateStr3);
 		DateTime dt4 = DateUtil.parse(dateStr4);
-		Assert.assertEquals(dt1, dt2);
-		Assert.assertEquals(dt2, dt3);
-		Assert.assertEquals(dt3, dt4);
+		Assertions.assertEquals(dt1, dt2);
+		Assertions.assertEquals(dt2, dt3);
+		Assertions.assertEquals(dt3, dt4);
 	}
 
 	@Test
@@ -573,9 +573,9 @@ public class DateUtilTest {
 		DateTime dt2 = DateUtil.parse(dateStr2);
 		DateTime dt3 = DateUtil.parse(dateStr3);
 		DateTime dt4 = DateUtil.parse(dateStr4);
-		Assert.assertEquals(dt1, dt2);
-		Assert.assertEquals(dt2, dt3);
-		Assert.assertEquals(dt3, dt4);
+		Assertions.assertEquals(dt1, dt2);
+		Assertions.assertEquals(dt2, dt3);
+		Assertions.assertEquals(dt3, dt4);
 	}
 
 	@Test
@@ -585,7 +585,7 @@ public class DateUtilTest {
 
 		DateTime dt1 = DateUtil.parse(dateStr1);
 		DateTime dt2 = DateUtil.parse(dateStr2);
-		Assert.assertEquals(dt1, dt2);
+		Assertions.assertEquals(dt1, dt2);
 	}
 
 	@Test
@@ -595,7 +595,7 @@ public class DateUtilTest {
 
 		DateTime dt1 = DateUtil.parse(dateStr1);
 		DateTime dt2 = DateUtil.parse(dateStr2);
-		Assert.assertEquals(dt1, dt2);
+		Assertions.assertEquals(dt1, dt2);
 	}
 
 	@Test
@@ -605,68 +605,68 @@ public class DateUtilTest {
 
 		// parse方法支持UTC格式测试
 		DateTime dt2 = DateUtil.parse(dateStr1);
-		Assert.assertEquals(dt, dt2);
+		Assertions.assertEquals(dt, dt2);
 
 		// 默认使用Pattern对应的时区，即UTC时区
 		String dateStr = dt.toString();
-		Assert.assertEquals("2018-09-13 05:34:31", dateStr);
+		Assertions.assertEquals("2018-09-13 05:34:31", dateStr);
 
 		// 使用当前（上海）时区
 		dateStr = dt.toString(TimeZone.getTimeZone("GMT+8:00"));
-		Assert.assertEquals("2018-09-13 13:34:31", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:31", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:32+0800";
 		dt = DateUtil.parseUTC(dateStr1);
 		dateStr = dt.toString(TimeZone.getTimeZone("GMT+8:00"));
-		Assert.assertEquals("2018-09-13 13:34:32", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:32", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:33+08:00";
 		dt = DateUtil.parseUTC(dateStr1);
 		dateStr = dt.toString(TimeZone.getTimeZone("GMT+8:00"));
-		Assert.assertEquals("2018-09-13 13:34:33", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:33", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:34+0800";
 		dt = DateUtil.parse(dateStr1);
 		assert dt != null;
 		dateStr = dt.toString(TimeZone.getTimeZone("GMT+8:00"));
-		Assert.assertEquals("2018-09-13 13:34:34", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:34", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:35+08:00";
 		dt = DateUtil.parse(dateStr1);
 		assert dt != null;
 		dateStr = dt.toString(TimeZone.getTimeZone("GMT+8:00"));
-		Assert.assertEquals("2018-09-13 13:34:35", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:35", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:36.999+0800";
 		dt = DateUtil.parseUTC(dateStr1);
 		final SimpleDateFormat simpleDateFormat = new SimpleDateFormat(DatePattern.NORM_DATETIME_MS_PATTERN);
 		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT+8:00"));
 		dateStr = dt.toString(simpleDateFormat);
-		Assert.assertEquals("2018-09-13 13:34:36.999", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:36.999", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:37.999+08:00";
 		dt = DateUtil.parseUTC(dateStr1);
 		dateStr = dt.toString(simpleDateFormat);
-		Assert.assertEquals("2018-09-13 13:34:37.999", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:37.999", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:38.999+0800";
 		dt = DateUtil.parse(dateStr1);
 		assert dt != null;
 		dateStr = dt.toString(simpleDateFormat);
-		Assert.assertEquals("2018-09-13 13:34:38.999", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:38.999", dateStr);
 
 		dateStr1 = "2018-09-13T13:34:39.999+08:00";
 		dt = DateUtil.parse(dateStr1);
 		assert dt != null;
 		dateStr = dt.toString(simpleDateFormat);
-		Assert.assertEquals("2018-09-13 13:34:39.999", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:39.999", dateStr);
 
 		// 使用UTC时区
 		dateStr1 = "2018-09-13T13:34:39.99";
 		dt = DateUtil.parse(dateStr1);
 		assert dt != null;
 		dateStr = dt.toString();
-		Assert.assertEquals("2018-09-13 13:34:39", dateStr);
+		Assertions.assertEquals("2018-09-13 13:34:39", dateStr);
 	}
 
 	@Test
@@ -675,15 +675,15 @@ public class DateUtilTest {
 		// 检查不同毫秒长度都可以正常匹配
 		String utcTime = "2021-03-30T12:56:51.3Z";
 		DateTime parse = DateUtil.parseUTC(utcTime);
-		Assert.assertEquals("2021-03-30 12:56:51", parse.toString());
+		Assertions.assertEquals("2021-03-30 12:56:51", parse.toString());
 
 		utcTime = "2021-03-30T12:56:51.34Z";
 		parse = DateUtil.parseUTC(utcTime);
-		Assert.assertEquals("2021-03-30 12:56:51", parse.toString());
+		Assertions.assertEquals("2021-03-30 12:56:51", parse.toString());
 
 		utcTime = "2021-03-30T12:56:51.345Z";
 		parse = DateUtil.parseUTC(utcTime);
-		Assert.assertEquals("2021-03-30 12:56:51", parse.toString());
+		Assertions.assertEquals("2021-03-30 12:56:51", parse.toString());
 	}
 
 	@Test
@@ -694,10 +694,10 @@ public class DateUtilTest {
 		final DateTime parse = DateUtil.parse(dateStr, sdf);
 
 		DateTime dateTime = DateUtil.parseCST(dateStr);
-		Assert.assertEquals(parse, dateTime);
+		Assertions.assertEquals(parse, dateTime);
 
 		dateTime = DateUtil.parse(dateStr);
-		Assert.assertEquals(parse, dateTime);
+		Assertions.assertEquals(parse, dateTime);
 	}
 
 	@Test
@@ -711,21 +711,21 @@ public class DateUtilTest {
 		FastDateFormat fdf = FastDateFormat.getInstance(DatePattern.JDK_DATETIME_PATTERN, TimeZone.getTimeZone("America/Chicago"), Locale.US);
 		final DateTime parse2 = DateUtil.parse(dateStr, fdf);
 
-		Assert.assertEquals(parse, parse2);
+		Assertions.assertEquals(parse, parse2);
 	}
 
 	@Test
 	public void parseJDkTest() {
 		String dateStr = "Thu May 16 17:57:18 GMT+08:00 2019";
 		DateTime time = DateUtil.parse(dateStr);
-		Assert.assertEquals("2019-05-16 17:57:18", Objects.requireNonNull(time).toString());
+		Assertions.assertEquals("2019-05-16 17:57:18", Objects.requireNonNull(time).toString());
 	}
 
 	@Test
 	public void parseISOTest() {
 		String dateStr = "2020-04-23T02:31:00.000Z";
 		DateTime time = DateUtil.parse(dateStr);
-		Assert.assertEquals("2020-04-23 02:31:00", Objects.requireNonNull(time).toString());
+		Assertions.assertEquals("2020-04-23 02:31:00", Objects.requireNonNull(time).toString());
 	}
 
 	@Test
@@ -733,7 +733,7 @@ public class DateUtilTest {
 		DateTime date = DateUtil.date();
 		date.setField(DateField.YEAR, 2019);
 		DateTime endOfYear = DateUtil.endOfYear(date);
-		Assert.assertEquals("2019-12-31 23:59:59", endOfYear.toString());
+		Assertions.assertEquals("2019-12-31 23:59:59", endOfYear.toString());
 	}
 
 	@Test
@@ -741,7 +741,7 @@ public class DateUtilTest {
 		Date date = DateUtil.endOfQuarter(
 				DateUtil.parse("2020-05-31 00:00:00"));
 
-		Assert.assertEquals("2020-06-30 23:59:59", DateUtil.format(date, "yyyy-MM-dd HH:mm:ss"));
+		Assertions.assertEquals("2020-06-30 23:59:59", DateUtil.format(date, "yyyy-MM-dd HH:mm:ss"));
 	}
 
 	@Test
@@ -750,21 +750,21 @@ public class DateUtilTest {
 		DateTime now = DateUtil.parse("2019-09-15 13:00");
 
 		DateTime startOfWeek = DateUtil.beginOfWeek(now);
-		Assert.assertEquals("2019-09-09 00:00:00", startOfWeek.toString());
+		Assertions.assertEquals("2019-09-09 00:00:00", startOfWeek.toString());
 		DateTime endOfWeek = DateUtil.endOfWeek(now);
-		Assert.assertEquals("2019-09-15 23:59:59", endOfWeek.toString());
+		Assertions.assertEquals("2019-09-15 23:59:59", endOfWeek.toString());
 
 		long between = DateUtil.between(endOfWeek, startOfWeek, DateUnit.DAY);
 		// 周一和周日相距6天
-		Assert.assertEquals(6, between);
+		Assertions.assertEquals(6, between);
 	}
 
 	@Test
 	public void dayOfWeekTest() {
 		int dayOfWeek = DateUtil.dayOfWeek(DateUtil.parse("2018-03-07"));
-		Assert.assertEquals(Calendar.WEDNESDAY, dayOfWeek);
+		Assertions.assertEquals(Calendar.WEDNESDAY, dayOfWeek);
 		Week week = DateUtil.dayOfWeekEnum(DateUtil.parse("2018-03-07"));
-		Assert.assertEquals(Week.WEDNESDAY, week);
+		Assertions.assertEquals(Week.WEDNESDAY, week);
 	}
 
 	@Test
@@ -772,53 +772,53 @@ public class DateUtilTest {
 		Date date1 = DateUtil.parse("2021-04-13 23:59:59.999");
 		Date date2 = DateUtil.parse("2021-04-13 23:59:10");
 
-		Assert.assertEquals(1, DateUtil.compare(date1, date2));
-		Assert.assertEquals(1, DateUtil.compare(date1, date2, DatePattern.NORM_DATETIME_PATTERN));
-		Assert.assertEquals(0, DateUtil.compare(date1, date2, DatePattern.NORM_DATE_PATTERN));
-		Assert.assertEquals(0, DateUtil.compare(date1, date2, DatePattern.NORM_DATETIME_MINUTE_PATTERN));
+		Assertions.assertEquals(1, DateUtil.compare(date1, date2));
+		Assertions.assertEquals(1, DateUtil.compare(date1, date2, DatePattern.NORM_DATETIME_PATTERN));
+		Assertions.assertEquals(0, DateUtil.compare(date1, date2, DatePattern.NORM_DATE_PATTERN));
+		Assertions.assertEquals(0, DateUtil.compare(date1, date2, DatePattern.NORM_DATETIME_MINUTE_PATTERN));
 
 
 		Date date11 = DateUtil.parse("2021-04-13 23:59:59.999");
 		Date date22 = DateUtil.parse("2021-04-11 23:10:10");
-		Assert.assertEquals(0, DateUtil.compare(date11, date22, DatePattern.NORM_MONTH_PATTERN));
+		Assertions.assertEquals(0, DateUtil.compare(date11, date22, DatePattern.NORM_MONTH_PATTERN));
 	}
 
 	@Test
 	public void yearAndQTest() {
 		String yearAndQuarter = DateUtil.yearAndQuarter(DateUtil.parse("2018-12-01"));
-		Assert.assertEquals("20184", yearAndQuarter);
+		Assertions.assertEquals("20184", yearAndQuarter);
 
 		LinkedHashSet<String> yearAndQuarters = DateUtil.yearAndQuarter(DateUtil.parse("2018-09-10"), DateUtil.parse("2018-12-20"));
 		List<String> list = CollUtil.list(false, yearAndQuarters);
-		Assert.assertEquals(2, list.size());
-		Assert.assertEquals("20183", list.get(0));
-		Assert.assertEquals("20184", list.get(1));
+		Assertions.assertEquals(2, list.size());
+		Assertions.assertEquals("20183", list.get(0));
+		Assertions.assertEquals("20184", list.get(1));
 
 		LinkedHashSet<String> yearAndQuarters2 = DateUtil.yearAndQuarter(DateUtil.parse("2018-10-10"), DateUtil.parse("2018-12-10"));
 		List<String> list2 = CollUtil.list(false, yearAndQuarters2);
-		Assert.assertEquals(1, list2.size());
-		Assert.assertEquals("20184", list2.get(0));
+		Assertions.assertEquals(1, list2.size());
+		Assertions.assertEquals("20184", list2.get(0));
 	}
 
 	@Test
 	public void formatHttpDateTest() {
 		String formatHttpDate = DateUtil.formatHttpDate(DateUtil.parse("2019-01-02 22:32:01"));
-		Assert.assertEquals("Wed, 02 Jan 2019 14:32:01 GMT", formatHttpDate);
+		Assertions.assertEquals("Wed, 02 Jan 2019 14:32:01 GMT", formatHttpDate);
 	}
 
 	@Test
 	public void toInstantTest() {
 		LocalDateTime localDateTime = LocalDateTime.parse("2017-05-06T08:30:00", DateTimeFormatter.ISO_DATE_TIME);
 		Instant instant = DateUtil.toInstant(localDateTime);
-		Assert.assertEquals("2017-05-06T00:30:00Z", instant.toString());
+		Assertions.assertEquals("2017-05-06T00:30:00Z", instant.toString());
 
 		LocalDate localDate = localDateTime.toLocalDate();
 		instant = DateUtil.toInstant(localDate);
-		Assert.assertNotNull(instant);
+		Assertions.assertNotNull(instant);
 
 		LocalTime localTime = localDateTime.toLocalTime();
 		instant = DateUtil.toInstant(localTime);
-		Assert.assertNotNull(instant);
+		Assertions.assertNotNull(instant);
 	}
 
 	@Test
@@ -826,12 +826,12 @@ public class DateUtilTest {
 		//LocalDateTime ==> date
 		LocalDateTime localDateTime = LocalDateTime.parse("2017-05-06T08:30:00", DateTimeFormatter.ISO_DATE_TIME);
 		DateTime date = DateUtil.date(localDateTime);
-		Assert.assertEquals("2017-05-06 08:30:00", date.toString());
+		Assertions.assertEquals("2017-05-06 08:30:00", date.toString());
 
 		//LocalDate ==> date
 		LocalDate localDate = localDateTime.toLocalDate();
 		DateTime date2 = DateUtil.date(localDate);
-		Assert.assertEquals("2017-05-06",
+		Assertions.assertEquals("2017-05-06",
 				DateUtil.format(date2, DatePattern.NORM_DATE_PATTERN));
 	}
 
@@ -840,7 +840,7 @@ public class DateUtilTest {
 		// 测试负数日期
 		long dateLong = -1497600000;
 		final DateTime date = DateUtil.date(dateLong);
-		Assert.assertEquals("1969-12-15 00:00:00", date.toString());
+		Assertions.assertEquals("1969-12-15 00:00:00", date.toString());
 	}
 
 	@Test
@@ -848,14 +848,16 @@ public class DateUtilTest {
 		String d1 = "2000-02-29";
 		String d2 = "2018-02-28";
 		final int age = DateUtil.age(DateUtil.parseDate(d1), DateUtil.parseDate(d2));
-		Assert.assertEquals(18, age);
+		Assertions.assertEquals(18, age);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void ageTest2() {
-		String d1 = "2019-02-29";
-		String d2 = "2018-02-28";
-		DateUtil.age(DateUtil.parseDate(d1), DateUtil.parseDate(d2));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			String d1 = "2019-02-29";
+			String d2 = "2018-02-28";
+			DateUtil.age(DateUtil.parseDate(d1), DateUtil.parseDate(d2));
+		});
 	}
 
 	@Test
@@ -865,7 +867,7 @@ public class DateUtilTest {
 		int length = 3;
 		//noinspection deprecation
 		boolean expired = DateUtil.isExpired(startDate, DateField.DAY_OF_YEAR, length, endDate);
-		Assert.assertTrue(expired);
+		Assertions.assertTrue(expired);
 	}
 
 	@Test
@@ -874,12 +876,12 @@ public class DateUtilTest {
 		String strDate = "2019-12-01 17:02:30";
 		LocalDateTime ldt = DateUtil.parseLocalDateTime(strDate);
 		String strDate1 = DateUtil.formatLocalDateTime(ldt);
-		Assert.assertEquals(strDate, strDate1);
+		Assertions.assertEquals(strDate, strDate1);
 
 		String strDate2 = "2019-12-01 17:02:30.111";
 		ldt = DateUtil.parseLocalDateTime(strDate2, DatePattern.NORM_DATETIME_MS_PATTERN);
 		strDate1 = DateUtil.format(ldt, DatePattern.NORM_DATETIME_PATTERN);
-		Assert.assertEquals(strDate, strDate1);
+		Assertions.assertEquals(strDate, strDate1);
 	}
 
 	@Test
@@ -887,7 +889,7 @@ public class DateUtilTest {
 		// 测试字符串与LocalDateTime的互相转换
 		String strDate = "2019-12-01";
 		final LocalDateTime localDateTime = DateUtil.parseLocalDateTime(strDate, "yyyy-MM-dd");
-		Assert.assertEquals(strDate, DateUtil.format(localDateTime, DatePattern.NORM_DATE_PATTERN));
+		Assertions.assertEquals(strDate, DateUtil.format(localDateTime, DatePattern.NORM_DATE_PATTERN));
 	}
 
 	@Test
@@ -896,7 +898,7 @@ public class DateUtilTest {
 		final DateTime end = DateUtil.parse("2019-10-05");
 
 		final long weekCount = DateUtil.betweenWeek(start, end, true);
-		Assert.assertEquals(30L, weekCount);
+		Assertions.assertEquals(30L, weekCount);
 	}
 
 	@Test
@@ -906,38 +908,38 @@ public class DateUtilTest {
 			long betweenDay = DateUtil.betweenDay(
 					DateUtil.parseDate("1970-01-01"),
 					DateUtil.parseDate(datr), false);
-			Assert.assertEquals(Math.abs(LocalDate.parse(datr).toEpochDay()), betweenDay);
+			Assertions.assertEquals(Math.abs(LocalDate.parse(datr).toEpochDay()), betweenDay);
 		}
 	}
 
 	@Test
 	public void dayOfYearTest() {
 		int dayOfYear = DateUtil.dayOfYear(DateUtil.parse("2020-01-01"));
-		Assert.assertEquals(1, dayOfYear);
+		Assertions.assertEquals(1, dayOfYear);
 		int lengthOfYear = DateUtil.lengthOfYear(2020);
-		Assert.assertEquals(366, lengthOfYear);
+		Assertions.assertEquals(366, lengthOfYear);
 	}
 
 	@SuppressWarnings("ConstantConditions")
 	@Test
 	public void parseSingleNumberTest() {
 		DateTime dateTime = DateUtil.parse("2020-5-08");
-		Assert.assertEquals("2020-05-08 00:00:00", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 00:00:00", dateTime.toString());
 		dateTime = DateUtil.parse("2020-5-8");
-		Assert.assertEquals("2020-05-08 00:00:00", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 00:00:00", dateTime.toString());
 		dateTime = DateUtil.parse("2020-05-8");
-		Assert.assertEquals("2020-05-08 00:00:00", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 00:00:00", dateTime.toString());
 
 		//datetime
 		dateTime = DateUtil.parse("2020-5-8 3:12:3");
-		Assert.assertEquals("2020-05-08 03:12:03", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 03:12:03", dateTime.toString());
 		dateTime = DateUtil.parse("2020-5-8 3:2:3");
-		Assert.assertEquals("2020-05-08 03:02:03", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 03:02:03", dateTime.toString());
 		dateTime = DateUtil.parse("2020-5-8 3:12:13");
-		Assert.assertEquals("2020-05-08 03:12:13", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 03:12:13", dateTime.toString());
 
 		dateTime = DateUtil.parse("2020-5-8 4:12:26.223");
-		Assert.assertEquals("2020-05-08 04:12:26", dateTime.toString());
+		Assertions.assertEquals("2020-05-08 04:12:26", dateTime.toString());
 	}
 
 	@SuppressWarnings("ConstantConditions")
@@ -945,14 +947,16 @@ public class DateUtilTest {
 	public void parseISO8601Test() {
 		String dt = "2020-06-03 12:32:12,333";
 		final DateTime parse = DateUtil.parse(dt);
-		Assert.assertEquals("2020-06-03 12:32:12", parse.toString());
+		Assertions.assertEquals("2020-06-03 12:32:12", parse.toString());
 	}
 
-	@Test(expected = DateException.class)
+	@Test
 	public void parseNotFitTest() {
-		//https://github.com/looly/hutool/issues/1332
-		// 在日期格式不匹配的时候，测试是否正常报错
-		DateUtil.parse("2020-12-23", DatePattern.PURE_DATE_PATTERN);
+		Assertions.assertThrows(DateException.class, () -> {
+			//https://github.com/looly/hutool/issues/1332
+			// 在日期格式不匹配的时候，测试是否正常报错
+			DateUtil.parse("2020-12-23", DatePattern.PURE_DATE_PATTERN);
+		});
 	}
 
 	@Test
@@ -961,37 +965,37 @@ public class DateUtilTest {
 		calendar.set(2021, Calendar.JULY, 14, 23, 59, 59);
 		Date date = new DateTime(calendar);
 
-		Assert.assertEquals("2021-07-14 23:59:59", DateUtil.format(date, DatePattern.NORM_DATETIME_FORMATTER));
-		Assert.assertEquals("2021-07-14 23:59:59", DateUtil.format(date, DatePattern.NORM_DATETIME_FORMAT));
-		Assert.assertEquals("2021-07-14 23:59:59", DateUtil.format(date, DatePattern.NORM_DATETIME_PATTERN));
+		Assertions.assertEquals("2021-07-14 23:59:59", DateUtil.format(date, DatePattern.NORM_DATETIME_FORMATTER));
+		Assertions.assertEquals("2021-07-14 23:59:59", DateUtil.format(date, DatePattern.NORM_DATETIME_FORMAT));
+		Assertions.assertEquals("2021-07-14 23:59:59", DateUtil.format(date, DatePattern.NORM_DATETIME_PATTERN));
 	}
 
 	@Test
 	public void formatNormDateTimeFormatterTest() {
 		String format = DateUtil.format(DateUtil.parse("2021-07-14 10:05:38"), DatePattern.NORM_DATETIME_FORMATTER);
-		Assert.assertEquals("2021-07-14 10:05:38", format);
+		Assertions.assertEquals("2021-07-14 10:05:38", format);
 
 		format = DateUtil.format(LocalDateTimeUtil.parse("2021-07-14T10:05:38"),
 				"yyyy-MM-dd HH:mm:ss");
-		Assert.assertEquals("2021-07-14 10:05:38", format);
+		Assertions.assertEquals("2021-07-14 10:05:38", format);
 	}
 
 	@Test
 	public void isWeekendTest() {
 		DateTime parse = DateUtil.parse("2021-07-28");
-		Assert.assertFalse(DateUtil.isWeekend(parse));
+		Assertions.assertFalse(DateUtil.isWeekend(parse));
 
 		parse = DateUtil.parse("2021-07-25");
-		Assert.assertTrue(DateUtil.isWeekend(parse));
+		Assertions.assertTrue(DateUtil.isWeekend(parse));
 		parse = DateUtil.parse("2021-07-24");
-		Assert.assertTrue(DateUtil.isWeekend(parse));
+		Assertions.assertTrue(DateUtil.isWeekend(parse));
 	}
 
 	@Test
 	public void parseSingleMonthAndDayTest() {
 		final DateTime parse = DateUtil.parse("2021-1-1");
-		Assert.assertNotNull(parse);
-		Assert.assertEquals("2021-01-01 00:00:00", parse.toString());
+		Assertions.assertNotNull(parse);
+		Assertions.assertEquals("2021-01-01 00:00:00", parse.toString());
 
 		Console.log(DateUtil.parse("2021-1-22 00:00:00"));
 	}
@@ -999,6 +1003,6 @@ public class DateUtilTest {
 	@Test
 	public void parseByDateTimeFormatterTest() {
 		final DateTime parse = DateUtil.parse("2021-12-01", DatePattern.NORM_DATE_FORMATTER);
-		Assert.assertEquals("2021-12-01 00:00:00", parse.toString());
+		Assertions.assertEquals("2021-12-01 00:00:00", parse.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/GanzhiTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/GanzhiTest.java
@@ -1,14 +1,14 @@
 package cn.hutool.core.date;
 
 import cn.hutool.core.date.chinese.GanZhi;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GanzhiTest {
 
 	@Test
 	public void getGanzhiOfYearTest(){
-		Assert.assertEquals("庚子", GanZhi.getGanzhiOfYear(2020));
+		Assertions.assertEquals("庚子", GanZhi.getGanzhiOfYear(2020));
 	}
 
 	@Test
@@ -16,7 +16,7 @@ public class GanzhiTest {
 		//通过公历构建
 		ChineseDate chineseDate = new ChineseDate(DateUtil.parseDate("1993-01-06"));
 		String cyclicalYMD = chineseDate.getCyclicalYMD();
-		Assert.assertEquals("壬申年癸丑月丁亥日",cyclicalYMD);
+		Assertions.assertEquals("壬申年癸丑月丁亥日",cyclicalYMD);
 	}
 
 	@Test
@@ -24,7 +24,7 @@ public class GanzhiTest {
 		//通过农历构建
 		ChineseDate chineseDate = new ChineseDate(1992,12,14);
 		String cyclicalYMD = chineseDate.getCyclicalYMD();
-		Assert.assertEquals("壬申年癸丑月丁亥日",cyclicalYMD);
+		Assertions.assertEquals("壬申年癸丑月丁亥日",cyclicalYMD);
 	}
 
 	@Test
@@ -32,7 +32,7 @@ public class GanzhiTest {
 		//通过公历构建
 		ChineseDate chineseDate = new ChineseDate(DateUtil.parseDate("2020-08-28"));
 		String cyclicalYMD = chineseDate.getCyclicalYMD();
-		Assert.assertEquals("庚子年甲申月癸卯日",cyclicalYMD);
+		Assertions.assertEquals("庚子年甲申月癸卯日",cyclicalYMD);
 	}
 
 	@Test
@@ -40,6 +40,6 @@ public class GanzhiTest {
 		//通过公历构建
 		ChineseDate chineseDate = new ChineseDate(DateUtil.parseDate("1905-08-28"));
 		String cyclicalYMD = chineseDate.getCyclicalYMD();
-		Assert.assertEquals("乙巳年甲申月己亥日",cyclicalYMD);
+		Assertions.assertEquals("乙巳年甲申月己亥日",cyclicalYMD);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.LocalDate;
@@ -13,7 +13,7 @@ public class LocalDateTimeUtilTest {
 
 	@Test
 	public void nowTest() {
-		Assert.assertNotNull(LocalDateTimeUtil.now());
+		Assertions.assertNotNull(LocalDateTimeUtil.now());
 	}
 
 	@Test
@@ -22,97 +22,97 @@ public class LocalDateTimeUtilTest {
 		final DateTime dt = DateUtil.parse(dateStr);
 
 		LocalDateTime of = LocalDateTimeUtil.of(dt);
-		Assert.assertNotNull(of);
-		Assert.assertEquals(dateStr, of.toString());
+		Assertions.assertNotNull(of);
+		Assertions.assertEquals(dateStr, of.toString());
 
 		of = LocalDateTimeUtil.ofUTC(dt.getTime());
-		Assert.assertEquals(dateStr, of.toString());
+		Assertions.assertEquals(dateStr, of.toString());
 	}
 
 	@Test
 	public void parseOffsetTest() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2021-07-30T16:27:27+08:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-		Assert.assertEquals("2021-07-30T16:27:27", localDateTime.toString());
+		Assertions.assertEquals("2021-07-30T16:27:27", localDateTime.toString());
 	}
 
 	@Test
 	public void parseTest() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56", DateTimeFormatter.ISO_DATE_TIME);
-		Assert.assertEquals("2020-01-23T12:23:56", localDateTime.toString());
+		Assertions.assertEquals("2020-01-23T12:23:56", localDateTime.toString());
 	}
 
 	@Test
 	public void parseTest2() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23", DatePattern.NORM_DATE_PATTERN);
-		Assert.assertEquals("2020-01-23T00:00", localDateTime.toString());
+		Assertions.assertEquals("2020-01-23T00:00", localDateTime.toString());
 	}
 
 	@Test
 	public void parseTest3() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("12:23:56", DatePattern.NORM_TIME_PATTERN);
-		Assert.assertEquals("12:23:56", localDateTime.toLocalTime().toString());
+		Assertions.assertEquals("12:23:56", localDateTime.toLocalTime().toString());
 	}
 
 	@Test
 	public void parseTest4() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56");
-		Assert.assertEquals("2020-01-23T12:23:56", localDateTime.toString());
+		Assertions.assertEquals("2020-01-23T12:23:56", localDateTime.toString());
 	}
 
 	@Test
 	public void parseTest5() {
 		LocalDateTime localDateTime = LocalDateTimeUtil.parse("19940121183604", "yyyyMMddHHmmss");
-		Assert.assertEquals("1994-01-21T18:36:04", localDateTime.toString());
+		Assertions.assertEquals("1994-01-21T18:36:04", localDateTime.toString());
 	}
 
 	@Test
 	public void parseTest6() {
 		LocalDateTime localDateTime = LocalDateTimeUtil.parse("19940121183604682", "yyyyMMddHHmmssSSS");
-		Assert.assertEquals("1994-01-21T18:36:04.682", localDateTime.toString());
+		Assertions.assertEquals("1994-01-21T18:36:04.682", localDateTime.toString());
 
 		localDateTime = LocalDateTimeUtil.parse("1994012118360468", "yyyyMMddHHmmssSS");
-		Assert.assertEquals("1994-01-21T18:36:04.680", localDateTime.toString());
+		Assertions.assertEquals("1994-01-21T18:36:04.680", localDateTime.toString());
 
 		localDateTime = LocalDateTimeUtil.parse("199401211836046", "yyyyMMddHHmmssS");
-		Assert.assertEquals("1994-01-21T18:36:04.600", localDateTime.toString());
+		Assertions.assertEquals("1994-01-21T18:36:04.600", localDateTime.toString());
 	}
 
 	@Test
 	public void parseDateTest() {
 		LocalDate localDate = LocalDateTimeUtil.parseDate("2020-01-23");
-		Assert.assertEquals("2020-01-23", localDate.toString());
+		Assertions.assertEquals("2020-01-23", localDate.toString());
 
 		localDate = LocalDateTimeUtil.parseDate("2020-01-23T12:23:56", DateTimeFormatter.ISO_DATE_TIME);
-		Assert.assertEquals("2020-01-23", localDate.toString());
+		Assertions.assertEquals("2020-01-23", localDate.toString());
 	}
 
 	@Test
 	public void parseSingleMonthAndDayTest() {
 		LocalDate localDate = LocalDateTimeUtil.parseDate("2020-1-1", "yyyy-M-d");
-		Assert.assertEquals("2020-01-01", localDate.toString());
+		Assertions.assertEquals("2020-01-01", localDate.toString());
 	}
 
 	@Test
 	public void formatTest() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56");
 		String format = LocalDateTimeUtil.format(localDateTime, DatePattern.NORM_DATETIME_PATTERN);
-		Assert.assertEquals("2020-01-23 12:23:56", format);
+		Assertions.assertEquals("2020-01-23 12:23:56", format);
 
 		format = LocalDateTimeUtil.formatNormal(localDateTime);
-		Assert.assertEquals("2020-01-23 12:23:56", format);
+		Assertions.assertEquals("2020-01-23 12:23:56", format);
 
 		format = LocalDateTimeUtil.format(localDateTime, DatePattern.NORM_DATE_PATTERN);
-		Assert.assertEquals("2020-01-23", format);
+		Assertions.assertEquals("2020-01-23", format);
 	}
 
 	@Test
 	public void formatLocalDateTest() {
 		final LocalDate date = LocalDate.parse("2020-01-23");
 		String format = LocalDateTimeUtil.format(date, DatePattern.NORM_DATE_PATTERN);
-		Assert.assertEquals("2020-01-23", format);
+		Assertions.assertEquals("2020-01-23", format);
 
 		format = LocalDateTimeUtil.formatNormal(date);
-		Assert.assertEquals("2020-01-23", format);
+		Assertions.assertEquals("2020-01-23", format);
 	}
 
 	@Test
@@ -120,12 +120,12 @@ public class LocalDateTimeUtilTest {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56");
 		LocalDateTime offset = LocalDateTimeUtil.offset(localDateTime, 1, ChronoUnit.DAYS);
 		// 非同一对象
-		Assert.assertNotSame(localDateTime, offset);
+		Assertions.assertNotSame(localDateTime, offset);
 
-		Assert.assertEquals("2020-01-24T12:23:56", offset.toString());
+		Assertions.assertEquals("2020-01-24T12:23:56", offset.toString());
 
 		offset = LocalDateTimeUtil.offset(localDateTime, -1, ChronoUnit.DAYS);
-		Assert.assertEquals("2020-01-22T12:23:56", offset.toString());
+		Assertions.assertEquals("2020-01-22T12:23:56", offset.toString());
 	}
 
 	@Test
@@ -133,14 +133,14 @@ public class LocalDateTimeUtilTest {
 		final Duration between = LocalDateTimeUtil.between(
 				LocalDateTimeUtil.parse("2019-02-02T00:00:00"),
 				LocalDateTimeUtil.parse("2020-02-02T00:00:00"));
-		Assert.assertEquals(365, between.toDays());
+		Assertions.assertEquals(365, between.toDays());
 	}
 
 	@Test
 	public void beginOfDayTest() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56");
 		final LocalDateTime beginOfDay = LocalDateTimeUtil.beginOfDay(localDateTime);
-		Assert.assertEquals("2020-01-23T00:00", beginOfDay.toString());
+		Assertions.assertEquals("2020-01-23T00:00", beginOfDay.toString());
 	}
 
 	@Test
@@ -148,33 +148,33 @@ public class LocalDateTimeUtilTest {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56");
 
 		LocalDateTime endOfDay = LocalDateTimeUtil.endOfDay(localDateTime);
-		Assert.assertEquals("2020-01-23T23:59:59.999999999", endOfDay.toString());
+		Assertions.assertEquals("2020-01-23T23:59:59.999999999", endOfDay.toString());
 
 		endOfDay = LocalDateTimeUtil.endOfDay(localDateTime, true);
-		Assert.assertEquals("2020-01-23T23:59:59", endOfDay.toString());
+		Assertions.assertEquals("2020-01-23T23:59:59", endOfDay.toString());
 	}
 
 	@Test
 	public void dayOfWeekTest() {
 		final Week one = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 20));
-		Assert.assertEquals(Week.MONDAY, one);
+		Assertions.assertEquals(Week.MONDAY, one);
 
 		final Week two = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 21));
-		Assert.assertEquals(Week.TUESDAY, two);
+		Assertions.assertEquals(Week.TUESDAY, two);
 
 		final Week three = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 22));
-		Assert.assertEquals(Week.WEDNESDAY, three);
+		Assertions.assertEquals(Week.WEDNESDAY, three);
 
 		final Week four = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 23));
-		Assert.assertEquals(Week.THURSDAY, four);
+		Assertions.assertEquals(Week.THURSDAY, four);
 
 		final Week five = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 24));
-		Assert.assertEquals(Week.FRIDAY, five);
+		Assertions.assertEquals(Week.FRIDAY, five);
 
 		final Week six = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 25));
-		Assert.assertEquals(Week.SATURDAY, six);
+		Assertions.assertEquals(Week.SATURDAY, six);
 
 		final Week seven = LocalDateTimeUtil.dayOfWeek(LocalDate.of(2021, 9, 26));
-		Assert.assertEquals(Week.SUNDAY, seven);
+		Assertions.assertEquals(Week.SUNDAY, seven);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/MonthTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/MonthTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Calendar;
 
@@ -11,30 +11,30 @@ public class MonthTest {
 	@Test
 	public void getLastDayTest(){
 		int lastDay = Month.of(Calendar.JANUARY).getLastDay(false);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 		lastDay = Month.of(Calendar.FEBRUARY).getLastDay(false);
-		Assert.assertEquals(28, lastDay);
+		Assertions.assertEquals(28, lastDay);
 		lastDay = Month.of(Calendar.FEBRUARY).getLastDay(true);
-		Assert.assertEquals(29, lastDay);
+		Assertions.assertEquals(29, lastDay);
 		lastDay = Month.of(Calendar.MARCH).getLastDay(true);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 		lastDay = Month.of(Calendar.APRIL).getLastDay(true);
-		Assert.assertEquals(30, lastDay);
+		Assertions.assertEquals(30, lastDay);
 		lastDay = Month.of(Calendar.MAY).getLastDay(true);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 		lastDay = Month.of(Calendar.JUNE).getLastDay(true);
-		Assert.assertEquals(30, lastDay);
+		Assertions.assertEquals(30, lastDay);
 		lastDay = Month.of(Calendar.JULY).getLastDay(true);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 		lastDay = Month.of(Calendar.AUGUST).getLastDay(true);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 		lastDay = Month.of(Calendar.SEPTEMBER).getLastDay(true);
-		Assert.assertEquals(30, lastDay);
+		Assertions.assertEquals(30, lastDay);
 		lastDay = Month.of(Calendar.OCTOBER).getLastDay(true);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 		lastDay = Month.of(Calendar.NOVEMBER).getLastDay(true);
-		Assert.assertEquals(30, lastDay);
+		Assertions.assertEquals(30, lastDay);
 		lastDay = Month.of(Calendar.DECEMBER).getLastDay(true);
-		Assert.assertEquals(31, lastDay);
+		Assertions.assertEquals(31, lastDay);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/TemporalAccessorUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/TemporalAccessorUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -11,24 +11,24 @@ public class TemporalAccessorUtilTest {
 	@Test
 	public void formatLocalDateTest(){
 		final String format = TemporalAccessorUtil.format(LocalDate.of(2020, 12, 7), DatePattern.NORM_DATETIME_PATTERN);
-		Assert.assertEquals("2020-12-07 00:00:00", format);
+		Assertions.assertEquals("2020-12-07 00:00:00", format);
 	}
 
 	@Test
 	public void formatLocalTimeTest(){
 		final String today = TemporalAccessorUtil.format(LocalDate.now(), DatePattern.NORM_DATE_PATTERN);
 		final String format = TemporalAccessorUtil.format(LocalTime.MIN, DatePattern.NORM_DATETIME_PATTERN);
-		Assert.assertEquals(today + " 00:00:00", format);
+		Assertions.assertEquals(today + " 00:00:00", format);
 	}
 
 	@Test
 	public void formatCustomTest(){
 		final String today = TemporalAccessorUtil.format(
 				LocalDate.of(2021, 6, 26), "#sss");
-		Assert.assertEquals("1624636800", today);
+		Assertions.assertEquals("1624636800", today);
 
 		final String today2 = TemporalAccessorUtil.format(
 				LocalDate.of(2021, 6, 26), "#SSS");
-		Assert.assertEquals("1624636800000", today2);
+		Assertions.assertEquals("1624636800000", today2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/TimeIntervalTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/TimeIntervalTest.java
@@ -2,7 +2,7 @@ package cn.hutool.core.date;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TimeIntervalTest {
 	@Test

--- a/hutool-core/src/test/java/cn/hutool/core/date/TimeZoneTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/TimeZoneTest.java
@@ -2,22 +2,22 @@ package cn.hutool.core.date;
 
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.date.format.FastDateFormat;
 
 public class TimeZoneTest {
-	
+
 	@Test
 	public void timeZoneConvertTest() {
 		DateTime dt = DateUtil.parse("2018-07-10 21:44:32", //
 				FastDateFormat.getInstance(DatePattern.NORM_DATETIME_PATTERN, TimeZone.getTimeZone("GMT+8:00")));
-		Assert.assertEquals("2018-07-10 21:44:32", dt.toString());
-		
+		Assertions.assertEquals("2018-07-10 21:44:32", dt.toString());
+
 		dt.setTimeZone(TimeZone.getTimeZone("Europe/London"));
 		int hour = dt.getField(DateField.HOUR_OF_DAY);
-		Assert.assertEquals(14, hour);
-		Assert.assertEquals("2018-07-10 14:44:32", dt.toString());
+		Assertions.assertEquals(14, hour);
+		Assertions.assertEquals("2018-07-10 14:44:32", dt.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/ZodiacTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/ZodiacTest.java
@@ -1,21 +1,21 @@
 package cn.hutool.core.date;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ZodiacTest {
 
 	@Test
 	public void getZodiacTest() {
-		Assert.assertEquals("摩羯座", Zodiac.getZodiac(Month.JANUARY, 19));
-		Assert.assertEquals("水瓶座", Zodiac.getZodiac(Month.JANUARY, 20));
-		Assert.assertEquals("巨蟹座", Zodiac.getZodiac(6, 17));
+		Assertions.assertEquals("摩羯座", Zodiac.getZodiac(Month.JANUARY, 19));
+		Assertions.assertEquals("水瓶座", Zodiac.getZodiac(Month.JANUARY, 20));
+		Assertions.assertEquals("巨蟹座", Zodiac.getZodiac(6, 17));
 	}
 
 	@Test
 	public void getChineseZodiacTest() {
-		Assert.assertEquals("狗", Zodiac.getChineseZodiac(1994));
-		Assert.assertEquals("狗", Zodiac.getChineseZodiac(2018));
-		Assert.assertEquals("猪", Zodiac.getChineseZodiac(2019));
+		Assertions.assertEquals("狗", Zodiac.getChineseZodiac(1994));
+		Assertions.assertEquals("狗", Zodiac.getChineseZodiac(2018));
+		Assertions.assertEquals("猪", Zodiac.getChineseZodiac(2019));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/chinese/SolarTermsTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/chinese/SolarTermsTest.java
@@ -2,80 +2,80 @@ package cn.hutool.core.date.chinese;
 
 import cn.hutool.core.date.ChineseDate;
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SolarTermsTest {
 
 	@Test
 	public void getTermTest1(){
 		final int term = SolarTerms.getTerm(1987, 3);
-		Assert.assertEquals(4, term);
+		Assertions.assertEquals(4, term);
 	}
 
 	@Test
 	public void getTermTest() {
 
-		Assert.assertEquals("小寒", SolarTerms.getTerm(2021, 1, 5));
+		Assertions.assertEquals("小寒", SolarTerms.getTerm(2021, 1, 5));
 
-		Assert.assertEquals("大寒", SolarTerms.getTerm(2021, 1, 20));
+		Assertions.assertEquals("大寒", SolarTerms.getTerm(2021, 1, 20));
 
-		Assert.assertEquals("立春", SolarTerms.getTerm(2021, 2, 3));
+		Assertions.assertEquals("立春", SolarTerms.getTerm(2021, 2, 3));
 
-		Assert.assertEquals("雨水", SolarTerms.getTerm(2021, 2, 18));
+		Assertions.assertEquals("雨水", SolarTerms.getTerm(2021, 2, 18));
 
-		Assert.assertEquals("惊蛰", SolarTerms.getTerm(2021, 3, 5));
+		Assertions.assertEquals("惊蛰", SolarTerms.getTerm(2021, 3, 5));
 
-		Assert.assertEquals("春分", SolarTerms.getTerm(2021, 3, 20));
+		Assertions.assertEquals("春分", SolarTerms.getTerm(2021, 3, 20));
 
-		Assert.assertEquals("清明", SolarTerms.getTerm(2021, 4, 4));
+		Assertions.assertEquals("清明", SolarTerms.getTerm(2021, 4, 4));
 
-		Assert.assertEquals("谷雨", SolarTerms.getTerm(2021, 4, 20));
+		Assertions.assertEquals("谷雨", SolarTerms.getTerm(2021, 4, 20));
 
-		Assert.assertEquals("立夏", SolarTerms.getTerm(2021, 5, 5));
+		Assertions.assertEquals("立夏", SolarTerms.getTerm(2021, 5, 5));
 
-		Assert.assertEquals("小满", SolarTerms.getTerm(2021, 5, 21));
+		Assertions.assertEquals("小满", SolarTerms.getTerm(2021, 5, 21));
 
-		Assert.assertEquals("芒种", SolarTerms.getTerm(2021, 6, 5));
+		Assertions.assertEquals("芒种", SolarTerms.getTerm(2021, 6, 5));
 
-		Assert.assertEquals("夏至", SolarTerms.getTerm(2021, 6, 21));
+		Assertions.assertEquals("夏至", SolarTerms.getTerm(2021, 6, 21));
 
-		Assert.assertEquals("小暑", SolarTerms.getTerm(2021, 7, 7));
+		Assertions.assertEquals("小暑", SolarTerms.getTerm(2021, 7, 7));
 
-		Assert.assertEquals("大暑", SolarTerms.getTerm(2021, 7, 22));
+		Assertions.assertEquals("大暑", SolarTerms.getTerm(2021, 7, 22));
 
-		Assert.assertEquals("立秋", SolarTerms.getTerm(2021, 8, 7));
+		Assertions.assertEquals("立秋", SolarTerms.getTerm(2021, 8, 7));
 
-		Assert.assertEquals("处暑", SolarTerms.getTerm(2021, 8, 23));
+		Assertions.assertEquals("处暑", SolarTerms.getTerm(2021, 8, 23));
 
-		Assert.assertEquals("白露", SolarTerms.getTerm(2021, 9, 7));
+		Assertions.assertEquals("白露", SolarTerms.getTerm(2021, 9, 7));
 
-		Assert.assertEquals("秋分", SolarTerms.getTerm(2021, 9, 23));
+		Assertions.assertEquals("秋分", SolarTerms.getTerm(2021, 9, 23));
 
-		Assert.assertEquals("寒露", SolarTerms.getTerm(2021, 10, 8));
+		Assertions.assertEquals("寒露", SolarTerms.getTerm(2021, 10, 8));
 
-		Assert.assertEquals("霜降", SolarTerms.getTerm(2021, 10, 23));
+		Assertions.assertEquals("霜降", SolarTerms.getTerm(2021, 10, 23));
 
-		Assert.assertEquals("立冬", SolarTerms.getTerm(2021, 11, 7));
+		Assertions.assertEquals("立冬", SolarTerms.getTerm(2021, 11, 7));
 
-		Assert.assertEquals("小雪", SolarTerms.getTerm(2021, 11, 22));
+		Assertions.assertEquals("小雪", SolarTerms.getTerm(2021, 11, 22));
 
-		Assert.assertEquals("大雪", SolarTerms.getTerm(2021, 12, 7));
+		Assertions.assertEquals("大雪", SolarTerms.getTerm(2021, 12, 7));
 
-		Assert.assertEquals("冬至", SolarTerms.getTerm(2021, 12, 21));
+		Assertions.assertEquals("冬至", SolarTerms.getTerm(2021, 12, 21));
 	}
 
 
 	@Test
 	public void getTermByDateTest() {
-		Assert.assertEquals("春分", SolarTerms.getTerm(DateUtil.parseDate("2021-03-20")));
-		Assert.assertEquals("处暑", SolarTerms.getTerm(DateUtil.parseDate("2022-08-23")));
+		Assertions.assertEquals("春分", SolarTerms.getTerm(DateUtil.parseDate("2021-03-20")));
+		Assertions.assertEquals("处暑", SolarTerms.getTerm(DateUtil.parseDate("2022-08-23")));
 	}
 
 
 	@Test
 	public void getTermByChineseDateTest() {
-		Assert.assertEquals("清明", SolarTerms.getTerm(new ChineseDate(2021, 2, 23)));
-		Assert.assertEquals("秋分", SolarTerms.getTerm(new ChineseDate(2022, 8, 28)));
+		Assertions.assertEquals("清明", SolarTerms.getTerm(new ChineseDate(2021, 2, 23)));
+		Assertions.assertEquals("秋分", SolarTerms.getTerm(new ChineseDate(2022, 8, 28)));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/exceptions/CheckedUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/exceptions/CheckedUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.exceptions;
 
 import cn.hutool.core.lang.func.Func1;
 import cn.hutool.core.lang.func.VoidFunc0;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,7 +37,7 @@ public class CheckedUtilTest {
 			//本行代码原本需要抛出受检查异常，现在只抛出运行时异常
 			CheckedUtil.uncheck(() -> new FileInputStream(noFile)).call();
 		} catch (Exception re) {
-			Assert.assertTrue(re instanceof RuntimeException);
+			Assertions.assertTrue(re instanceof RuntimeException);
 		}
 
 	}
@@ -59,7 +59,7 @@ public class CheckedUtilTest {
 			//本行代码原本需要抛出受检查异常，现在只抛出运行时异常
 			CheckedUtil.uncheck(afunc).call("hello world");
 		} catch (Exception re) {
-			Assert.assertTrue(re instanceof RuntimeException);
+			Assertions.assertTrue(re instanceof RuntimeException);
 		}
 
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/exceptions/ExceptionUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/exceptions/ExceptionUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.exceptions;
 
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.io.IORuntimeException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -17,14 +17,14 @@ public class ExceptionUtilTest {
 	@Test
 	public void wrapTest() {
 		IORuntimeException e = ExceptionUtil.wrap(new IOException(), IORuntimeException.class);
-		Assert.assertNotNull(e);
+		Assertions.assertNotNull(e);
 	}
 
 	@Test
 	public void getRootTest() {
 		// 查找入口方法
 		StackTraceElement ele = ExceptionUtil.getRootStackElement();
-		Assert.assertEquals("main", ele.getMethodName());
+		Assertions.assertEquals("main", ele.getMethodName());
 	}
 
 	@Test
@@ -33,17 +33,17 @@ public class ExceptionUtilTest {
 		IOException ioException = new IOException();
 		IllegalArgumentException argumentException = new IllegalArgumentException(ioException);
 		IOException ioException1 = ExceptionUtil.convertFromOrSuppressedThrowable(argumentException, IOException.class, true);
-		Assert.assertNotNull(ioException1);
+		Assertions.assertNotNull(ioException1);
 	}
 
 	@Test
 	public void bytesIntConvertTest(){
 		final String s = Convert.toStr(12);
 		final int integer = Convert.toInt(s);
-		Assert.assertEquals(12, integer);
+		Assertions.assertEquals(12, integer);
 
 		final byte[] bytes = Convert.intToBytes(12);
 		final int i = Convert.bytesToInt(bytes);
-		Assert.assertEquals(12, i);
+		Assertions.assertEquals(12, i);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/img/FontUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/img/FontUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.img;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.awt.Font;
 
@@ -10,6 +10,6 @@ public class FontUtilTest {
 	@Test
 	public void createFontTest(){
 		final Font font = FontUtil.createFont();
-		Assert.assertNotNull(font);
+		Assertions.assertNotNull(font);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/img/ImgTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/img/ImgTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.img;
 import cn.hutool.core.io.FileTypeUtil;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.URLUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -15,32 +15,32 @@ import java.io.File;
 public class ImgTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void cutTest1() {
 		Img.from(FileUtil.file("e:/pic/face.jpg")).cut(0, 0, 200).write(FileUtil.file("e:/pic/face_radis.png"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void compressTest() {
 		Img.from(FileUtil.file("f:/test/4347273249269e3fb272341acc42d4e.jpg")).setQuality(0.8).write(FileUtil.file("f:/test/test_dest.jpg"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		final Img from = Img.from(FileUtil.file("d:/test/81898311-001d6100-95eb-11ea-83c2-a14d7b1010bd.png"));
 		ImgUtil.write(from.getImg(), FileUtil.file("d:/test/dest.jpg"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void roundTest() {
 		Img.from(FileUtil.file("e:/pic/face.jpg")).round(0.5).write(FileUtil.file("e:/pic/face_round.png"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pressTextTest() {
 		Img.from(FileUtil.file("d:/test/617180969474805871.jpg"))
 				.setPositionBaseCentre(false)
@@ -53,7 +53,7 @@ public class ImgTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pressImgTest() {
 		Img.from(FileUtil.file("d:/test/图片1.JPG"))
 				.pressImage(ImgUtil.read("d:/test/617180969474805871.jpg"), new Rectangle(0, 0, 800, 800), 1f)
@@ -61,7 +61,7 @@ public class ImgTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void strokeTest() {
 		Img.from(FileUtil.file("d:/test/公章3.png"))
 				.stroke(null, 2f)
@@ -72,7 +72,7 @@ public class ImgTest {
 	 * issue#I49FIU
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void scaleTest() {
 		String downloadFile = "d:/test/1435859438434136064.JPG";
 		File file = FileUtil.file(downloadFile);

--- a/hutool-core/src/test/java/cn/hutool/core/img/ImgUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/img/ImgUtilTest.java
@@ -1,9 +1,9 @@
 package cn.hutool.core.img;
 
 import cn.hutool.core.io.FileUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.imageio.ImageIO;
 import java.awt.Color;
@@ -19,13 +19,13 @@ import java.net.URL;
 public class ImgUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scaleTest() {
 		ImgUtil.scale(FileUtil.file("e:/pic/test.jpg"), FileUtil.file("e:/pic/test_result.jpg"), 0.8f);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scaleTest2() {
 		ImgUtil.scale(
 				FileUtil.file("d:/test/2.png"),
@@ -33,38 +33,38 @@ public class ImgUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scalePngTest() {
 		ImgUtil.scale(FileUtil.file("f:/test/test.png"), FileUtil.file("f:/test/test_result.png"), 0.5f);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scaleByWidthAndHeightTest() {
 		ImgUtil.scale(FileUtil.file("f:/test/aaa.jpg"), FileUtil.file("f:/test/aaa_result.jpg"), 100, 400, Color.BLUE);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void cutTest() {
 		ImgUtil.cut(FileUtil.file("d:/face.jpg"), FileUtil.file("d:/face_result.jpg"), new Rectangle(200, 200, 100, 100));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void rotateTest() throws IOException {
 		Image image = ImgUtil.rotate(ImageIO.read(FileUtil.file("e:/pic/366466.jpg")), 180);
 		ImgUtil.write(image, FileUtil.file("e:/pic/result.png"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void flipTest() {
 		ImgUtil.flip(FileUtil.file("d:/logo.png"), FileUtil.file("d:/result.png"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pressImgTest() {
 		ImgUtil.pressImage(
 				FileUtil.file("d:/test/1435859438434136064.jpg"),
@@ -73,7 +73,7 @@ public class ImgUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pressTextTest() {
 		ImgUtil.pressText(//
 				FileUtil.file("d:/test/2.jpg"), //
@@ -86,33 +86,33 @@ public class ImgUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sliceByRowsAndColsTest() {
 		ImgUtil.sliceByRowsAndCols(FileUtil.file("d:/test/logo.jpg"), FileUtil.file("d:/test/dest"), 1, 5);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void convertTest() {
 		ImgUtil.convert(FileUtil.file("e:/test2.png"), FileUtil.file("e:/test2Convert.jpg"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		final byte[] bytes = ImgUtil.toBytes(ImgUtil.read("d:/test/logo_484.png"), "png");
 		FileUtil.writeBytes(bytes, "d:/test/result.png");
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void compressTest() {
 		ImgUtil.compress(FileUtil.file("d:/test/dest.png"),
 				FileUtil.file("d:/test/1111_target.jpg"), 0.1f);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void copyTest() {
 		BufferedImage image = ImgUtil.copyImage(ImgUtil.read("f:/pic/test.png"), BufferedImage.TYPE_INT_RGB);
 		ImgUtil.write(image, FileUtil.file("f:/pic/test_dest.jpg"));
@@ -121,11 +121,11 @@ public class ImgUtilTest {
 	@Test
 	public void toHexTest(){
 		final String s = ImgUtil.toHex(Color.RED);
-		Assert.assertEquals("#FF0000", s);
+		Assertions.assertEquals("#FF0000", s);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void backgroundRemovalTest() {
 		// 图片 背景 换成 透明的
 		ImgUtil.backgroundRemoval(

--- a/hutool-core/src/test/java/cn/hutool/core/io/BufferUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/BufferUtilTest.java
@@ -2,15 +2,15 @@ package cn.hutool.core.io;
 
 import java.nio.ByteBuffer;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.StrUtil;
 
 /**
  * BufferUtil单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -22,7 +22,7 @@ public class BufferUtilTest {
 		ByteBuffer buffer = ByteBuffer.wrap(bytes);
 
 		ByteBuffer buffer2 = BufferUtil.copy(buffer, ByteBuffer.allocate(5));
-		Assert.assertEquals("AAABB", StrUtil.utf8Str(buffer2));
+		Assertions.assertEquals("AAABB", StrUtil.utf8Str(buffer2));
 	}
 
 	@Test
@@ -31,7 +31,7 @@ public class BufferUtilTest {
 		ByteBuffer buffer = ByteBuffer.wrap(bytes);
 
 		byte[] bs = BufferUtil.readBytes(buffer, 5);
-		Assert.assertEquals("AAABB", StrUtil.utf8Str(bs));
+		Assertions.assertEquals("AAABB", StrUtil.utf8Str(bs));
 	}
 
 	@Test
@@ -40,7 +40,7 @@ public class BufferUtilTest {
 		ByteBuffer buffer = ByteBuffer.wrap(bytes);
 
 		byte[] bs = BufferUtil.readBytes(buffer, 5);
-		Assert.assertEquals("AAABB", StrUtil.utf8Str(bs));
+		Assertions.assertEquals("AAABB", StrUtil.utf8Str(bs));
 	}
 
 	@Test
@@ -50,17 +50,17 @@ public class BufferUtilTest {
 
 		// 第一行
 		String line = BufferUtil.readLine(buffer, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("aa", line);
+		Assertions.assertEquals("aa", line);
 
 		// 第二行
 		line = BufferUtil.readLine(buffer, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("bbb", line);
+		Assertions.assertEquals("bbb", line);
 
 		// 第三行因为没有行结束标志，因此返回null
 		line = BufferUtil.readLine(buffer, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertNull(line);
+		Assertions.assertNull(line);
 
 		// 读取剩余部分
-		Assert.assertEquals("cc", StrUtil.utf8Str(BufferUtil.readBytes(buffer)));
+		Assertions.assertEquals("cc", StrUtil.utf8Str(BufferUtil.readBytes(buffer)));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/CharsetDetectorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/CharsetDetectorTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.io;
 
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 
@@ -14,6 +14,6 @@ public class CharsetDetectorTest {
 		// 测试多个Charset对同一个流的处理是否有问题
 		final Charset detect = CharsetDetector.detect(ResourceUtil.getStream("test.xml"),
 				CharsetUtil.CHARSET_GBK, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(CharsetUtil.CHARSET_UTF_8, detect);
+		Assertions.assertEquals(CharsetUtil.CHARSET_UTF_8, detect);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/ClassPathResourceTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/ClassPathResourceTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.io;
 
 import cn.hutool.core.io.resource.ClassPathResource;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -19,7 +19,7 @@ public class ClassPathResourceTest {
 	public void readStringTest() {
 		ClassPathResource resource = new ClassPathResource("test.properties");
 		String content = resource.readUtf8Str();
-		Assert.assertTrue(StrUtil.isNotEmpty(content));
+		Assertions.assertTrue(StrUtil.isNotEmpty(content));
 	}
 
 	@Test
@@ -27,7 +27,7 @@ public class ClassPathResourceTest {
 		// 读取classpath根目录测试
 		ClassPathResource resource = new ClassPathResource("/");
 		String content = resource.readUtf8Str();
-		Assert.assertTrue(StrUtil.isNotEmpty(content));
+		Assertions.assertTrue(StrUtil.isNotEmpty(content));
 	}
 
 	@Test
@@ -36,8 +36,8 @@ public class ClassPathResourceTest {
 		Properties properties = new Properties();
 		properties.load(resource.getStream());
 
-		Assert.assertEquals("1", properties.get("a"));
-		Assert.assertEquals("2", properties.get("b"));
+		Assertions.assertEquals("1", properties.get("a"));
+		Assertions.assertEquals("2", properties.get("b"));
 	}
 
 	@Test
@@ -46,17 +46,17 @@ public class ClassPathResourceTest {
 		final ClassPathResource resource = new ClassPathResource("LICENSE-junit.txt");
 
 		String result = resource.readUtf8Str();
-		Assert.assertNotNull(result);
+		Assertions.assertNotNull(result);
 
 		//二次读取测试，用于测试关闭流对再次读取的影响
 		result = resource.readUtf8Str();
-		Assert.assertNotNull(result);
+		Assertions.assertNotNull(result);
 	}
 
 	@Test
 	public void getAbsTest() {
 		final ClassPathResource resource = new ClassPathResource("LICENSE-junit.txt");
 		String absPath = resource.getAbsolutePath();
-		Assert.assertTrue(absPath.contains("LICENSE-junit.txt"));
+		Assertions.assertTrue(absPath.contains("LICENSE-junit.txt"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileCopierTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileCopierTest.java
@@ -1,7 +1,8 @@
 package cn.hutool.core.io;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.file.FileCopier;
 
@@ -11,33 +12,35 @@ import cn.hutool.core.io.file.FileCopier;
  *
  */
 public class FileCopierTest {
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void dirCopyTest() {
 		FileCopier copier = FileCopier.create("D:\\Java", "e:/eclipse/eclipse2.zip");
 		copier.copy();
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void dirCopyTest2() {
 		//测试带.的文件夹复制
 		FileCopier copier = FileCopier.create("D:\\workspace\\java\\.metadata", "D:\\workspace\\java\\.metadata\\temp");
 		copier.copy();
-		
+
 		FileUtil.copy("D:\\workspace\\java\\looly\\hutool\\.git", "D:\\workspace\\java\\temp", true);
 	}
-	
-	@Test(expected = IORuntimeException.class)
-	public void dirCopySubTest() {
-		//测试父目录复制到子目录报错
-		FileCopier copier = FileCopier.create("D:\\workspace\\java\\.metadata", "D:\\workspace\\java\\.metadata\\temp");
-		copier.copy();
-	}
-	
+
 	@Test
-	@Ignore
+	public void dirCopySubTest() {
+		Assertions.assertThrows(IORuntimeException.class, () -> {
+			//测试父目录复制到子目录报错
+			FileCopier copier = FileCopier.create("D:\\workspace\\java\\.metadata", "D:\\workspace\\java\\.metadata\\temp");
+			copier.copy();
+		});
+	}
+
+	@Test
+	@Disabled
 	public void copyFileToDirTest() {
 		FileCopier copier = FileCopier.create("d:/GReen_Soft/XshellXftpPortable.zip", "c:/hp/");
 		copier.copy();

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileReaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileReaderTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.io;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.file.FileReader;
 
@@ -11,11 +11,11 @@ import cn.hutool.core.io.file.FileReader;
  *
  */
 public class FileReaderTest {
-	
+
 	@Test
 	public void fileReaderTest(){
 		FileReader fileReader = new FileReader("test.properties");
 		String result = fileReader.readString();
-		Assert.assertNotNull(result);
+		Assertions.assertNotNull(result);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileTypeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileTypeUtilTest.java
@@ -1,9 +1,9 @@
 package cn.hutool.core.io;
 
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -15,19 +15,19 @@ import java.io.File;
 public class FileTypeUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void fileTypeUtilTest() {
 		File file = FileUtil.file("hutool.jpg");
 		String type = FileTypeUtil.getType(file);
-		Assert.assertEquals("jpg", type);
+		Assertions.assertEquals("jpg", type);
 
 		FileTypeUtil.putFileType("ffd8ffe000104a464946", "new_jpg");
 		String newType = FileTypeUtil.getType(file);
-		Assert.assertEquals("new_jpg", newType);
+		Assertions.assertEquals("new_jpg", newType);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void emptyTest() {
 		File file = FileUtil.file("d:/empty.txt");
 		String type = FileTypeUtil.getType(file);
@@ -35,7 +35,7 @@ public class FileTypeUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void docTest() {
 		File file = FileUtil.file("f:/test/test.doc");
 		String type = FileTypeUtil.getType(file);
@@ -43,23 +43,23 @@ public class FileTypeUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void ofdTest() {
 		File file = FileUtil.file("e:/test.ofd");
 		String hex = IoUtil.readHex28Upper(FileUtil.getInputStream(file));
 		Console.log(hex);
 		String type = FileTypeUtil.getType(file);
 		Console.log(type);
-		Assert.assertEquals("ofd", type);
+		Assertions.assertEquals("ofd", type);
 	}
 
 
 	@Test
-	@Ignore
+	@Disabled
 	public void inputStreamAndFilenameTest() {
 		File file = FileUtil.file("e:/laboratory/test.xlsx");
 		String type = FileTypeUtil.getType(file);
-		Assert.assertEquals("xlsx", type);
+		Assertions.assertEquals("xlsx", type);
 	}
 
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileUtilTest.java
@@ -3,9 +3,9 @@ package cn.hutool.core.io;
 import cn.hutool.core.io.file.LineSeparator;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -19,62 +19,64 @@ import java.util.List;
  */
 public class FileUtilTest {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void fileTest() {
-		File file = FileUtil.file("d:/aaa", "bbb");
-		Assert.assertNotNull(file);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			File file = FileUtil.file("d:/aaa", "bbb");
+			Assertions.assertNotNull(file);
 
-		// 构建目录中出现非子目录抛出异常
-		FileUtil.file(file, "../ccc");
+			// 构建目录中出现非子目录抛出异常
+			FileUtil.file(file, "../ccc");
 
-		FileUtil.file("E:/");
+			FileUtil.file("E:/");
+		});
 	}
 
 	@Test
 	public void getAbsolutePathTest() {
 		String absolutePath = FileUtil.getAbsolutePath("LICENSE-junit.txt");
-		Assert.assertNotNull(absolutePath);
+		Assertions.assertNotNull(absolutePath);
 		String absolutePath2 = FileUtil.getAbsolutePath(absolutePath);
-		Assert.assertNotNull(absolutePath2);
-		Assert.assertEquals(absolutePath, absolutePath2);
+		Assertions.assertNotNull(absolutePath2);
+		Assertions.assertEquals(absolutePath, absolutePath2);
 
 		String path = FileUtil.getAbsolutePath("中文.xml");
-		Assert.assertTrue(path.contains("中文.xml"));
+		Assertions.assertTrue(path.contains("中文.xml"));
 
 		path = FileUtil.getAbsolutePath("d:");
-		Assert.assertEquals("d:", path);
+		Assertions.assertEquals("d:", path);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void touchTest() {
 		FileUtil.touch("d:\\tea\\a.jpg");
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void delTest() {
 		// 删除一个不存在的文件，应返回true
 		boolean result = FileUtil.del("e:/Hutool_test_3434543533409843.txt");
-		Assert.assertTrue(result);
+		Assertions.assertTrue(result);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void delTest2() {
 		// 删除一个不存在的文件，应返回true
 		boolean result = FileUtil.del(Paths.get("e:/Hutool_test_3434543533409843.txt"));
-		Assert.assertTrue(result);
+		Assertions.assertTrue(result);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void renameTest() {
 		FileUtil.rename(FileUtil.file("d:/test/3.jpg"), "2.jpg", false);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void renameTest2() {
 		FileUtil.move(FileUtil.file("d:/test/a"), FileUtil.file("d:/test/b"), false);
 	}
@@ -86,12 +88,12 @@ public class FileUtilTest {
 
 		FileUtil.copy(srcFile, destFile, true);
 
-		Assert.assertTrue(destFile.exists());
-		Assert.assertEquals(srcFile.length(), destFile.length());
+		Assertions.assertTrue(destFile.exists());
+		Assertions.assertEquals(srcFile.length(), destFile.length());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void copyFilesFromDirTest() {
 		File srcFile = FileUtil.file("D:\\驱动");
 		File destFile = FileUtil.file("d:\\驱动备份");
@@ -100,7 +102,7 @@ public class FileUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void copyDirTest() {
 		File srcFile = FileUtil.file("D:\\test");
 		File destFile = FileUtil.file("E:\\");
@@ -109,7 +111,7 @@ public class FileUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void moveDirTest() {
 		File srcFile = FileUtil.file("E:\\test2");
 		File destFile = FileUtil.file("D:\\");
@@ -124,79 +126,79 @@ public class FileUtilTest {
 		File destFile = FileUtil.file("d:/hutool.jpg");
 
 		boolean equals = FileUtil.equals(srcFile, destFile);
-		Assert.assertTrue(equals);
+		Assertions.assertTrue(equals);
 
 		// 源文件存在，目标文件不存在
 		File srcFile1 = FileUtil.file("hutool.jpg");
 		File destFile1 = FileUtil.file("d:/hutool.jpg");
 
 		boolean notEquals = FileUtil.equals(srcFile1, destFile1);
-		Assert.assertFalse(notEquals);
+		Assertions.assertFalse(notEquals);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void convertLineSeparatorTest() {
 		FileUtil.convertLineSeparator(FileUtil.file("d:/aaa.txt"), CharsetUtil.CHARSET_UTF_8, LineSeparator.WINDOWS);
 	}
 
 	@Test
 	public void normalizeTest() {
-		Assert.assertEquals("/foo/", FileUtil.normalize("/foo//"));
-		Assert.assertEquals("/foo/", FileUtil.normalize("/foo/./"));
-		Assert.assertEquals("/bar", FileUtil.normalize("/foo/../bar"));
-		Assert.assertEquals("/bar/", FileUtil.normalize("/foo/../bar/"));
-		Assert.assertEquals("/baz", FileUtil.normalize("/foo/../bar/../baz"));
-		Assert.assertEquals("/", FileUtil.normalize("/../"));
-		Assert.assertEquals("foo", FileUtil.normalize("foo/bar/.."));
-		Assert.assertEquals("../bar", FileUtil.normalize("foo/../../bar"));
-		Assert.assertEquals("bar", FileUtil.normalize("foo/../bar"));
-		Assert.assertEquals("/server/bar", FileUtil.normalize("//server/foo/../bar"));
-		Assert.assertEquals("/bar", FileUtil.normalize("//server/../bar"));
-		Assert.assertEquals("C:/bar", FileUtil.normalize("C:\\foo\\..\\bar"));
+		Assertions.assertEquals("/foo/", FileUtil.normalize("/foo//"));
+		Assertions.assertEquals("/foo/", FileUtil.normalize("/foo/./"));
+		Assertions.assertEquals("/bar", FileUtil.normalize("/foo/../bar"));
+		Assertions.assertEquals("/bar/", FileUtil.normalize("/foo/../bar/"));
+		Assertions.assertEquals("/baz", FileUtil.normalize("/foo/../bar/../baz"));
+		Assertions.assertEquals("/", FileUtil.normalize("/../"));
+		Assertions.assertEquals("foo", FileUtil.normalize("foo/bar/.."));
+		Assertions.assertEquals("../bar", FileUtil.normalize("foo/../../bar"));
+		Assertions.assertEquals("bar", FileUtil.normalize("foo/../bar"));
+		Assertions.assertEquals("/server/bar", FileUtil.normalize("//server/foo/../bar"));
+		Assertions.assertEquals("/bar", FileUtil.normalize("//server/../bar"));
+		Assertions.assertEquals("C:/bar", FileUtil.normalize("C:\\foo\\..\\bar"));
 		//
-		Assert.assertEquals("C:/bar", FileUtil.normalize("C:\\..\\bar"));
-		Assert.assertEquals("../../bar", FileUtil.normalize("../../bar"));
-		Assert.assertEquals("C:/bar", FileUtil.normalize("/C:/bar"));
-		Assert.assertEquals("C:", FileUtil.normalize("C:"));
-		Assert.assertEquals("\\/192.168.1.1/Share/", FileUtil.normalize("\\\\192.168.1.1\\Share\\"));
+		Assertions.assertEquals("C:/bar", FileUtil.normalize("C:\\..\\bar"));
+		Assertions.assertEquals("../../bar", FileUtil.normalize("../../bar"));
+		Assertions.assertEquals("C:/bar", FileUtil.normalize("/C:/bar"));
+		Assertions.assertEquals("C:", FileUtil.normalize("C:"));
+		Assertions.assertEquals("\\/192.168.1.1/Share/", FileUtil.normalize("\\\\192.168.1.1\\Share\\"));
 	}
 
 	@Test
 	public void normalizeBlankTest() {
-		Assert.assertEquals("C:/aaa ", FileUtil.normalize("C:\\aaa "));
+		Assertions.assertEquals("C:/aaa ", FileUtil.normalize("C:\\aaa "));
 	}
 
 	@Test
 	public void normalizeHomePathTest() {
 		String home = FileUtil.getUserHomePath().replace('\\', '/');
-		Assert.assertEquals(home + "/bar/", FileUtil.normalize("~/foo/../bar/"));
+		Assertions.assertEquals(home + "/bar/", FileUtil.normalize("~/foo/../bar/"));
 	}
 
 	@Test
 	public void normalizeHomePathTest2() {
 		String home = FileUtil.getUserHomePath().replace('\\', '/');
 		// 多个~应该只替换开头的
-		Assert.assertEquals(home + "/~bar/", FileUtil.normalize("~/foo/../~bar/"));
+		Assertions.assertEquals(home + "/~bar/", FileUtil.normalize("~/foo/../~bar/"));
 	}
 
 	@Test
 	public void normalizeClassPathTest() {
-		Assert.assertEquals("", FileUtil.normalize("classpath:"));
+		Assertions.assertEquals("", FileUtil.normalize("classpath:"));
 	}
 
 	@Test
 	public void normalizeClassPathTest2() {
-		Assert.assertEquals("../a/b.csv", FileUtil.normalize("../a/b.csv"));
-		Assert.assertEquals("../../../a/b.csv", FileUtil.normalize("../../../a/b.csv"));
+		Assertions.assertEquals("../a/b.csv", FileUtil.normalize("../a/b.csv"));
+		Assertions.assertEquals("../../../a/b.csv", FileUtil.normalize("../../../a/b.csv"));
 	}
 
 	@Test
 	public void doubleNormalizeTest() {
 		String normalize = FileUtil.normalize("/aa/b:/c");
 		String normalize2 = FileUtil.normalize(normalize);
-		Assert.assertEquals("/aa/b:/c", normalize);
-		Assert.assertEquals(normalize, normalize2);
+		Assertions.assertEquals("/aa/b:/c", normalize);
+		Assertions.assertEquals(normalize, normalize2);
 	}
 
 	@Test
@@ -204,45 +206,45 @@ public class FileUtilTest {
 		Path path = Paths.get("/aaa/bbb/ccc/ddd/eee/fff");
 
 		Path subPath = FileUtil.subPath(path, 5, 4);
-		Assert.assertEquals("eee", subPath.toString());
+		Assertions.assertEquals("eee", subPath.toString());
 		subPath = FileUtil.subPath(path, 0, 1);
-		Assert.assertEquals("aaa", subPath.toString());
+		Assertions.assertEquals("aaa", subPath.toString());
 		subPath = FileUtil.subPath(path, 1, 0);
-		Assert.assertEquals("aaa", subPath.toString());
+		Assertions.assertEquals("aaa", subPath.toString());
 
 		// 负数
 		subPath = FileUtil.subPath(path, -1, 0);
-		Assert.assertEquals("aaa/bbb/ccc/ddd/eee", subPath.toString().replace('\\', '/'));
+		Assertions.assertEquals("aaa/bbb/ccc/ddd/eee", subPath.toString().replace('\\', '/'));
 		subPath = FileUtil.subPath(path, -1, Integer.MAX_VALUE);
-		Assert.assertEquals("fff", subPath.toString());
+		Assertions.assertEquals("fff", subPath.toString());
 		subPath = FileUtil.subPath(path, -1, path.getNameCount());
-		Assert.assertEquals("fff", subPath.toString());
+		Assertions.assertEquals("fff", subPath.toString());
 		subPath = FileUtil.subPath(path, -2, -3);
-		Assert.assertEquals("ddd", subPath.toString());
+		Assertions.assertEquals("ddd", subPath.toString());
 	}
 
 	@Test
 	public void subPathTest2() {
 		String subPath = FileUtil.subPath("d:/aaa/bbb/", "d:/aaa/bbb/ccc/");
-		Assert.assertEquals("ccc/", subPath);
+		Assertions.assertEquals("ccc/", subPath);
 
 		subPath = FileUtil.subPath("d:/aaa/bbb", "d:/aaa/bbb/ccc/");
-		Assert.assertEquals("ccc/", subPath);
+		Assertions.assertEquals("ccc/", subPath);
 
 		subPath = FileUtil.subPath("d:/aaa/bbb", "d:/aaa/bbb/ccc/test.txt");
-		Assert.assertEquals("ccc/test.txt", subPath);
+		Assertions.assertEquals("ccc/test.txt", subPath);
 
 		subPath = FileUtil.subPath("d:/aaa/bbb/", "d:/aaa/bbb/ccc");
-		Assert.assertEquals("ccc", subPath);
+		Assertions.assertEquals("ccc", subPath);
 
 		subPath = FileUtil.subPath("d:/aaa/bbb", "d:/aaa/bbb/ccc");
-		Assert.assertEquals("ccc", subPath);
+		Assertions.assertEquals("ccc", subPath);
 
 		subPath = FileUtil.subPath("d:/aaa/bbb", "d:/aaa/bbb");
-		Assert.assertEquals("", subPath);
+		Assertions.assertEquals("", subPath);
 
 		subPath = FileUtil.subPath("d:/aaa/bbb/", "d:/aaa/bbb");
-		Assert.assertEquals("", subPath);
+		Assertions.assertEquals("", subPath);
 	}
 
 	@Test
@@ -250,29 +252,29 @@ public class FileUtilTest {
 		Path path = Paths.get("/aaa/bbb/ccc/ddd/eee/fff");
 
 		Path ele = FileUtil.getPathEle(path, -1);
-		Assert.assertEquals("fff", ele.toString());
+		Assertions.assertEquals("fff", ele.toString());
 		ele = FileUtil.getPathEle(path, 0);
-		Assert.assertEquals("aaa", ele.toString());
+		Assertions.assertEquals("aaa", ele.toString());
 		ele = FileUtil.getPathEle(path, -5);
-		Assert.assertEquals("bbb", ele.toString());
+		Assertions.assertEquals("bbb", ele.toString());
 		ele = FileUtil.getPathEle(path, -6);
-		Assert.assertEquals("aaa", ele.toString());
+		Assertions.assertEquals("aaa", ele.toString());
 	}
 
 	@Test
 	public void listFileNamesTest() {
 		List<String> names = FileUtil.listFileNames("classpath:");
-		Assert.assertTrue(names.contains("hutool.jpg"));
+		Assertions.assertTrue(names.contains("hutool.jpg"));
 
 		names = FileUtil.listFileNames("");
-		Assert.assertTrue(names.contains("hutool.jpg"));
+		Assertions.assertTrue(names.contains("hutool.jpg"));
 
 		names = FileUtil.listFileNames(".");
-		Assert.assertTrue(names.contains("hutool.jpg"));
+		Assertions.assertTrue(names.contains("hutool.jpg"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void listFileNamesInJarTest() {
 		List<String> names = FileUtil.listFileNames("d:/test/hutool-core-5.1.0.jar!/cn/hutool/core/util ");
 		for (String name : names) {
@@ -281,7 +283,7 @@ public class FileUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void listFileNamesTest2() {
 		List<String> names = FileUtil.listFileNames("D:\\m2_repo\\commons-cli\\commons-cli\\1.0\\commons-cli-1.0.jar!org/apache/commons/cli/");
 		for (String string : names) {
@@ -290,7 +292,7 @@ public class FileUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void loopFilesTest() {
 		List<File> files = FileUtil.loopFiles("d:/");
 		for (File file : files) {
@@ -299,13 +301,13 @@ public class FileUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void loopFilesTest2() {
 		FileUtil.loopFiles("").forEach(Console::log);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void loopFilesWithDepthTest() {
 		List<File> files = FileUtil.loopFiles(FileUtil.file("d:/m2_repo"), 2, null);
 		for (File file : files) {
@@ -318,22 +320,22 @@ public class FileUtilTest {
 		// 只在Windows下测试
 		if (FileUtil.isWindows()) {
 			File parent = FileUtil.getParent(FileUtil.file("d:/aaa/bbb/cc/ddd"), 0);
-			Assert.assertEquals(FileUtil.file("d:\\aaa\\bbb\\cc\\ddd"), parent);
+			Assertions.assertEquals(FileUtil.file("d:\\aaa\\bbb\\cc\\ddd"), parent);
 
 			parent = FileUtil.getParent(FileUtil.file("d:/aaa/bbb/cc/ddd"), 1);
-			Assert.assertEquals(FileUtil.file("d:\\aaa\\bbb\\cc"), parent);
+			Assertions.assertEquals(FileUtil.file("d:\\aaa\\bbb\\cc"), parent);
 
 			parent = FileUtil.getParent(FileUtil.file("d:/aaa/bbb/cc/ddd"), 2);
-			Assert.assertEquals(FileUtil.file("d:\\aaa\\bbb"), parent);
+			Assertions.assertEquals(FileUtil.file("d:\\aaa\\bbb"), parent);
 
 			parent = FileUtil.getParent(FileUtil.file("d:/aaa/bbb/cc/ddd"), 4);
-			Assert.assertEquals(FileUtil.file("d:\\"), parent);
+			Assertions.assertEquals(FileUtil.file("d:\\"), parent);
 
 			parent = FileUtil.getParent(FileUtil.file("d:/aaa/bbb/cc/ddd"), 5);
-			Assert.assertNull(parent);
+			Assertions.assertNull(parent);
 
 			parent = FileUtil.getParent(FileUtil.file("d:/aaa/bbb/cc/ddd"), 10);
-			Assert.assertNull(parent);
+			Assertions.assertNull(parent);
 		}
 	}
 
@@ -341,107 +343,107 @@ public class FileUtilTest {
 	public void lastIndexOfSeparatorTest() {
 		String dir = "d:\\aaa\\bbb\\cc\\ddd";
 		int index = FileUtil.lastIndexOfSeparator(dir);
-		Assert.assertEquals(13, index);
+		Assertions.assertEquals(13, index);
 
 		String file = "ddd.jpg";
 		int index2 = FileUtil.lastIndexOfSeparator(file);
-		Assert.assertEquals(-1, index2);
+		Assertions.assertEquals(-1, index2);
 	}
 
 	@Test
 	public void getNameTest() {
 		String path = "d:\\aaa\\bbb\\cc\\ddd\\";
 		String name = FileUtil.getName(path);
-		Assert.assertEquals("ddd", name);
+		Assertions.assertEquals("ddd", name);
 
 		path = "d:\\aaa\\bbb\\cc\\ddd.jpg";
 		name = FileUtil.getName(path);
-		Assert.assertEquals("ddd.jpg", name);
+		Assertions.assertEquals("ddd.jpg", name);
 	}
 
 	@Test
 	public void mainNameTest() {
 		String path = "d:\\aaa\\bbb\\cc\\ddd\\";
 		String mainName = FileUtil.mainName(path);
-		Assert.assertEquals("ddd", mainName);
+		Assertions.assertEquals("ddd", mainName);
 
 		path = "d:\\aaa\\bbb\\cc\\ddd";
 		mainName = FileUtil.mainName(path);
-		Assert.assertEquals("ddd", mainName);
+		Assertions.assertEquals("ddd", mainName);
 
 		path = "d:\\aaa\\bbb\\cc\\ddd.jpg";
 		mainName = FileUtil.mainName(path);
-		Assert.assertEquals("ddd", mainName);
+		Assertions.assertEquals("ddd", mainName);
 	}
 
 	@Test
 	public void extNameTest() {
 		String path =  FileUtil.isWindows() ? "d:\\aaa\\bbb\\cc\\ddd\\" : "~/Desktop/hutool/ddd/";
 		String mainName = FileUtil.extName(path);
-		Assert.assertEquals("", mainName);
+		Assertions.assertEquals("", mainName);
 
 		path =  FileUtil.isWindows() ? "d:\\aaa\\bbb\\cc\\ddd" : "~/Desktop/hutool/ddd";
 		mainName = FileUtil.extName(path);
-		Assert.assertEquals("", mainName);
+		Assertions.assertEquals("", mainName);
 
 		path = FileUtil.isWindows() ? "d:\\aaa\\bbb\\cc\\ddd.jpg" : "~/Desktop/hutool/ddd.jpg";
 		mainName = FileUtil.extName(path);
-		Assert.assertEquals("jpg", mainName);
+		Assertions.assertEquals("jpg", mainName);
 
 		path = FileUtil.isWindows() ? "d:\\aaa\\bbb\\cc\\fff.xlsx" : "~/Desktop/hutool/fff.xlsx";
 		mainName = FileUtil.extName(path);
-		Assert.assertEquals("xlsx", mainName);
+		Assertions.assertEquals("xlsx", mainName);
 	}
 
 	@Test
 	public void getWebRootTest() {
 		File webRoot = FileUtil.getWebRoot();
-		Assert.assertNotNull(webRoot);
-		Assert.assertEquals("hutool-core", webRoot.getName());
+		Assertions.assertNotNull(webRoot);
+		Assertions.assertEquals("hutool-core", webRoot.getName());
 	}
 
 	@Test
 	public void getMimeTypeTest() {
 		String mimeType = FileUtil.getMimeType("test2Write.jpg");
-		Assert.assertEquals("image/jpeg", mimeType);
+		Assertions.assertEquals("image/jpeg", mimeType);
 
 		mimeType = FileUtil.getMimeType("test2Write.html");
-		Assert.assertEquals("text/html", mimeType);
+		Assertions.assertEquals("text/html", mimeType);
 
 		mimeType = FileUtil.getMimeType("main.css");
-		Assert.assertEquals("text/css", mimeType);
+		Assertions.assertEquals("text/css", mimeType);
 
 		mimeType = FileUtil.getMimeType("test.js");
-		Assert.assertEquals("application/x-javascript", mimeType);
+		Assertions.assertEquals("application/x-javascript", mimeType);
 
 		// office03
 		mimeType = FileUtil.getMimeType("test.doc");
-		Assert.assertEquals("application/msword", mimeType);
+		Assertions.assertEquals("application/msword", mimeType);
 		mimeType = FileUtil.getMimeType("test.xls");
-		Assert.assertEquals("application/vnd.ms-excel", mimeType);
+		Assertions.assertEquals("application/vnd.ms-excel", mimeType);
 		mimeType = FileUtil.getMimeType("test.ppt");
-		Assert.assertEquals("application/vnd.ms-powerpoint", mimeType);
+		Assertions.assertEquals("application/vnd.ms-powerpoint", mimeType);
 
 		// office07+
 		mimeType = FileUtil.getMimeType("test.docx");
-		Assert.assertEquals("application/vnd.openxmlformats-officedocument.wordprocessingml.document", mimeType);
+		Assertions.assertEquals("application/vnd.openxmlformats-officedocument.wordprocessingml.document", mimeType);
 		mimeType = FileUtil.getMimeType("test.xlsx");
-		Assert.assertEquals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", mimeType);
+		Assertions.assertEquals("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", mimeType);
 		mimeType = FileUtil.getMimeType("test.pptx");
-		Assert.assertEquals("application/vnd.openxmlformats-officedocument.presentationml.presentation", mimeType);
+		Assertions.assertEquals("application/vnd.openxmlformats-officedocument.presentationml.presentation", mimeType);
 	}
 
 	@Test
 	public void isSubTest() {
 		File file = new File("d:/test");
 		File file2 = new File("d:/test2/aaa");
-		Assert.assertFalse(FileUtil.isSub(file, file2));
+		Assertions.assertFalse(FileUtil.isSub(file, file2));
 	}
 
 	@Test
 	public void isSubRelativeTest() {
 		File file = new File("..");
 		File file2 = new File(".");
-		Assert.assertTrue(FileUtil.isSub(file, file2));
+		Assertions.assertTrue(FileUtil.isSub(file, file2));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/IoUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/IoUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.io;
 
 import cn.hutool.core.io.resource.ResourceUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -12,13 +12,13 @@ public class IoUtilTest {
 	@Test
 	public void readBytesTest(){
 		final byte[] bytes = IoUtil.readBytes(ResourceUtil.getStream("hutool.jpg"));
-		Assert.assertEquals(22807, bytes.length);
+		Assertions.assertEquals(22807, bytes.length);
 	}
 
 	@Test
 	public void readLinesTest(){
 		try(BufferedReader reader = ResourceUtil.getUtf8Reader("test_lines.csv");){
-			IoUtil.readLines(reader, (LineHandler) Assert::assertNotNull);
+			IoUtil.readLines(reader, (LineHandler) Assertions::assertNotNull);
 		} catch (IOException e) {
 			throw new IORuntimeException(e);
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/io/ManifestUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/ManifestUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.io;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.jar.Manifest;
 
@@ -10,6 +10,6 @@ public class ManifestUtilTest {
 	@Test
 	public void getManiFestTest(){
 		final Manifest manifest = ManifestUtil.getManifest(Test.class);
-		Assert.assertNotNull(manifest);
+		Assertions.assertNotNull(manifest);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/checksum/CRC16Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/checksum/CRC16Test.java
@@ -10,8 +10,8 @@ import cn.hutool.core.io.checksum.crc16.CRC16Modbus;
 import cn.hutool.core.io.checksum.crc16.CRC16USB;
 import cn.hutool.core.io.checksum.crc16.CRC16X25;
 import cn.hutool.core.io.checksum.crc16.CRC16XModem;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CRC16Test {
 
@@ -21,74 +21,74 @@ public class CRC16Test {
 	public void ccittTest(){
 		final CRC16CCITT crc16 = new CRC16CCITT();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("c852", crc16.getHexValue());
+		Assertions.assertEquals("c852", crc16.getHexValue());
 	}
 
 	@Test
 	public void ccittFalseTest(){
 		final CRC16CCITTFalse crc16 = new CRC16CCITTFalse();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("a5e4", crc16.getHexValue());
+		Assertions.assertEquals("a5e4", crc16.getHexValue());
 	}
 
 	@Test
 	public void xmodemTest(){
 		final CRC16XModem crc16 = new CRC16XModem();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("5a8d", crc16.getHexValue());
+		Assertions.assertEquals("5a8d", crc16.getHexValue());
 	}
 
 	@Test
 	public void x25Test(){
 		final CRC16X25 crc16 = new CRC16X25();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("a152", crc16.getHexValue());
+		Assertions.assertEquals("a152", crc16.getHexValue());
 	}
 
 	@Test
 	public void modbusTest(){
 		final CRC16Modbus crc16 = new CRC16Modbus();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("25fb", crc16.getHexValue());
+		Assertions.assertEquals("25fb", crc16.getHexValue());
 	}
 
 	@Test
 	public void ibmTest(){
 		final CRC16IBM crc16 = new CRC16IBM();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("18c", crc16.getHexValue());
+		Assertions.assertEquals("18c", crc16.getHexValue());
 	}
 
 	@Test
 	public void maximTest(){
 		final CRC16Maxim crc16 = new CRC16Maxim();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("fe73", crc16.getHexValue());
+		Assertions.assertEquals("fe73", crc16.getHexValue());
 	}
 
 	@Test
 	public void usbTest(){
 		final CRC16USB crc16 = new CRC16USB();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("da04", crc16.getHexValue());
+		Assertions.assertEquals("da04", crc16.getHexValue());
 	}
 
 	@Test
 	public void dnpTest(){
 		final CRC16DNP crc16 = new CRC16DNP();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("3d1a", crc16.getHexValue());
+		Assertions.assertEquals("3d1a", crc16.getHexValue());
 	}
 
 	@Test
 	public void ansiTest(){
 		final CRC16Ansi crc16 = new CRC16Ansi();
 		crc16.update(data.getBytes());
-		Assert.assertEquals("1e00", crc16.getHexValue());
+		Assertions.assertEquals("1e00", crc16.getHexValue());
 
 		crc16.reset();
 		String str2 = "QN=20160801085857223;ST=32;CN=1062;PW=100000;MN=010000A8900016F000169DC0;Flag=5;CP=&&RtdInterval=30&&";
 		crc16.update(str2.getBytes());
-		Assert.assertEquals("1c80", crc16.getHexValue());
+		Assertions.assertEquals("1c80", crc16.getHexValue());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/checksum/CrcTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/checksum/CrcTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.io.checksum;
 import cn.hutool.core.io.checksum.crc16.CRC16XModem;
 import cn.hutool.core.util.HexUtil;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * CRC校验单元测试
@@ -23,7 +23,7 @@ public class CrcTest {
 				-46, -128, 4, 48, 52, 0, 0, 0, 0, 0, 0, 0, 0, 4, 1, 1, -32, -80, 0, 98, -5, 71, 0, 64, 0, 0, 0, 0, -116, 1, 104, 2 };
 		CRC8 crc8 = new CRC8(CRC_POLYNOM, CRC_INITIAL);
 		crc8.update(data, 0, data.length);
-		Assert.assertEquals(29, crc8.getValue());
+		Assertions.assertEquals(29, crc8.getValue());
 	}
 
 	@Test
@@ -31,7 +31,7 @@ public class CrcTest {
 		CRC16 crc = new CRC16();
 		crc.update(12);
 		crc.update(16);
-		Assert.assertEquals("cc04", HexUtil.toHex(crc.getValue()));
+		Assertions.assertEquals("cc04", HexUtil.toHex(crc.getValue()));
 	}
 
 	@Test
@@ -40,7 +40,7 @@ public class CrcTest {
 		CRC16 crc = new CRC16();
 		crc.update(str.getBytes(), 0, str.getBytes().length);
 		String crc16 = HexUtil.toHex(crc.getValue());
-		Assert.assertEquals("18c", crc16);
+		Assertions.assertEquals("18c", crc16);
 	}
 
 	@Test
@@ -50,6 +50,6 @@ public class CrcTest {
 		CRC16XModem crc16 = new CRC16XModem();
 		crc16.update(StrUtil.bytes(text));
 		String hexValue = crc16.getHexValue(true);
-		Assert.assertEquals("0e04", hexValue);
+		Assertions.assertEquals("0e04", hexValue);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/file/FileSystemUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/file/FileSystemUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.io.file;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
@@ -14,7 +14,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 public class FileSystemUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void listTest(){
 		final FileSystem fileSystem = FileSystemUtil.createZip("d:/test/test.zip",
 				CharsetUtil.CHARSET_GBK);

--- a/hutool-core/src/test/java/cn/hutool/core/io/file/PathUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/file/PathUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.io.file;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -10,7 +10,7 @@ import java.nio.file.StandardCopyOption;
 public class PathUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void copyFileTest(){
 		PathUtil.copyFile(
 				Paths.get("d:/test/1595232240113.jpg"),
@@ -21,7 +21,7 @@ public class PathUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void copyTest(){
 		PathUtil.copy(
 				Paths.get("d:/Red2_LYY"),
@@ -30,7 +30,7 @@ public class PathUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void copyContentTest(){
 		PathUtil.copyContent(
 				Paths.get("d:/Red2_LYY"),
@@ -39,30 +39,30 @@ public class PathUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void moveTest(){
 		PathUtil.move(Paths.get("d:/lombok.jar"), Paths.get("d:/test/"), false);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void moveDirTest(){
 		PathUtil.move(Paths.get("c:\\aaa"), Paths.get("d:/test/looly"), false);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void delDirTest(){
 		PathUtil.del(Paths.get("d:/test/looly"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getMimeTypeTest(){
 		String mimeType = PathUtil.getMimeType(Paths.get("d:/test/test.jpg"));
-		Assert.assertEquals("image/jpeg", mimeType);
+		Assertions.assertEquals("image/jpeg", mimeType);
 
 		mimeType = PathUtil.getMimeType(Paths.get("d:/test/test.mov"));
-		Assert.assertEquals("video/quicktime", mimeType);
+		Assertions.assertEquals("video/quicktime", mimeType);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/file/TailerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/file/TailerTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.io.file;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.CharsetUtil;
@@ -9,13 +9,13 @@ import cn.hutool.core.util.CharsetUtil;
 public class TailerTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void tailTest() {
 		FileUtil.tail(FileUtil.file("d:/test/tail.txt"), CharsetUtil.CHARSET_GBK);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void tailWithLinesTest() {
 		Tailer tailer = new Tailer(FileUtil.file("f:/test/test.log"), Tailer.CONSOLE_HANDLER, 2);
 		tailer.start();

--- a/hutool-core/src/test/java/cn/hutool/core/io/resource/ResourceUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/resource/ResourceUtilTest.java
@@ -3,34 +3,34 @@ package cn.hutool.core.io.resource;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ResourceUtilTest {
 
 	@Test
 	public void readXmlTest(){
 		final String str = ResourceUtil.readUtf8Str("test.xml");
-		Assert.assertNotNull(str);
+		Assertions.assertNotNull(str);
 
 		Resource resource = new ClassPathResource("test.xml");
 		final String xmlStr = resource.readUtf8Str();
 
-		Assert.assertEquals(str, xmlStr);
+		Assertions.assertEquals(str, xmlStr);
 	}
 
 	@Test
 	public void stringResourceTest(){
 		final StringResource stringResource = new StringResource("testData", "test");
-		Assert.assertEquals("test", stringResource.getName());
-		Assert.assertArrayEquals("testData".getBytes(), stringResource.readBytes());
-		Assert.assertArrayEquals("testData".getBytes(), IoUtil.readBytes(stringResource.getStream()));
+		Assertions.assertEquals("test", stringResource.getName());
+		Assertions.assertArrayEquals("testData".getBytes(), stringResource.readBytes());
+		Assertions.assertArrayEquals("testData".getBytes(), IoUtil.readBytes(stringResource.getStream()));
 	}
 
 	@Test
 	public void fileResourceTest(){
 		final FileResource resource = new FileResource(FileUtil.file("test.xml"));
-		Assert.assertEquals("test.xml", resource.getName());
-		Assert.assertTrue(StrUtil.isNotEmpty(resource.readUtf8Str()));
+		Assertions.assertEquals("test.xml", resource.getName());
+		Assertions.assertTrue(StrUtil.isNotEmpty(resource.readUtf8Str()));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/io/unit/DataSizeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/unit/DataSizeUtilTest.java
@@ -1,49 +1,49 @@
 package cn.hutool.core.io.unit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DataSizeUtilTest {
 
 	@Test
 	public void parseTest(){
 		long parse = DataSizeUtil.parse("3M");
-		Assert.assertEquals(3145728, parse);
+		Assertions.assertEquals(3145728, parse);
 
 		parse = DataSizeUtil.parse("3m");
-		Assert.assertEquals(3145728, parse);
+		Assertions.assertEquals(3145728, parse);
 
 		parse = DataSizeUtil.parse("3MB");
-		Assert.assertEquals(3145728, parse);
+		Assertions.assertEquals(3145728, parse);
 
 		parse = DataSizeUtil.parse("3mb");
-		Assert.assertEquals(3145728, parse);
+		Assertions.assertEquals(3145728, parse);
 
 		parse = DataSizeUtil.parse("3.1M");
-		Assert.assertEquals(3250585, parse);
+		Assertions.assertEquals(3250585, parse);
 
 		parse = DataSizeUtil.parse("3.1m");
-		Assert.assertEquals(3250585, parse);
+		Assertions.assertEquals(3250585, parse);
 
 		parse = DataSizeUtil.parse("3.1MB");
-		Assert.assertEquals(3250585, parse);
+		Assertions.assertEquals(3250585, parse);
 
 		parse = DataSizeUtil.parse("-3.1MB");
-		Assert.assertEquals(-3250585, parse);
+		Assertions.assertEquals(-3250585, parse);
 
 		parse = DataSizeUtil.parse("+3.1MB");
-		Assert.assertEquals(3250585, parse);
+		Assertions.assertEquals(3250585, parse);
 
 		parse = DataSizeUtil.parse("3.1mb");
-		Assert.assertEquals(3250585, parse);
+		Assertions.assertEquals(3250585, parse);
 
 		parse = DataSizeUtil.parse("3.1");
-		Assert.assertEquals(3, parse);
+		Assertions.assertEquals(3, parse);
 
 		try {
 			DataSizeUtil.parse("3.1.3");
 		} catch (IllegalArgumentException ie) {
-			Assert.assertEquals("'3.1.3' is not a valid data size", ie.getMessage());
+			Assertions.assertEquals("'3.1.3' is not a valid data size", ie.getMessage());
 		}
 
 
@@ -52,12 +52,12 @@ public class DataSizeUtilTest {
 	@Test
 	public void formatTest(){
 		String format = DataSizeUtil.format(Long.MAX_VALUE);
-		Assert.assertEquals("8 EB", format);
+		Assertions.assertEquals("8 EB", format);
 
 		format = DataSizeUtil.format(1024L * 1024 * 1024 * 1024 * 1024);
-		Assert.assertEquals("1 PB", format);
+		Assertions.assertEquals("1 PB", format);
 
 		format = DataSizeUtil.format(1024L * 1024 * 1024 * 1024);
-		Assert.assertEquals("1 TB", format);
+		Assertions.assertEquals("1 TB", format);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/AssertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/AssertTest.java
@@ -1,38 +1,43 @@
 package cn.hutool.core.lang;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AssertTest {
-	
+
 	@Test
-	public void isNullTest(){
-		String a = null;
-		cn.hutool.core.lang.Assert.isNull(a);
-	}
-	@Test
-	public void notNullTest(){
+	public void isNullTest() {
 		String a = null;
 		cn.hutool.core.lang.Assert.isNull(a);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
+	public void notNullTest() {
+		String a = null;
+		cn.hutool.core.lang.Assert.isNull(a);
+	}
+
+	@Test
 	public void isTrueTest() {
-		int i = 0;
-		//noinspection ConstantConditions
-		cn.hutool.core.lang.Assert.isTrue(i > 0, IllegalArgumentException::new);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			int i = 0;
+			cn.hutool.core.lang.Assert.isTrue(i > 0, IllegalArgumentException::new);
+		});
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class)
+	@Test
 	public void isTrueTest2() {
-		int i = -1;
-		//noinspection ConstantConditions
-		cn.hutool.core.lang.Assert.isTrue(i >= 0, IndexOutOfBoundsException::new);
+		Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+			int i = -1;
+			cn.hutool.core.lang.Assert.isTrue(i >= 0, IndexOutOfBoundsException::new);
+		});
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class)
+	@Test
 	public void isTrueTest3() {
-		int i = -1;
-		//noinspection ConstantConditions
-		Assert.isTrue(i > 0, ()-> new IndexOutOfBoundsException("relation message to return"));
+		Assertions.assertThrows(IndexOutOfBoundsException.class, () -> {
+			int i = -1;
+			Assert.isTrue(i > 0, () -> new IndexOutOfBoundsException("relation message to return"));
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ClassScanerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ClassScanerTest.java
@@ -1,14 +1,14 @@
 package cn.hutool.core.lang;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
 public class ClassScanerTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scanTest() {
 		ClassScanner scaner = new ClassScanner("cn.hutool.core.util", null);
 		Set<Class<?>> set = scaner.scan();
@@ -18,7 +18,7 @@ public class ClassScanerTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scanPackageBySuperTest(){
 		// 扫描包，如果在classpath下找到，就不扫描JDK的jar了
 		final Set<Class<?>> classes = ClassScanner.scanPackageBySuper(null, Iterable.class);
@@ -26,7 +26,7 @@ public class ClassScanerTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void scanAllPackageBySuperTest(){
 		// 扫描包，如果在classpath下找到，就不扫描JDK的jar了
 		final Set<Class<?>> classes = ClassScanner.scanAllPackageBySuper(null, Iterable.class);

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTableTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTableTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 public class ConsoleTableTest {
 
 	@Test
-//    @Disabled
 	public void printTest() {
 		ConsoleTable t = new ConsoleTable();
 		t.addHeader("姓名", "年龄");

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTableTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTableTest.java
@@ -1,11 +1,11 @@
 package cn.hutool.core.lang;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConsoleTableTest {
 
 	@Test
-//    @Ignore
+//    @Disabled
 	public void printTest() {
 		ConsoleTable t = new ConsoleTable();
 		t.addHeader("姓名", "年龄");

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ConsoleTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.thread.ThreadUtil;
 
@@ -11,14 +11,14 @@ import cn.hutool.core.thread.ThreadUtil;
  *
  */
 public class ConsoleTest {
-	
+
 	@Test
 	public void logTest(){
 		Console.log();
-		
+
 		String[] a = {"abc", "bcd", "def"};
 		Console.log(a);
-		
+
 		Console.log("This is Console log for {}.", "test");
 	}
 
@@ -27,12 +27,12 @@ public class ConsoleTest {
 		Console.log("a", "b", "c");
 		Console.log((Object) "a", "b", "c");
 	}
-	
+
 	@Test
 	public void printTest(){
 		String[] a = {"abc", "bcd", "def"};
 		Console.print(a);
-		
+
 		Console.log("This is Console print for {}.", "test");
 	}
 
@@ -41,14 +41,14 @@ public class ConsoleTest {
 		Console.print("a", "b", "c");
 		Console.print((Object) "a", "b", "c");
 	}
-	
+
 	@Test
 	public void errorTest(){
 		Console.error();
-		
+
 		String[] a = {"abc", "bcd", "def"};
 		Console.error(a);
-		
+
 		Console.error("This is Console error for {}.", "test");
 	}
 
@@ -57,17 +57,17 @@ public class ConsoleTest {
 		Console.error("a", "b", "c");
 		Console.error((Object) "a", "b", "c");
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void inputTest() {
 		Console.log("Please input something: ");
 		String input = Console.input();
 		Console.log(input);
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void printProgressTest() {
 		for(int i = 0; i < 100; i++) {
 			Console.printProgress('#', 100, i / 100D);

--- a/hutool-core/src/test/java/cn/hutool/core/lang/DictTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/DictTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.lang;
 
 import cn.hutool.core.date.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,9 +14,9 @@ public class DictTest {
 				.set("key1", 1)//int
 				.set("key2", 1000L)//long
 				.set("key3", DateTime.now());//Date
-		
+
 		Long v2 = dict.getLong("key2");
-		Assert.assertEquals(Long.valueOf(1000L), v2);
+		Assertions.assertEquals(Long.valueOf(1000L), v2);
 	}
 
 	@Test
@@ -27,8 +27,8 @@ public class DictTest {
 
 		dict.putAll(map);
 
-		Assert.assertEquals(1, dict.get("A"));
-		Assert.assertEquals(1, dict.get("a"));
+		Assertions.assertEquals(1, dict.get("A"));
+		Assertions.assertEquals(1, dict.get("a"));
 	}
 
 	@Test
@@ -39,9 +39,9 @@ public class DictTest {
 				"BLUE", "#0000FF"
 		);
 
-		Assert.assertEquals("#FF0000", dict.get("RED"));
-		Assert.assertEquals("#00FF00", dict.get("GREEN"));
-		Assert.assertEquals("#0000FF", dict.get("BLUE"));
+		Assertions.assertEquals("#FF0000", dict.get("RED"));
+		Assertions.assertEquals("#00FF00", dict.get("GREEN"));
+		Assertions.assertEquals("#0000FF", dict.get("BLUE"));
 	}
 
 	@Test
@@ -56,6 +56,6 @@ public class DictTest {
 
 		dict.removeEqual(dict2);
 
-		Assert.assertTrue(dict.isEmpty());
+		Assertions.assertTrue(dict.isEmpty());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/NanoIdTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/NanoIdTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.lang;
 
 import cn.hutool.core.lang.id.NanoId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.security.SecureRandom;
 import java.util.HashMap;
@@ -12,9 +12,9 @@ import java.util.Random;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for NanoId.
@@ -135,36 +135,42 @@ public class NanoIdTest {
 		//Verify the distribution of characters is pretty even
 		for (final Long charCount : charCounts.values()) {
 			final double distribution = (charCount * alphabet.length / (double) (idCount * idSize));
-			Assert.assertTrue(distribution >= 0.95 && distribution <= 1.05);
+			Assertions.assertTrue(distribution >= 0.95 && distribution <= 1.05);
 		}
 
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void randomNanoIdEmptyAlphabetExceptionThrownTest() {
-		NanoId.randomNanoId(new SecureRandom(), new char[]{}, 10);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			NanoId.randomNanoId(new SecureRandom(), new char[]{}, 10);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void randomNanoId256AlphabetExceptionThrownTest() {
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			//The alphabet is composed of 256 unique characters
+			final char[] largeAlphabet = new char[256];
+			for (int i = 0; i < 256; i++) {
+				largeAlphabet[i] = (char) i;
+			}
 
-		//The alphabet is composed of 256 unique characters
-		final char[] largeAlphabet = new char[256];
-		for (int i = 0; i < 256; i++) {
-			largeAlphabet[i] = (char) i;
-		}
-
-		NanoId.randomNanoId(new SecureRandom(), largeAlphabet, 20);
-
+			NanoId.randomNanoId(new SecureRandom(), largeAlphabet, 20);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void randomNanoIdNegativeSizeExceptionThrown() {
-		NanoId.randomNanoId(new SecureRandom(), new char[]{'a', 'b', 'c'}, -10);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			NanoId.randomNanoId(new SecureRandom(), new char[]{'a', 'b', 'c'}, -10);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void randomNanoIdZeroSizeExceptionThrown() {
-		NanoId.randomNanoId(new SecureRandom(), new char[]{'a', 'b', 'c'}, 0);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			NanoId.randomNanoId(new SecureRandom(), new char[]{'a', 'b', 'c'}, 0);
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ObjectIdTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ObjectIdTest.java
@@ -2,18 +2,18 @@ package cn.hutool.core.lang;
 
 import java.util.HashSet;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * ObjectId单元测试
- * 
+ *
  * @author looly
  *
  */
 public class ObjectIdTest {
-	
+
 	@Test
 	public void distinctTest() {
 		//生成10000个id测试是否重复
@@ -21,12 +21,12 @@ public class ObjectIdTest {
 		for(int i = 0; i < 10000; i++) {
 			set.add(ObjectId.next());
 		}
-		
-		Assert.assertEquals(10000, set.size());
+
+		Assertions.assertEquals(10000, set.size());
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void nextTest() {
 		Console.log(ObjectId.next());
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/lang/OptTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/OptTest.java
@@ -1,14 +1,16 @@
 package cn.hutool.core.lang;
 
 import cn.hutool.core.collection.CollectionUtil;
+import cn.hutool.core.lang.id.NanoId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +28,7 @@ public class OptTest {
 	public void ofBlankAbleTest() {
 		// ofBlankAble相对于ofNullable考虑了字符串为空串的情况
 		String hutool = Opt.ofBlankAble("").orElse("hutool");
-		Assert.assertEquals("hutool", hutool);
+		Assertions.assertEquals("hutool", hutool);
 	}
 
 	@Test
@@ -34,7 +36,7 @@ public class OptTest {
 		// 和原版Optional有区别的是，get不会抛出NoSuchElementException
 		// 如果想使用原版Optional中的get这样，获取一个一定不为空的值，则应该使用orElseThrow
 		Object opt = Opt.ofNullable(null).get();
-		Assert.assertNull(opt);
+		Assertions.assertNull(opt);
 	}
 
 	@Test
@@ -42,11 +44,11 @@ public class OptTest {
 		// 这是jdk11 Optional中的新函数，直接照搬了过来
 		// 判断包裹内元素是否为空，注意并没有判断空字符串的情况
 		boolean isEmpty = Opt.empty().isEmpty();
-		Assert.assertTrue(isEmpty);
+		Assertions.assertTrue(isEmpty);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void ifPresentOrElseTest() {
 		// 存在就打印对应的值，不存在则用{@code System.err.println}打印另一句字符串
 		Opt.ofNullable("Hello Hutool!").ifPresentOrElse(Console::log, () -> Console.error("Ops!Something is wrong!"));
@@ -63,12 +65,12 @@ public class OptTest {
 		User user = new User();
 		// 相当于ifPresent的链式调用
 		Opt.ofNullable("hutool").peek(user::setUsername).peek(user::setNickname);
-		Assert.assertEquals("hutool", user.getNickname());
-		Assert.assertEquals("hutool", user.getUsername());
+		Assertions.assertEquals("hutool", user.getNickname());
+		Assertions.assertEquals("hutool", user.getUsername());
 
 		// 注意，传入的lambda中，对包裹内的元素执行赋值操作并不会影响到原来的元素
 		String name = Opt.ofNullable("hutool").peek(username -> username = "123").peek(username -> username = "456").get();
-		Assert.assertEquals("hutool", name);
+		Assertions.assertEquals("hutool", name);
 	}
 
 	@Test
@@ -79,18 +81,18 @@ public class OptTest {
 		Opt.ofNullable("hutool").peeks(user::setUsername, user::setNickname);
 		// 也可以在适当的地方换行使得代码的可读性提高
 		Opt.of(user).peeks(
-				u -> Assert.assertEquals("hutool", u.getNickname()),
-				u -> Assert.assertEquals("hutool", u.getUsername())
+				u -> Assertions.assertEquals("hutool", u.getNickname()),
+				u -> Assertions.assertEquals("hutool", u.getUsername())
 		);
-		Assert.assertEquals("hutool", user.getNickname());
-		Assert.assertEquals("hutool", user.getUsername());
+		Assertions.assertEquals("hutool", user.getNickname());
+		Assertions.assertEquals("hutool", user.getUsername());
 
 		// 注意，传入的lambda中，对包裹内的元素执行赋值操作并不会影响到原来的元素,这是java语言的特性。。。
 		// 这也是为什么我们需要getter和setter而不直接给bean中的属性赋值中的其中一个原因
 		String name = Opt.ofNullable("hutool").peeks(
 				username -> username = "123", username -> username = "456",
-				n -> Assert.assertEquals("hutool", n)).get();
-		Assert.assertEquals("hutool", name);
+				n -> Assertions.assertEquals("hutool", n)).get();
+		Assertions.assertEquals("hutool", name);
 
 		// 当然，以下情况不会抛出NPE，但也没什么意义
 		Opt.ofNullable("hutool").peeks().peeks().peeks();
@@ -104,34 +106,40 @@ public class OptTest {
 		// 这是jdk9 Optional中的新函数，直接照搬了过来
 		// 给一个替代的Opt
 		String str = Opt.<String>ofNullable(null).or(() -> Opt.ofNullable("Hello hutool!")).map(String::toUpperCase).orElseThrow();
-		Assert.assertEquals("HELLO HUTOOL!", str);
+		Assertions.assertEquals("HELLO HUTOOL!", str);
 
 		User user = User.builder().username("hutool").build();
 		Opt<User> userOpt = Opt.of(user);
 		// 获取昵称，获取不到则获取用户名
 		String name = userOpt.map(User::getNickname).or(() -> userOpt.map(User::getUsername)).get();
-		Assert.assertEquals("hutool", name);
+		Assertions.assertEquals("hutool", name);
 	}
 
-	@Test(expected = NoSuchElementException.class)
+	@Test
 	public void orElseThrowTest() {
-		// 获取一个不可能为空的值，否则抛出NoSuchElementException异常
-		Object obj = Opt.ofNullable(null).orElseThrow();
-		Assert.assertNull(obj);
+		Assertions.assertThrows(NoSuchElementException.class, () -> {
+			// 获取一个不可能为空的值，否则抛出NoSuchElementException异常
+			Object obj = Opt.ofNullable(null).orElseThrow();
+			Assertions.assertNull(obj);
+		});
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void orElseThrowTest2() {
-		// 获取一个不可能为空的值，否则抛出自定义异常
-		Object assignException = Opt.ofNullable(null).orElseThrow(IllegalStateException::new);
-		Assert.assertNull(assignException);
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			// 获取一个不可能为空的值，否则抛出自定义异常
+			Object assignException = Opt.ofNullable(null).orElseThrow(IllegalStateException::new);
+			Assertions.assertNull(assignException);
+		});
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void orElseThrowTest3() {
-		// 获取一个不可能为空的值，否则抛出带自定义消息的自定义异常
-		Object exceptionWithMessage = Opt.empty().orElseThrow(IllegalStateException::new, "Ops!Something is wrong!");
-		Assert.assertNull(exceptionWithMessage);
+		Assertions.assertThrows(IllegalStateException.class, () -> {
+			// 获取一个不可能为空的值，否则抛出带自定义消息的自定义异常
+			Object exceptionWithMessage = Opt.empty().orElseThrow(IllegalStateException::new, "Ops!Something is wrong!");
+			Assertions.assertNull(exceptionWithMessage);
+		});
 	}
 
 	@Test
@@ -143,8 +151,8 @@ public class OptTest {
 		// 现在，兼容
 		User user = Opt.ofNullable(userList).map(List::stream)
 				.flattedMap(Stream::findFirst).orElseGet(User.builder()::build);
-		Assert.assertNull(user.getUsername());
-		Assert.assertNull(user.getNickname());
+		Assertions.assertNull(user.getUsername());
+		Assertions.assertNull(user.getNickname());
 	}
 
 	@Test
@@ -154,15 +162,15 @@ public class OptTest {
 		List<String> past = Opt.ofNullable(Collections.<String>emptyList()).filter(CollectionUtil::isNotEmpty).orElseGet(() -> Collections.singletonList("hutool"));
 		// 现在，一个ofEmptyAble搞定
 		List<String> hutool = Opt.ofEmptyAble(Collections.<String>emptyList()).orElseGet(() -> Collections.singletonList("hutool"));
-		Assert.assertEquals(past, hutool);
-		Assert.assertEquals(hutool, Collections.singletonList("hutool"));
+		Assertions.assertEquals(past, hutool);
+		Assertions.assertEquals(hutool, Collections.singletonList("hutool"));
 	}
 
 	@Test
 	public void mapOrElseTest() {
 		// 如果值存在就转换为大写，否则打印一句字符串，支持链式调用、转换为其他类型
 		String hutool = Opt.ofBlankAble("hutool").mapOrElse(String::toUpperCase, () -> Console.log("yes")).mapOrElse(String::intern, () -> Console.log("Value is not present~")).get();
-		Assert.assertEquals("HUTOOL", hutool);
+		Assertions.assertEquals("HUTOOL", hutool);
 	}
 
 	@SuppressWarnings({"MismatchedQueryAndUpdateOfCollection", "ConstantConditions"})
@@ -183,10 +191,10 @@ public class OptTest {
 			// 你可以在里面写一长串调用链 list.get(0).getUser().getId()
 			return list.get(0);
 		}).exceptionOrElse("hutool");
-		Assert.assertEquals(npe, npeSituation);
-		Assert.assertEquals(indexOut, indexOutSituation);
-		Assert.assertEquals("hutool", npe);
-		Assert.assertEquals("hutool", indexOut);
+		Assertions.assertEquals(npe, npeSituation);
+		Assertions.assertEquals(indexOut, indexOutSituation);
+		Assertions.assertEquals("hutool", npe);
+		Assertions.assertEquals("hutool", indexOut);
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/lang/OptTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/OptTest.java
@@ -1,7 +1,6 @@
 package cn.hutool.core.lang;
 
 import cn.hutool.core.collection.CollectionUtil;
-import cn.hutool.core.lang.id.NanoId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,7 +9,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/hutool-core/src/test/java/cn/hutool/core/lang/RangeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/RangeTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.date.DateField;
 import cn.hutool.core.date.DateRange;
 import cn.hutool.core.date.DateTime;
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -29,11 +29,11 @@ public class RangeTest {
 			return current.offsetNew(DateField.DAY_OF_YEAR, 1);
 		});
 
-		Assert.assertTrue(range.hasNext());
-		Assert.assertEquals(DateUtil.parse("2017-01-01"), range.next());
-		Assert.assertTrue(range.hasNext());
-		Assert.assertEquals(DateUtil.parse("2017-01-02"), range.next());
-		Assert.assertFalse(range.hasNext());
+		Assertions.assertTrue(range.hasNext());
+		Assertions.assertEquals(DateUtil.parse("2017-01-01"), range.next());
+		Assertions.assertTrue(range.hasNext());
+		Assertions.assertEquals(DateUtil.parse("2017-01-02"), range.next());
+		Assertions.assertFalse(range.hasNext());
 	}
 
 	@Test
@@ -43,22 +43,22 @@ public class RangeTest {
 
 		final DateRange range = DateUtil.range(start, end, DateField.MONTH);
 
-		Assert.assertTrue(range.hasNext());
-		Assert.assertEquals(DateUtil.parse("2021-01-31"), range.next());
-		Assert.assertTrue(range.hasNext());
-		Assert.assertEquals(DateUtil.parse("2021-02-28"), range.next());
-		Assert.assertTrue(range.hasNext());
-		Assert.assertEquals(DateUtil.parse("2021-03-31"), range.next());
-		Assert.assertFalse(range.hasNext());
+		Assertions.assertTrue(range.hasNext());
+		Assertions.assertEquals(DateUtil.parse("2021-01-31"), range.next());
+		Assertions.assertTrue(range.hasNext());
+		Assertions.assertEquals(DateUtil.parse("2021-02-28"), range.next());
+		Assertions.assertTrue(range.hasNext());
+		Assertions.assertEquals(DateUtil.parse("2021-03-31"), range.next());
+		Assertions.assertFalse(range.hasNext());
 	}
 
 	@Test
 	public void intRangeTest() {
 		final Range<Integer> range = new Range<>(1, 1, (current, end, index) -> current >= end ? null : current + 10);
 
-		Assert.assertTrue(range.hasNext());
-		Assert.assertEquals(Integer.valueOf(1), range.next());
-		Assert.assertFalse(range.hasNext());
+		Assertions.assertTrue(range.hasNext());
+		Assertions.assertEquals(Integer.valueOf(1), range.next());
+		Assertions.assertFalse(range.hasNext());
 	}
 
 	@Test
@@ -68,19 +68,19 @@ public class RangeTest {
 
 		// 测试包含开始和结束情况下步进为1的情况
 		DateRange range = DateUtil.range(start, end, DateField.DAY_OF_YEAR);
-		Assert.assertEquals(range.next(), DateUtil.parse("2017-01-01"));
-		Assert.assertEquals(range.next(), DateUtil.parse("2017-01-02"));
-		Assert.assertEquals(range.next(), DateUtil.parse("2017-01-03"));
+		Assertions.assertEquals(range.next(), DateUtil.parse("2017-01-01"));
+		Assertions.assertEquals(range.next(), DateUtil.parse("2017-01-02"));
+		Assertions.assertEquals(range.next(), DateUtil.parse("2017-01-03"));
 		try {
 			range.next();
-			Assert.fail("已超过边界，下一个元素不应该存在！");
+			Assertions.fail("已超过边界，下一个元素不应该存在！");
 		} catch (NoSuchElementException ignored) {
 		}
 
 		// 测试多步进的情况
 		range = new DateRange(start, end, DateField.DAY_OF_YEAR, 2);
-		Assert.assertEquals(DateUtil.parse("2017-01-01"), range.next());
-		Assert.assertEquals(DateUtil.parse("2017-01-03"), range.next());
+		Assertions.assertEquals(DateUtil.parse("2017-01-01"), range.next());
+		Assertions.assertEquals(DateUtil.parse("2017-01-03"), range.next());
 	}
 
 	@Test
@@ -90,12 +90,12 @@ public class RangeTest {
 
 		// 测试不包含开始结束时间的情况
 		DateRange range = new DateRange(start, end, DateField.DAY_OF_YEAR, 1, false, false);
-		Assert.assertEquals(DateUtil.parse("2017-01-02"), range.next());
-		Assert.assertEquals(DateUtil.parse("2017-01-03"), range.next());
-		Assert.assertEquals(DateUtil.parse("2017-01-04"), range.next());
+		Assertions.assertEquals(DateUtil.parse("2017-01-02"), range.next());
+		Assertions.assertEquals(DateUtil.parse("2017-01-03"), range.next());
+		Assertions.assertEquals(DateUtil.parse("2017-01-04"), range.next());
 		try {
 			range.next();
-			Assert.fail("不包含结束时间情况下，下一个元素不应该存在！");
+			Assertions.fail("不包含结束时间情况下，下一个元素不应该存在！");
 		} catch (NoSuchElementException ignored) {
 		}
 	}
@@ -106,7 +106,7 @@ public class RangeTest {
 		DateTime end = DateUtil.parse("2017-01-31");
 
 		List<DateTime> rangeToList = DateUtil.rangeToList(start, end, DateField.DAY_OF_YEAR);
-		Assert.assertEquals(DateUtil.parse("2017-01-01"), rangeToList.get(0));
-		Assert.assertEquals(DateUtil.parse("2017-01-02"), rangeToList.get(1));
+		Assertions.assertEquals(DateUtil.parse("2017-01-01"), rangeToList.get(0));
+		Assertions.assertEquals(DateUtil.parse("2017-01-02"), rangeToList.get(1));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/SimhashTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/SimhashTest.java
@@ -1,24 +1,24 @@
 package cn.hutool.core.lang;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.text.Simhash;
 import cn.hutool.core.util.StrUtil;
 
 public class SimhashTest {
-	
+
 	@Test
 	public void simTest() {
 		String text1 = "我是 一个 普通 字符串";
 		String text2 = "我是 一个 普通 字符串";
-		
+
 		Simhash simhash = new Simhash();
 		long hash = simhash.hash(StrUtil.split(text1, ' '));
-		Assert.assertTrue(hash != 0);
-		
+		Assertions.assertTrue(hash != 0);
+
 		simhash.store(hash);
 		boolean duplicate = simhash.equals(StrUtil.split(text2, ' '));
-		Assert.assertTrue(duplicate);
+		Assertions.assertTrue(duplicate);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/SimpleCacheTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/SimpleCacheTest.java
@@ -2,13 +2,12 @@ package cn.hutool.core.lang;
 
 import cn.hutool.core.thread.ConcurrencyTester;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SimpleCacheTest {
 
-	@Before
+	@Test
 	public void putTest(){
 		final SimpleCache<String, String> cache = new SimpleCache<>();
 		ThreadUtil.execute(()->cache.put("key1", "value1"));
@@ -37,12 +36,12 @@ public class SimpleCacheTest {
 		cache.get("key4");
 		cache.get("key5", ()->"value5");
 
-		Assert.assertEquals("value1", cache.get("key1"));
-		Assert.assertEquals("value2", cache.get("key2"));
-		Assert.assertEquals("value3", cache.get("key3"));
-		Assert.assertEquals("value4", cache.get("key4"));
-		Assert.assertEquals("value5", cache.get("key5"));
-		Assert.assertEquals("value6", cache.get("key6", ()-> "value6"));
+		Assertions.assertEquals("value1", cache.get("key1"));
+		Assertions.assertEquals("value2", cache.get("key2"));
+		Assertions.assertEquals("value3", cache.get("key3"));
+		Assertions.assertEquals("value4", cache.get("key4"));
+		Assertions.assertEquals("value5", cache.get("key5"));
+		Assertions.assertEquals("value6", cache.get("key6", ()-> "value6"));
 	}
 
 	@Test
@@ -54,7 +53,7 @@ public class SimpleCacheTest {
 			return "aaaValue";
 		}));
 
-		Assert.assertTrue(tester.getInterval() > 0);
-		Assert.assertEquals("aaaValue", cache.get("aaa"));
+		Assertions.assertTrue(tester.getInterval() > 0);
+		Assertions.assertEquals("aaaValue", cache.get("aaa"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/SingletonTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/SingletonTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.lang;
 import cn.hutool.core.exceptions.UtilException;
 import cn.hutool.core.thread.ThreadUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SingletonTest {
 
@@ -33,10 +33,10 @@ public class SingletonTest {
 	 * 测试单例构建属性锁死问题
 	 * C构建单例时候，同时构建B，此时在SimpleCache中会有写锁竞争（写入C时获取了写锁，此时要写入B，也要获取写锁）
 	 */
-	@Test(timeout = 1000L)
+	@Test
 	public void reentrantTest(){
 		final C c = Singleton.get(C.class);
-		Assert.assertEquals("aaa", c.getB().getA());
+		Assertions.assertEquals("aaa", c.getB().getA());
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/lang/SnowflakeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/SnowflakeTest.java
@@ -5,9 +5,9 @@ import cn.hutool.core.exceptions.UtilException;
 import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.core.util.IdUtil;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -24,7 +24,7 @@ public class SnowflakeTest {
 		//构建Snowflake，提供终端ID和数据中心ID
 		Snowflake idWorker = new Snowflake(0, 0);
 		long nextId = idWorker.nextId();
-		Assert.assertTrue(nextId > 0);
+		Assertions.assertTrue(nextId > 0);
 	}
 
 	@Test
@@ -37,7 +37,7 @@ public class SnowflakeTest {
 			long id = idWorker.nextId();
 			hashSet.add(id);
 		}
-		Assert.assertEquals(1000L, hashSet.size());
+		Assertions.assertEquals(1000L, hashSet.size());
 	}
 
 	@Test
@@ -46,13 +46,13 @@ public class SnowflakeTest {
 		Snowflake idWorker = new Snowflake(1, 2);
 		long nextId = idWorker.nextId();
 
-		Assert.assertEquals(1, idWorker.getWorkerId(nextId));
-		Assert.assertEquals(2, idWorker.getDataCenterId(nextId));
-		Assert.assertTrue(idWorker.getGenerateDateTime(nextId) - System.currentTimeMillis() < 10);
+		Assertions.assertEquals(1, idWorker.getWorkerId(nextId));
+		Assertions.assertEquals(2, idWorker.getDataCenterId(nextId));
+		Assertions.assertTrue(idWorker.getGenerateDateTime(nextId) - System.currentTimeMillis() < 10);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void uniqueTest(){
 		// 测试并发环境下生成ID是否重复
 		Snowflake snowflake = IdUtil.getSnowflake(0, 0);
@@ -71,7 +71,7 @@ public class SnowflakeTest {
 	public void getSnowflakeLengthTest(){
 		for (int i = 0; i < 1000; i++) {
 			final long l = IdUtil.getSnowflake(0, 0).nextId();
-			Assert.assertEquals(19, StrUtil.toString(l).length());
+			Assertions.assertEquals(19, StrUtil.toString(l).length());
 		}
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/StrFormatterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/StrFormatterTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.text.StrFormatter;
 
@@ -11,44 +11,44 @@ public class StrFormatterTest {
 	public void formatTest() {
 		//通常使用
 		String result1 = StrFormatter.format("this is {} for {}", "a", "b");
-		Assert.assertEquals("this is a for b", result1);
+		Assertions.assertEquals("this is a for b", result1);
 
 		//转义{}
 		String result2 = StrFormatter.format("this is \\{} for {}", "a", "b");
-		Assert.assertEquals("this is {} for a", result2);
+		Assertions.assertEquals("this is {} for a", result2);
 
 		//转义\
 		String result3 = StrFormatter.format("this is \\\\{} for {}", "a", "b");
-		Assert.assertEquals("this is \\a for b", result3);
+		Assertions.assertEquals("this is \\a for b", result3);
 	}
 
 	@Test
 	public void formatWithTest() {
 		//通常使用
 		String result1 = StrFormatter.formatWith("this is ? for ?", "?", "a", "b");
-		Assert.assertEquals("this is a for b", result1);
+		Assertions.assertEquals("this is a for b", result1);
 
 		//转义?
 		String result2 = StrFormatter.formatWith("this is \\? for ?", "?", "a", "b");
-		Assert.assertEquals("this is ? for a", result2);
+		Assertions.assertEquals("this is ? for a", result2);
 
 		//转义\
 		String result3 = StrFormatter.formatWith("this is \\\\? for ?", "?", "a", "b");
-		Assert.assertEquals("this is \\a for b", result3);
+		Assertions.assertEquals("this is \\a for b", result3);
 	}
 
 	@Test
 	public void formatWithTest2() {
 		//通常使用
 		String result1 = StrFormatter.formatWith("this is $$$ for $$$", "$$$", "a", "b");
-		Assert.assertEquals("this is a for b", result1);
+		Assertions.assertEquals("this is a for b", result1);
 
 		//转义?
 		String result2 = StrFormatter.formatWith("this is \\$$$ for $$$", "$$$", "a", "b");
-		Assert.assertEquals("this is $$$ for a", result2);
+		Assertions.assertEquals("this is $$$ for a", result2);
 
 		//转义\
 		String result3 = StrFormatter.formatWith("this is \\\\$$$ for $$$", "$$$", "a", "b");
-		Assert.assertEquals("this is \\a for b", result3);
+		Assertions.assertEquals("this is \\a for b", result3);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/TupleTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/TupleTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 import java.util.TimeZone;
@@ -12,6 +12,6 @@ public class TupleTest {
 	public void hashCodeTest(){
 		final Tuple tuple = new Tuple(Locale.getDefault(), TimeZone.getDefault());
 		final Tuple tuple2 = new Tuple(Locale.getDefault(), TimeZone.getDefault());
-		Assert.assertEquals(tuple, tuple2);
+		Assertions.assertEquals(tuple, tuple2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/UUIDTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/UUIDTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.lang;
 
 import cn.hutool.core.collection.ConcurrentHashSet;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -16,6 +16,6 @@ public class UUIDTest {
 	public void fastUUIDTest(){
 		Set<String> set = new ConcurrentHashSet<>(100);
 		ThreadUtil.concurrencyTest(100, ()-> set.add(UUID.fastUUID().toString()));
-		Assert.assertEquals(100, set.size());
+		Assertions.assertEquals(100, set.size());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.lang;
 
 import cn.hutool.core.exceptions.ValidateException;
 import cn.hutool.core.util.IdUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 验证器单元测试
@@ -14,10 +14,10 @@ public class ValidatorTest {
 
 	@Test
 	public void isNumberTest() {
-		Assert.assertTrue(Validator.isNumber("45345365465"));
-		Assert.assertTrue(Validator.isNumber("0004545435"));
-		Assert.assertTrue(Validator.isNumber("5.222"));
-		Assert.assertTrue(Validator.isNumber("0.33323"));
+		Assertions.assertTrue(Validator.isNumber("45345365465"));
+		Assertions.assertTrue(Validator.isNumber("0004545435"));
+		Assertions.assertTrue(Validator.isNumber("5.222"));
+		Assertions.assertTrue(Validator.isNumber("0.33323"));
 	}
 
 	@Test
@@ -26,197 +26,199 @@ public class ValidatorTest {
 		String var2 = "str";
 		String var3 = "180";
 		String var4 = "身高180体重180";
-		Assert.assertFalse(Validator.hasNumber(var1));
-		Assert.assertFalse(Validator.hasNumber(var2));
-		Assert.assertTrue(Validator.hasNumber(var3));
-		Assert.assertTrue(Validator.hasNumber(var4));
+		Assertions.assertFalse(Validator.hasNumber(var1));
+		Assertions.assertFalse(Validator.hasNumber(var2));
+		Assertions.assertTrue(Validator.hasNumber(var3));
+		Assertions.assertTrue(Validator.hasNumber(var4));
 	}
 
 	@Test
 	public void isLetterTest() {
-		Assert.assertTrue(Validator.isLetter("asfdsdsfds"));
-		Assert.assertTrue(Validator.isLetter("asfdsdfdsfVCDFDFGdsfds"));
-		Assert.assertTrue(Validator.isLetter("asfdsdf你好dsfVCDFDFGdsfds"));
+		Assertions.assertTrue(Validator.isLetter("asfdsdsfds"));
+		Assertions.assertTrue(Validator.isLetter("asfdsdfdsfVCDFDFGdsfds"));
+		Assertions.assertTrue(Validator.isLetter("asfdsdf你好dsfVCDFDFGdsfds"));
 	}
 
 	@Test
 	public void isUperCaseTest() {
-		Assert.assertTrue(Validator.isUpperCase("VCDFDFG"));
-		Assert.assertTrue(Validator.isUpperCase("ASSFD"));
+		Assertions.assertTrue(Validator.isUpperCase("VCDFDFG"));
+		Assertions.assertTrue(Validator.isUpperCase("ASSFD"));
 
-		Assert.assertFalse(Validator.isUpperCase("asfdsdsfds"));
-		Assert.assertFalse(Validator.isUpperCase("ASSFD你好"));
+		Assertions.assertFalse(Validator.isUpperCase("asfdsdsfds"));
+		Assertions.assertFalse(Validator.isUpperCase("ASSFD你好"));
 	}
 
 	@Test
 	public void isLowerCaseTest() {
-		Assert.assertTrue(Validator.isLowerCase("asfdsdsfds"));
+		Assertions.assertTrue(Validator.isLowerCase("asfdsdsfds"));
 
-		Assert.assertFalse(Validator.isLowerCase("aaaa你好"));
-		Assert.assertFalse(Validator.isLowerCase("VCDFDFG"));
-		Assert.assertFalse(Validator.isLowerCase("ASSFD"));
-		Assert.assertFalse(Validator.isLowerCase("ASSFD你好"));
+		Assertions.assertFalse(Validator.isLowerCase("aaaa你好"));
+		Assertions.assertFalse(Validator.isLowerCase("VCDFDFG"));
+		Assertions.assertFalse(Validator.isLowerCase("ASSFD"));
+		Assertions.assertFalse(Validator.isLowerCase("ASSFD你好"));
 	}
 
 	@Test
 	public void isBirthdayTest() {
 		boolean b = Validator.isBirthday("20150101");
-		Assert.assertTrue(b);
+		Assertions.assertTrue(b);
 		boolean b2 = Validator.isBirthday("2015-01-01");
-		Assert.assertTrue(b2);
+		Assertions.assertTrue(b2);
 		boolean b3 = Validator.isBirthday("2015.01.01");
-		Assert.assertTrue(b3);
+		Assertions.assertTrue(b3);
 		boolean b4 = Validator.isBirthday("2015年01月01日");
-		Assert.assertTrue(b4);
+		Assertions.assertTrue(b4);
 		boolean b5 = Validator.isBirthday("2015.01.01");
-		Assert.assertTrue(b5);
+		Assertions.assertTrue(b5);
 		boolean b6 = Validator.isBirthday("2018-08-15");
-		Assert.assertTrue(b6);
+		Assertions.assertTrue(b6);
 
 		//验证年非法
-		Assert.assertFalse(Validator.isBirthday("2095.05.01"));
+		Assertions.assertFalse(Validator.isBirthday("2095.05.01"));
 		//验证月非法
-		Assert.assertFalse(Validator.isBirthday("2015.13.01"));
+		Assertions.assertFalse(Validator.isBirthday("2015.13.01"));
 		//验证日非法
-		Assert.assertFalse(Validator.isBirthday("2015.02.29"));
+		Assertions.assertFalse(Validator.isBirthday("2015.02.29"));
 	}
 
 	@Test
 	public void isCitizenIdTest() {
 		// 18为身份证号码验证
 		boolean b = Validator.isCitizenId("110101199003074477");
-		Assert.assertTrue(b);
+		Assertions.assertTrue(b);
 
 		// 15位身份证号码验证
 		boolean b1 = Validator.isCitizenId("410001910101123");
-		Assert.assertTrue(b1);
+		Assertions.assertTrue(b1);
 
 		// 10位身份证号码验证
 		boolean b2 = Validator.isCitizenId("U193683453");
-		Assert.assertTrue(b2);
+		Assertions.assertTrue(b2);
 	}
 
-	@Test(expected = ValidateException.class)
+	@Test
 	public void validateTest() throws ValidateException {
-		Validator.validateChinese("我是一段zhongwen", "内容中包含非中文");
+		Assertions.assertThrows(ValidateException.class, () -> {
+			Validator.validateChinese("我是一段zhongwen", "内容中包含非中文");
+		});
 	}
 
 	@Test
 	public void isEmailTest() {
 		boolean email = Validator.isEmail("abc_cde@163.com");
-		Assert.assertTrue(email);
+		Assertions.assertTrue(email);
 		boolean email1 = Validator.isEmail("abc_%cde@163.com");
-		Assert.assertTrue(email1);
+		Assertions.assertTrue(email1);
 		boolean email2 = Validator.isEmail("abc_%cde@aaa.c");
-		Assert.assertTrue(email2);
+		Assertions.assertTrue(email2);
 		boolean email3 = Validator.isEmail("xiaolei.lu@aaa.b");
-		Assert.assertTrue(email3);
+		Assertions.assertTrue(email3);
 		boolean email4 = Validator.isEmail("xiaolei.Lu@aaa.b");
-		Assert.assertTrue(email4);
+		Assertions.assertTrue(email4);
 	}
 
 	@Test
 	public void isMobileTest() {
 		boolean m1 = Validator.isMobile("13900221432");
-		Assert.assertTrue(m1);
+		Assertions.assertTrue(m1);
 		boolean m2 = Validator.isMobile("015100221432");
-		Assert.assertTrue(m2);
+		Assertions.assertTrue(m2);
 		boolean m3 = Validator.isMobile("+8618600221432");
-		Assert.assertTrue(m3);
+		Assertions.assertTrue(m3);
 	}
 
 	@Test
 	public void isMatchTest() {
 		String url = "http://aaa-bbb.somthing.com/a.php?a=b&c=2";
-		Assert.assertTrue(Validator.isMatchRegex(PatternPool.URL_HTTP, url));
+		Assertions.assertTrue(Validator.isMatchRegex(PatternPool.URL_HTTP, url));
 
 		url = "https://aaa-bbb.somthing.com/a.php?a=b&c=2";
-		Assert.assertTrue(Validator.isMatchRegex(PatternPool.URL_HTTP, url));
+		Assertions.assertTrue(Validator.isMatchRegex(PatternPool.URL_HTTP, url));
 
 		url = "https://aaa-bbb.somthing.com:8080/a.php?a=b&c=2";
-		Assert.assertTrue(Validator.isMatchRegex(PatternPool.URL_HTTP, url));
+		Assertions.assertTrue(Validator.isMatchRegex(PatternPool.URL_HTTP, url));
 	}
 
 	@Test
 	public void isGeneralTest() {
 		String str = "";
 		boolean general = Validator.isGeneral(str, -1, 5);
-		Assert.assertTrue(general);
+		Assertions.assertTrue(general);
 
 		str = "123_abc_ccc";
 		general = Validator.isGeneral(str, -1, 100);
-		Assert.assertTrue(general);
+		Assertions.assertTrue(general);
 
 		// 不允许中文
 		str = "123_abc_ccc中文";
 		general = Validator.isGeneral(str, -1, 100);
-		Assert.assertFalse(general);
+		Assertions.assertFalse(general);
 	}
 
 	@Test
 	public void isPlateNumberTest(){
-		Assert.assertTrue(Validator.isPlateNumber("粤BA03205"));
-		Assert.assertTrue(Validator.isPlateNumber("闽20401领"));
+		Assertions.assertTrue(Validator.isPlateNumber("粤BA03205"));
+		Assertions.assertTrue(Validator.isPlateNumber("闽20401领"));
 	}
 
 	@Test
 	public void isChineseTest(){
-		Assert.assertTrue(Validator.isChinese("全都是中文"));
-		Assert.assertFalse(Validator.isChinese("not全都是中文"));
+		Assertions.assertTrue(Validator.isChinese("全都是中文"));
+		Assertions.assertFalse(Validator.isChinese("not全都是中文"));
 	}
 
 	@Test
 	public void isUUIDTest(){
-		Assert.assertTrue(Validator.isUUID(IdUtil.randomUUID()));
-		Assert.assertTrue(Validator.isUUID(IdUtil.fastSimpleUUID()));
+		Assertions.assertTrue(Validator.isUUID(IdUtil.randomUUID()));
+		Assertions.assertTrue(Validator.isUUID(IdUtil.fastSimpleUUID()));
 
-		Assert.assertTrue(Validator.isUUID(IdUtil.randomUUID().toUpperCase()));
-		Assert.assertTrue(Validator.isUUID(IdUtil.fastSimpleUUID().toUpperCase()));
+		Assertions.assertTrue(Validator.isUUID(IdUtil.randomUUID().toUpperCase()));
+		Assertions.assertTrue(Validator.isUUID(IdUtil.fastSimpleUUID().toUpperCase()));
 	}
 
 	@Test
 	public void isZipCodeTest(){
 		// 港
 		boolean zipCode = Validator.isZipCode("999077");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 		// 澳
 		zipCode = Validator.isZipCode("999078");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 		// 台（2020年3月起改用6位邮编，3+3）
 		zipCode = Validator.isZipCode("822001");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 
 		// 内蒙
 		zipCode = Validator.isZipCode("016063");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 		// 山西
 		zipCode = Validator.isZipCode("045246");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 		// 河北
 		zipCode = Validator.isZipCode("066502");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 		// 北京
 		zipCode = Validator.isZipCode("102629");
-		Assert.assertTrue(zipCode);
+		Assertions.assertTrue(zipCode);
 	}
 
 	@Test
 	public void isBetweenTest() {
-		Assert.assertTrue(Validator.isBetween(0, 0, 1));
-		Assert.assertTrue(Validator.isBetween(1L, 0L, 1L));
-		Assert.assertTrue(Validator.isBetween(0.19f, 0.1f, 0.2f));
-		Assert.assertTrue(Validator.isBetween(0.19, 0.1, 0.2));
+		Assertions.assertTrue(Validator.isBetween(0, 0, 1));
+		Assertions.assertTrue(Validator.isBetween(1L, 0L, 1L));
+		Assertions.assertTrue(Validator.isBetween(0.19f, 0.1f, 0.2f));
+		Assertions.assertTrue(Validator.isBetween(0.19, 0.1, 0.2));
 	}
 
 	@Test
 	public void isCarVinTest(){
-		Assert.assertTrue(Validator.isCarVin("LSJA24U62JG269225"));
-		Assert.assertTrue(Validator.isCarVin("LDC613P23A1305189"));
+		Assertions.assertTrue(Validator.isCarVin("LSJA24U62JG269225"));
+		Assertions.assertTrue(Validator.isCarVin("LDC613P23A1305189"));
 	}
 
 	@Test
 	public void isCarDrivingLicenceTest(){
-		Assert.assertTrue(Validator.isCarDrivingLicence("430101758218"));
+		Assertions.assertTrue(Validator.isCarDrivingLicence("430101758218"));
 	}
 
 	@Test
@@ -233,7 +235,7 @@ public class ValidatorTest {
 		String content = "https://detail.tmall.com/item.htm?" +
 				"id=639428931841&ali_refid=a3_430582_1006:1152464078:N:Sk5vwkMVsn5O6DcnvicELrFucL21A32m:0af8611e23c1d07697e";
 
-		Assert.assertTrue(Validator.isMatchRegex(Validator.URL, content));
-		Assert.assertTrue(Validator.isMatchRegex(Validator.URL_HTTP, content));
+		Assertions.assertTrue(Validator.isMatchRegex(Validator.URL, content));
+		Assertions.assertTrue(Validator.isMatchRegex(Validator.URL_HTTP, content));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/WeightRandomTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/WeightRandomTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.collection.CollUtil;
 
@@ -15,6 +15,6 @@ public class WeightRandomTest {
 		random.add("C", 100);
 
 		String result = random.next();
-		Assert.assertTrue(CollUtil.newArrayList("A", "B", "C").contains(result));
+		Assertions.assertTrue(CollUtil.newArrayList("A", "B", "C").contains(result));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/caller/CallerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/caller/CallerTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang.caller;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@link CallerUtil} 单元测试
@@ -9,25 +9,25 @@ import org.junit.Test;
  *
  */
 public class CallerTest {
-	
+
 	@Test
 	public void getCallerTest() {
 		Class<?> caller = CallerUtil.getCaller();
-		Assert.assertEquals(this.getClass(), caller);
-		
+		Assertions.assertEquals(this.getClass(), caller);
+
 		Class<?> caller0 = CallerUtil.getCaller(0);
-		Assert.assertEquals(CallerUtil.class, caller0);
-		
+		Assertions.assertEquals(CallerUtil.class, caller0);
+
 		Class<?> caller1 = CallerUtil.getCaller(1);
-		Assert.assertEquals(this.getClass(), caller1);
+		Assertions.assertEquals(this.getClass(), caller1);
 	}
-	
+
 	@Test
 	public void getCallerCallerTest() {
 		Class<?> callerCaller = CallerTestClass.getCaller();
-		Assert.assertEquals(this.getClass(), callerCaller);
+		Assertions.assertEquals(this.getClass(), callerCaller);
 	}
-	
+
 	private static class CallerTestClass{
 		public static Class<?> getCaller(){
 			return CallerUtil.getCallerCaller();

--- a/hutool-core/src/test/java/cn/hutool/core/lang/caller/CallerUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/caller/CallerUtilTest.java
@@ -1,16 +1,16 @@
 package cn.hutool.core.lang.caller;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CallerUtilTest {
 
 	@Test
 	public void getCallerMethodNameTest() {
 		final String callerMethodName = CallerUtil.getCallerMethodName(false);
-		Assert.assertEquals("getCallerMethodNameTest", callerMethodName);
+		Assertions.assertEquals("getCallerMethodNameTest", callerMethodName);
 
 		final String fullCallerMethodName = CallerUtil.getCallerMethodName(true);
-		Assert.assertEquals("cn.hutool.core.lang.caller.CallerUtilTest.getCallerMethodNameTest", fullCallerMethodName);
+		Assertions.assertEquals("cn.hutool.core.lang.caller.CallerUtilTest.getCallerMethodNameTest", fullCallerMethodName);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/func/LambdaUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/func/LambdaUtilTest.java
@@ -1,21 +1,21 @@
 package cn.hutool.core.lang.func;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LambdaUtilTest {
 
 	@Test
 	public void getMethodNameTest(){
 		String methodName = LambdaUtil.getMethodName(MyTeacher::getAge);
-		Assert.assertEquals("getAge", methodName);
+		Assertions.assertEquals("getAge", methodName);
 	}
 
 	@Test
 	public void getFieldNameTest(){
 		String fieldName = LambdaUtil.getFieldName(MyTeacher::getAge);
-		Assert.assertEquals("age", fieldName);
+		Assertions.assertEquals("age", fieldName);
 	}
 
 	@Data

--- a/hutool-core/src/test/java/cn/hutool/core/lang/intern/InternUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/intern/InternUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.lang.intern;
 
 import cn.hutool.core.util.RandomUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class InternUtilTest {
 
@@ -16,9 +16,9 @@ public class InternUtilTest {
 		String a1 = RandomUtil.randomString(RandomUtil.randomInt(100));
 		String a2 = new String(a1);
 
-		Assert.assertNotSame(a1, a2);
+		Assertions.assertNotSame(a1, a2);
 
-		Assert.assertSame(interner.intern(a1), interner.intern(a2));
+		Assertions.assertSame(interner.intern(a1), interner.intern(a2));
 	}
 
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/loader/LazyFunLoaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/loader/LazyFunLoaderTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang.loader;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LazyFunLoaderTest {
 
@@ -19,13 +19,13 @@ public class LazyFunLoaderTest {
 
 		LazyFunLoader<BigObject> loader = new LazyFunLoader<>(BigObject::new);
 
-		Assert.assertNotNull(loader.get());
-		Assert.assertTrue(loader.isInitialize());
+		Assertions.assertNotNull(loader.get());
+		Assertions.assertTrue(loader.isInitialize());
 
 		// 对于某些对象，在程序关闭时，需要进行销毁操作
 		loader.ifInitialized(BigObject::destroy);
 
-		Assert.assertTrue(loader.get().isDestroy);
+		Assertions.assertTrue(loader.get().isDestroy);
 	}
 
 	@Test
@@ -36,10 +36,10 @@ public class LazyFunLoaderTest {
 		// 若从未使用，则可以避免不必要的初始化
 		loader.ifInitialized(it -> {
 
-			Assert.fail();
+			Assertions.fail();
 			it.destroy();
 		});
 
-		Assert.assertFalse(loader.isInitialize());
+		Assertions.assertFalse(loader.isInitialize());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/reflect/ActualTypeMapperPoolTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/reflect/ActualTypeMapperPoolTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang.reflect;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -18,15 +18,15 @@ public class ActualTypeMapperPoolTest {
 		final Map<Type, Type> typeTypeMap = ActualTypeMapperPool.get(FinalClass.class);
 		typeTypeMap.forEach((key, value)->{
 			if("A".equals(key.getTypeName())){
-				Assert.assertEquals(Character.class, value);
+				Assertions.assertEquals(Character.class, value);
 			} else if("B".equals(key.getTypeName())){
-				Assert.assertEquals(Boolean.class, value);
+				Assertions.assertEquals(Boolean.class, value);
 			} else if("C".equals(key.getTypeName())){
-				Assert.assertEquals(String.class, value);
+				Assertions.assertEquals(String.class, value);
 			} else if("D".equals(key.getTypeName())){
-				Assert.assertEquals(Double.class, value);
+				Assertions.assertEquals(Double.class, value);
 			} else if("E".equals(key.getTypeName())){
-				Assert.assertEquals(Integer.class, value);
+				Assertions.assertEquals(Integer.class, value);
 			}
 		});
 	}
@@ -36,15 +36,15 @@ public class ActualTypeMapperPoolTest {
 		final Map<String, Type> typeTypeMap = ActualTypeMapperPool.getStrKeyMap(FinalClass.class);
 		typeTypeMap.forEach((key, value)->{
 			if("A".equals(key)){
-				Assert.assertEquals(Character.class, value);
+				Assertions.assertEquals(Character.class, value);
 			} else if("B".equals(key)){
-				Assert.assertEquals(Boolean.class, value);
+				Assertions.assertEquals(Boolean.class, value);
 			} else if("C".equals(key)){
-				Assert.assertEquals(String.class, value);
+				Assertions.assertEquals(String.class, value);
 			} else if("D".equals(key)){
-				Assert.assertEquals(Double.class, value);
+				Assertions.assertEquals(Double.class, value);
 			} else if("E".equals(key)){
-				Assert.assertEquals(Integer.class, value);
+				Assertions.assertEquals(Integer.class, value);
 			}
 		});
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/lang/reflect/MethodHandleUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/reflect/MethodHandleUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.lang.reflect;
 
 import cn.hutool.core.util.ClassLoaderUtil;
 import cn.hutool.core.util.ReflectUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodType;
@@ -19,16 +19,16 @@ public class MethodHandleUtilTest {
 				new Class[] { Duck.class },
 				MethodHandleUtil::invokeSpecial);
 
-		Assert.assertEquals("Quack", duck.quack());
+		Assertions.assertEquals("Quack", duck.quack());
 
 		// 测试子类执行default方法
 		final Method quackMethod = ReflectUtil.getMethod(Duck.class, "quack");
 		String quack = MethodHandleUtil.invokeSpecial(new BigDuck(), quackMethod);
-		Assert.assertEquals("Quack", quack);
+		Assertions.assertEquals("Quack", quack);
 
 		// 测试反射执行默认方法
 		quack = ReflectUtil.invoke(new Duck() {}, quackMethod);
-		Assert.assertEquals("Quack", quack);
+		Assertions.assertEquals("Quack", quack);
 	}
 
 	@Test
@@ -38,7 +38,7 @@ public class MethodHandleUtilTest {
 				new Class[] { Duck.class },
 				ReflectUtil::invoke);
 
-		Assert.assertEquals("Quack", duck.quack());
+		Assertions.assertEquals("Quack", duck.quack());
 	}
 
 	@Test
@@ -48,7 +48,7 @@ public class MethodHandleUtilTest {
 				new Class[] { Duck.class },
 				ReflectUtil::invoke);
 
-		Assert.assertEquals("Quack", duck.quack());
+		Assertions.assertEquals("Quack", duck.quack());
 	}
 
 	@Test
@@ -56,7 +56,7 @@ public class MethodHandleUtilTest {
 		// 测试执行普通方法
 		final int size = MethodHandleUtil.invokeSpecial(new BigDuck(),
 				ReflectUtil.getMethod(BigDuck.class, "getSize"));
-		Assert.assertEquals(36, size);
+		Assertions.assertEquals(36, size);
 	}
 
 	@Test
@@ -64,45 +64,45 @@ public class MethodHandleUtilTest {
 		// 测试执行普通方法
 		final String result = MethodHandleUtil.invoke(null,
 				ReflectUtil.getMethod(Duck.class, "getDuck", int.class), 78);
-		Assert.assertEquals("Duck 78", result);
+		Assertions.assertEquals("Duck 78", result);
 	}
 
 	@Test
 	public void findMethodTest() throws Throwable {
 		MethodHandle handle = MethodHandleUtil.findMethod(Duck.class, "quack",
 				MethodType.methodType(String.class));
-		Assert.assertNotNull(handle);
+		Assertions.assertNotNull(handle);
 		// 对象方法自行需要绑定对象或者传入对象参数
 		String invoke = (String) handle.invoke(new BigDuck());
-		Assert.assertEquals("Quack", invoke);
+		Assertions.assertEquals("Quack", invoke);
 
 		// 对象的方法获取
 		handle = MethodHandleUtil.findMethod(BigDuck.class, "getSize",
 				MethodType.methodType(int.class));
-		Assert.assertNotNull(handle);
+		Assertions.assertNotNull(handle);
 		int invokeInt = (int) handle.invoke(new BigDuck());
-		Assert.assertEquals(36, invokeInt);
+		Assertions.assertEquals(36, invokeInt);
 	}
 
 	@Test
 	public void findStaticMethodTest() throws Throwable {
 		final MethodHandle handle = MethodHandleUtil.findMethod(Duck.class, "getDuck",
 				MethodType.methodType(String.class, int.class));
-		Assert.assertNotNull(handle);
+		Assertions.assertNotNull(handle);
 
 		// static 方法执行不需要绑定或者传入对象，直接传入参数即可
 		final String invoke = (String) handle.invoke(12);
-		Assert.assertEquals("Duck 12", invoke);
+		Assertions.assertEquals("Duck 12", invoke);
 	}
 
 	@Test
 	public void findPrivateMethodTest() throws Throwable {
 		final MethodHandle handle = MethodHandleUtil.findMethod(BigDuck.class, "getPrivateValue",
 				MethodType.methodType(String.class));
-		Assert.assertNotNull(handle);
+		Assertions.assertNotNull(handle);
 
 		final String invoke = (String) handle.invoke(new BigDuck());
-		Assert.assertEquals("private value", invoke);
+		Assertions.assertEquals("private value", invoke);
 	}
 
 	@Test
@@ -110,20 +110,20 @@ public class MethodHandleUtilTest {
 		// 查找父类的方法
 		final MethodHandle handle = MethodHandleUtil.findMethod(BigDuck.class, "quack",
 				MethodType.methodType(String.class));
-		Assert.assertNotNull(handle);
+		Assertions.assertNotNull(handle);
 
 		final String invoke = (String) handle.invoke(new BigDuck());
-		Assert.assertEquals("Quack", invoke);
+		Assertions.assertEquals("Quack", invoke);
 	}
 
 	@Test
 	public void findPrivateStaticMethodTest() throws Throwable {
 		final MethodHandle handle = MethodHandleUtil.findMethod(BigDuck.class, "getPrivateStaticValue",
 				MethodType.methodType(String.class));
-		Assert.assertNotNull(handle);
+		Assertions.assertNotNull(handle);
 
 		final String invoke = (String) handle.invoke();
-		Assert.assertEquals("private static value", invoke);
+		Assertions.assertEquals("private static value", invoke);
 	}
 
 	interface Duck {

--- a/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeBuilderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeBuilderTest.java
@@ -1,15 +1,18 @@
 package cn.hutool.core.lang.tree;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
 public class TreeBuilderTest {
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void checkIsBuiltTest(){
-		final TreeBuilder<Integer> of = TreeBuilder.of(0);
-		of.build();
-		of.append(new ArrayList<>());
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			final TreeBuilder<Integer> of = TreeBuilder.of(0);
+			of.build();
+			of.append(new ArrayList<>());
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeSearchTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeSearchTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.lang.tree;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +32,6 @@ public class TreeSearchTest {
 		Tree<Long> tree=treeItems.get(0);
 		Tree<Long> searchResult=tree.getNode(3L);
 
-		Assert.assertEquals("module-B", searchResult.getName());
+		Assertions.assertEquals("module-B", searchResult.getName());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/tree/TreeTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.lang.tree;
 
 import cn.hutool.core.collection.CollUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,15 +32,15 @@ public class TreeTest {
 	public void sampleTreeTest() {
 		List<Tree<String>> treeList = TreeUtil.build(nodeList, "0");
 		for (Tree<String> tree : treeList) {
-			Assert.assertNotNull(tree);
-			Assert.assertEquals("0", tree.getParentId());
+			Assertions.assertNotNull(tree);
+			Assertions.assertEquals("0", tree.getParentId());
 //			Console.log(tree);
 		}
 
 		// 测试通过子节点查找父节点
 		final Tree<String> rootNode0 = treeList.get(0);
 		final Tree<String> parent = rootNode0.getChildren().get(0).getParent();
-		Assert.assertEquals(rootNode0, parent);
+		Assertions.assertEquals(rootNode0, parent);
 	}
 
 	@Test
@@ -65,7 +65,7 @@ public class TreeTest {
 					tree.putExtra("other", new Object());
 				});
 
-		Assert.assertEquals(treeNodes.size(), 2);
+		Assertions.assertEquals(treeNodes.size(), 2);
 	}
 
 	@Test
@@ -74,7 +74,7 @@ public class TreeTest {
 		final Tree<String> tree = TreeUtil.buildSingle(nodeList, "0");
 		tree.walk((tr)-> ids.add(tr.getId()));
 
-		Assert .assertEquals(7, ids.size());
+		Assertions.assertEquals(7, ids.size());
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class TreeTest {
 		List<String> ids = new ArrayList<>();
 		cloneTree.walk((tr)-> ids.add(tr.getId()));
 
-		Assert .assertEquals(7, ids.size());
+		Assertions.assertEquals(7, ids.size());
 	}
 
 	@Test
@@ -99,7 +99,7 @@ public class TreeTest {
 
 		List<String> ids = new ArrayList<>();
 		tree.walk((tr)-> ids.add(tr.getId()));
-		Assert .assertEquals(4, ids.size());
+		Assertions.assertEquals(4, ids.size());
 	}
 
 	@Test
@@ -114,10 +114,10 @@ public class TreeTest {
 
 		List<String> ids = new ArrayList<>();
 		newTree.walk((tr)-> ids.add(tr.getId()));
-		Assert .assertEquals(4, ids.size());
+		Assertions.assertEquals(4, ids.size());
 
 		List<String> ids2 = new ArrayList<>();
 		tree.walk((tr)-> ids2.add(tr.getId()));
-		Assert .assertEquals(7, ids2.size());
+		Assertions.assertEquals(7, ids2.size());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/BiMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/BiMapTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -13,10 +13,10 @@ public class BiMapTest {
 		biMap.put("aaa", 111);
 		biMap.put("bbb", 222);
 
-		Assert.assertEquals(new Integer(111), biMap.get("aaa"));
-		Assert.assertEquals(new Integer(222), biMap.get("bbb"));
+		Assertions.assertEquals(new Integer(111), biMap.get("aaa"));
+		Assertions.assertEquals(new Integer(222), biMap.get("bbb"));
 
-		Assert.assertEquals("aaa", biMap.getKey(111));
-		Assert.assertEquals("bbb", biMap.getKey(222));
+		Assertions.assertEquals("aaa", biMap.getKey(111));
+		Assertions.assertEquals("bbb", biMap.getKey(222));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/CamelCaseMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/CamelCaseMapTest.java
@@ -1,23 +1,23 @@
 package cn.hutool.core.map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CamelCaseMapTest {
-	
+
 	@Test
 	public void caseInsensitiveMapTest() {
 		CamelCaseMap<String, String> map = new CamelCaseMap<>();
 		map.put("customKey", "OK");
-		Assert.assertEquals("OK", map.get("customKey"));
-		Assert.assertEquals("OK", map.get("custom_key"));
+		Assertions.assertEquals("OK", map.get("customKey"));
+		Assertions.assertEquals("OK", map.get("custom_key"));
 	}
-	
+
 	@Test
 	public void caseInsensitiveLinkedMapTest() {
 		CamelCaseLinkedMap<String, String> map = new CamelCaseLinkedMap<>();
 		map.put("customKey", "OK");
-		Assert.assertEquals("OK", map.get("customKey"));
-		Assert.assertEquals("OK", map.get("custom_key"));
+		Assertions.assertEquals("OK", map.get("customKey"));
+		Assertions.assertEquals("OK", map.get("custom_key"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/CaseInsensitiveMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/CaseInsensitiveMapTest.java
@@ -1,23 +1,23 @@
 package cn.hutool.core.map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CaseInsensitiveMapTest {
-	
+
 	@Test
 	public void caseInsensitiveMapTest() {
 		CaseInsensitiveMap<String, String> map = new CaseInsensitiveMap<>();
 		map.put("aAA", "OK");
-		Assert.assertEquals("OK", map.get("aaa"));
-		Assert.assertEquals("OK", map.get("AAA"));
+		Assertions.assertEquals("OK", map.get("aaa"));
+		Assertions.assertEquals("OK", map.get("AAA"));
 	}
-	
+
 	@Test
 	public void caseInsensitiveLinkedMapTest() {
 		CaseInsensitiveLinkedMap<String, String> map = new CaseInsensitiveLinkedMap<>();
 		map.put("aAA", "OK");
-		Assert.assertEquals("OK", map.get("aaa"));
-		Assert.assertEquals("OK", map.get("AAA"));
+		Assertions.assertEquals("OK", map.get("aaa"));
+		Assertions.assertEquals("OK", map.get("AAA"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/MapBuilderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/MapBuilderTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -16,10 +16,10 @@ public class MapBuilderTest {
 				.put(false, "d", () -> getValue(4))
 				.build();
 
-		Assert.assertEquals(map.get("a"), "1");
-		Assert.assertFalse(map.containsKey("b"));
-		Assert.assertEquals(map.get("c"), "3");
-		Assert.assertFalse(map.containsKey("d"));
+		Assertions.assertEquals(map.get("a"), "1");
+		Assertions.assertFalse(map.containsKey("b"));
+		Assertions.assertEquals(map.get("c"), "3");
+		Assertions.assertFalse(map.containsKey("d"));
 	}
 
 	public String getValue(int value) {

--- a/hutool-core/src/test/java/cn/hutool/core/map/MapUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/MapUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.map;
 
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,10 +20,10 @@ public class MapUtilTest {
 
 		Map<String, String> map2 = MapUtil.filter(map, t -> Convert.toInt(t.getValue()) % 2 == 0);
 
-		Assert.assertEquals(2, map2.size());
+		Assertions.assertEquals(2, map2.size());
 
-		Assert.assertEquals("2", map2.get("b"));
-		Assert.assertEquals("4", map2.get("d"));
+		Assertions.assertEquals("2", map2.get("b"));
+		Assertions.assertEquals("4", map2.get("d"));
 	}
 
 	@Test
@@ -35,9 +35,9 @@ public class MapUtilTest {
 		map.put("fgh", "4");
 
 		Map<String, String> map2 = MapUtil.filter(map, t -> StrUtil.contains(t.getKey(), "bc"));
-		Assert.assertEquals(2, map2.size());
-		Assert.assertEquals("1", map2.get("abc"));
-		Assert.assertEquals("2", map2.get("bcd"));
+		Assertions.assertEquals(2, map2.size());
+		Assertions.assertEquals("1", map2.get("abc"));
+		Assertions.assertEquals("2", map2.get("bcd"));
 	}
 
 	@Test
@@ -54,12 +54,12 @@ public class MapUtilTest {
 			return t;
 		});
 
-		Assert.assertEquals(4, map2.size());
+		Assertions.assertEquals(4, map2.size());
 
-		Assert.assertEquals("10", map2.get("a"));
-		Assert.assertEquals("20", map2.get("b"));
-		Assert.assertEquals("30", map2.get("c"));
-		Assert.assertEquals("40", map2.get("d"));
+		Assertions.assertEquals("10", map2.get("a"));
+		Assertions.assertEquals("20", map2.get("b"));
+		Assertions.assertEquals("30", map2.get("c"));
+		Assertions.assertEquals("40", map2.get("d"));
 	}
 
 	@Test
@@ -72,10 +72,10 @@ public class MapUtilTest {
 
 		Map<String, String> map2 = MapUtil.reverse(map);
 
-		Assert.assertEquals("a", map2.get("1"));
-		Assert.assertEquals("b", map2.get("2"));
-		Assert.assertEquals("c", map2.get("3"));
-		Assert.assertEquals("d", map2.get("4"));
+		Assertions.assertEquals("a", map2.get("1"));
+		Assertions.assertEquals("b", map2.get("2"));
+		Assertions.assertEquals("c", map2.get("3"));
+		Assertions.assertEquals("d", map2.get("4"));
 	}
 
 	@Test
@@ -87,14 +87,14 @@ public class MapUtilTest {
 		map.put("d", "4");
 
 		Object[][] objectArray = MapUtil.toObjectArray(map);
-		Assert.assertEquals("a", objectArray[0][0]);
-		Assert.assertEquals("1", objectArray[0][1]);
-		Assert.assertEquals("b", objectArray[1][0]);
-		Assert.assertEquals("2", objectArray[1][1]);
-		Assert.assertEquals("c", objectArray[2][0]);
-		Assert.assertEquals("3", objectArray[2][1]);
-		Assert.assertEquals("d", objectArray[3][0]);
-		Assert.assertEquals("4", objectArray[3][1]);
+		Assertions.assertEquals("a", objectArray[0][0]);
+		Assertions.assertEquals("1", objectArray[0][1]);
+		Assertions.assertEquals("b", objectArray[1][0]);
+		Assertions.assertEquals("2", objectArray[1][1]);
+		Assertions.assertEquals("c", objectArray[2][0]);
+		Assertions.assertEquals("3", objectArray[2][1]);
+		Assertions.assertEquals("d", objectArray[3][0]);
+		Assertions.assertEquals("4", objectArray[3][1]);
 	}
 
 	@Test
@@ -105,12 +105,12 @@ public class MapUtilTest {
 				.put("key2", "value2").build();
 
 		String join1 = MapUtil.sortJoin(build, StrUtil.EMPTY, StrUtil.EMPTY, false);
-		Assert.assertEquals("key1value1key2value2key3value3", join1);
+		Assertions.assertEquals("key1value1key2value2key3value3", join1);
 
 		String join2 = MapUtil.sortJoin(build, StrUtil.EMPTY, StrUtil.EMPTY, false, "123");
-		Assert.assertEquals("key1value1key2value2key3value3123", join2);
+		Assertions.assertEquals("key1value1key2value2key3value3123", join2);
 
 		String join3 = MapUtil.sortJoin(build, StrUtil.EMPTY, StrUtil.EMPTY, false, "123", "abc");
-		Assert.assertEquals("key1value1key2value2key3value3123abc", join3);
+		Assertions.assertEquals("key1value1key2value2key3value3123abc", join3);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/TableMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/TableMapTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TableMapTest {
 
@@ -11,10 +11,10 @@ public class TableMapTest {
 		tableMap.put("aaa", 111);
 		tableMap.put("bbb", 222);
 
-		Assert.assertEquals(new Integer(111), tableMap.get("aaa"));
-		Assert.assertEquals(new Integer(222), tableMap.get("bbb"));
+		Assertions.assertEquals(new Integer(111), tableMap.get("aaa"));
+		Assertions.assertEquals(new Integer(222), tableMap.get("bbb"));
 
-		Assert.assertEquals("aaa", tableMap.getKey(111));
-		Assert.assertEquals("bbb", tableMap.getKey(222));
+		Assertions.assertEquals("aaa", tableMap.getKey(111));
+		Assertions.assertEquals("bbb", tableMap.getKey(222));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/TolerantMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/TolerantMapTest.java
@@ -2,8 +2,9 @@ package cn.hutool.core.map;
 
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.RandomUtil;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -11,8 +12,8 @@ public class TolerantMapTest {
 
 	private final TolerantMap<String, String> map = TolerantMap.of(new HashMap<>(), "default");
 
-	@Before
-	public void before() {
+	@BeforeEach
+	public void init() {
 		map.put("monday", "星期一");
 		map.put("tuesday", "星期二");
 	}
@@ -21,20 +22,25 @@ public class TolerantMapTest {
 	public void testSerialize() {
 		byte[] bytes = ObjectUtil.serialize(map);
 		TolerantMap<String, String> serializedMap = ObjectUtil.deserialize(bytes);
-		assert serializedMap != map;
-		assert map.equals(serializedMap);
+		Assertions.assertNotSame(serializedMap, map);
+		Assertions.assertEquals(map, serializedMap);
 	}
 
 	@Test
 	public void testClone() {
 		TolerantMap<String, String> clonedMap = ObjectUtil.clone(map);
-		assert clonedMap != map;
-		assert map.equals(clonedMap);
+		Assertions.assertNotSame(clonedMap, map);
+		Assertions.assertEquals(map, clonedMap);
 	}
 
 	@Test
 	public void testGet() {
-		assert "星期二".equals(map.get("tuesday"));
-		assert "default".equals(map.get(RandomUtil.randomString(6)));
+		Assertions.assertTrue(map.containsKey("tuesday"));
+		Assertions.assertEquals("星期二", map.get("tuesday"));
+	}
+
+	@Test
+	public void testGet2() {
+		Assertions.assertEquals("default", map.get(RandomUtil.randomString(6)));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/map/TolerantMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/TolerantMapTest.java
@@ -3,17 +3,17 @@ package cn.hutool.core.map;
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.RandomUtil;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
 public class TolerantMapTest {
 
-	private final TolerantMap<String, String> map = TolerantMap.of(new HashMap<>(), "default");
+	private static final TolerantMap<String, String> map = TolerantMap.of(new HashMap<>(), "default");
 
-	@BeforeEach
-	public void init() {
+	@BeforeAll
+	public static void init() {
 		map.put("monday", "星期一");
 		map.put("tuesday", "星期二");
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/map/TolerantMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/TolerantMapTest.java
@@ -35,12 +35,7 @@ public class TolerantMapTest {
 
 	@Test
 	public void testGet() {
-		Assertions.assertTrue(map.containsKey("tuesday"));
 		Assertions.assertEquals("星期二", map.get("tuesday"));
-	}
-
-	@Test
-	public void testGet2() {
 		Assertions.assertEquals("default", map.get(RandomUtil.randomString(6)));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/math/ArrangementTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/ArrangementTest.java
@@ -2,9 +2,9 @@ package cn.hutool.core.math;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.Console;
 
@@ -14,49 +14,49 @@ import cn.hutool.core.lang.Console;
  *
  */
 public class ArrangementTest {
-	
+
 	@Test
 	public void arrangementTest() {
 		long result = Arrangement.count(4, 2);
-		Assert.assertEquals(12, result);
-		
+		Assertions.assertEquals(12, result);
+
 		result = Arrangement.count(4, 1);
-		Assert.assertEquals(4, result);
-		
+		Assertions.assertEquals(4, result);
+
 		result = Arrangement.count(4, 0);
-		Assert.assertEquals(1, result);
-		
+		Assertions.assertEquals(1, result);
+
 		long resultAll = Arrangement.countAll(4);
-		Assert.assertEquals(64, resultAll);
+		Assertions.assertEquals(64, resultAll);
 	}
-	
+
 	@Test
 	public void selectTest() {
 		Arrangement arrangement = new Arrangement(new String[] { "1", "2", "3", "4" });
 		List<String[]> list = arrangement.select(2);
-		Assert.assertEquals(Arrangement.count(4, 2), list.size());
-		Assert.assertArrayEquals(new String[] {"1", "2"}, list.get(0));
-		Assert.assertArrayEquals(new String[] {"1", "3"}, list.get(1));
-		Assert.assertArrayEquals(new String[] {"1", "4"}, list.get(2));
-		Assert.assertArrayEquals(new String[] {"2", "1"}, list.get(3));
-		Assert.assertArrayEquals(new String[] {"2", "3"}, list.get(4));
-		Assert.assertArrayEquals(new String[] {"2", "4"}, list.get(5));
-		Assert.assertArrayEquals(new String[] {"3", "1"}, list.get(6));
-		Assert.assertArrayEquals(new String[] {"3", "2"}, list.get(7));
-		Assert.assertArrayEquals(new String[] {"3", "4"}, list.get(8));
-		Assert.assertArrayEquals(new String[] {"4", "1"}, list.get(9));
-		Assert.assertArrayEquals(new String[] {"4", "2"}, list.get(10));
-		Assert.assertArrayEquals(new String[] {"4", "3"}, list.get(11));
-		
+		Assertions.assertEquals(Arrangement.count(4, 2), list.size());
+		Assertions.assertArrayEquals(new String[] {"1", "2"}, list.get(0));
+		Assertions.assertArrayEquals(new String[] {"1", "3"}, list.get(1));
+		Assertions.assertArrayEquals(new String[] {"1", "4"}, list.get(2));
+		Assertions.assertArrayEquals(new String[] {"2", "1"}, list.get(3));
+		Assertions.assertArrayEquals(new String[] {"2", "3"}, list.get(4));
+		Assertions.assertArrayEquals(new String[] {"2", "4"}, list.get(5));
+		Assertions.assertArrayEquals(new String[] {"3", "1"}, list.get(6));
+		Assertions.assertArrayEquals(new String[] {"3", "2"}, list.get(7));
+		Assertions.assertArrayEquals(new String[] {"3", "4"}, list.get(8));
+		Assertions.assertArrayEquals(new String[] {"4", "1"}, list.get(9));
+		Assertions.assertArrayEquals(new String[] {"4", "2"}, list.get(10));
+		Assertions.assertArrayEquals(new String[] {"4", "3"}, list.get(11));
+
 		List<String[]> selectAll = arrangement.selectAll();
-		Assert.assertEquals(Arrangement.countAll(4), selectAll.size());
-		
+		Assertions.assertEquals(Arrangement.countAll(4), selectAll.size());
+
 		List<String[]> list2 = arrangement.select(0);
-		Assert.assertEquals(1, list2.size());
+		Assertions.assertEquals(1, list2.size());
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void selectTest2() {
 		List<String[]> list = MathUtil.arrangementSelect(new String[] { "1", "1", "3", "4" });
 		for (String[] strings : list) {

--- a/hutool-core/src/test/java/cn/hutool/core/math/CalculatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/CalculatorTest.java
@@ -1,40 +1,40 @@
 package cn.hutool.core.math;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CalculatorTest {
 
 	@Test
 	public void conversationTest(){
 		final double conversion = Calculator.conversion("(0*1--3)-5/-4-(3*(-2.13))");
-		Assert.assertEquals(10.64, conversion, 2);
+		Assertions.assertEquals(10.64, conversion, 2);
 	}
 
 	@Test
 	public void conversationTest2(){
 		final double conversion = Calculator.conversion("77 * 12");
-		Assert.assertEquals(924.0, conversion, 2);
+		Assertions.assertEquals(924.0, conversion, 2);
 	}
 
 	@Test
 	public void conversationTest3(){
 		final double conversion = Calculator.conversion("1");
-		Assert.assertEquals(1, conversion, 2);
+		Assertions.assertEquals(1, conversion, 2);
 	}
 
 	@Test
 	public void conversationTest4(){
 		final double conversion = Calculator.conversion("(88*66/23)%26+45%9");
-		Assert.assertEquals((88D * 66 / 23) % 26, conversion, 2);
+		Assertions.assertEquals((88D * 66 / 23) % 26, conversion, 2);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void conversationTest5(){
 		// https://github.com/dromara/hutool/issues/1984
 		final double conversion = Calculator.conversion("((1/1) / (1/1) -1) * 100");
-		Assert.assertEquals((88D * 66 / 23) % 26, conversion, 2);
+		Assertions.assertEquals((88D * 66 / 23) % 26, conversion, 2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/math/CombinationTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/CombinationTest.java
@@ -1,13 +1,13 @@
 package cn.hutool.core.math;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 /**
  * 组合单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -16,39 +16,39 @@ public class CombinationTest {
 	@Test
 	public void countTest() {
 		long result = Combination.count(5, 2);
-		Assert.assertEquals(10, result);
-		
+		Assertions.assertEquals(10, result);
+
 		result = Combination.count(5, 5);
-		Assert.assertEquals(1, result);
-		
+		Assertions.assertEquals(1, result);
+
 		result = Combination.count(5, 0);
-		Assert.assertEquals(1, result);
-		
+		Assertions.assertEquals(1, result);
+
 		long resultAll = Combination.countAll(5);
-		Assert.assertEquals(31, resultAll);
+		Assertions.assertEquals(31, resultAll);
 	}
 
 	@Test
 	public void selectTest() {
 		Combination combination = new Combination(new String[] { "1", "2", "3", "4", "5" });
 		List<String[]> list = combination.select(2);
-		Assert.assertEquals(Combination.count(5, 2), list.size());
-		
-		Assert.assertArrayEquals(new String[] {"1", "2"}, list.get(0));
-		Assert.assertArrayEquals(new String[] {"1", "3"}, list.get(1));
-		Assert.assertArrayEquals(new String[] {"1", "4"}, list.get(2));
-		Assert.assertArrayEquals(new String[] {"1", "5"}, list.get(3));
-		Assert.assertArrayEquals(new String[] {"2", "3"}, list.get(4));
-		Assert.assertArrayEquals(new String[] {"2", "4"}, list.get(5));
-		Assert.assertArrayEquals(new String[] {"2", "5"}, list.get(6));
-		Assert.assertArrayEquals(new String[] {"3", "4"}, list.get(7));
-		Assert.assertArrayEquals(new String[] {"3", "5"}, list.get(8));
-		Assert.assertArrayEquals(new String[] {"4", "5"}, list.get(9));
-		
+		Assertions.assertEquals(Combination.count(5, 2), list.size());
+
+		Assertions.assertArrayEquals(new String[] {"1", "2"}, list.get(0));
+		Assertions.assertArrayEquals(new String[] {"1", "3"}, list.get(1));
+		Assertions.assertArrayEquals(new String[] {"1", "4"}, list.get(2));
+		Assertions.assertArrayEquals(new String[] {"1", "5"}, list.get(3));
+		Assertions.assertArrayEquals(new String[] {"2", "3"}, list.get(4));
+		Assertions.assertArrayEquals(new String[] {"2", "4"}, list.get(5));
+		Assertions.assertArrayEquals(new String[] {"2", "5"}, list.get(6));
+		Assertions.assertArrayEquals(new String[] {"3", "4"}, list.get(7));
+		Assertions.assertArrayEquals(new String[] {"3", "5"}, list.get(8));
+		Assertions.assertArrayEquals(new String[] {"4", "5"}, list.get(9));
+
 		List<String[]> selectAll = combination.selectAll();
-		Assert.assertEquals(Combination.countAll(5), selectAll.size());
-		
+		Assertions.assertEquals(Combination.countAll(5), selectAll.size());
+
 		List<String[]> list2 = combination.select(0);
-		Assert.assertEquals(1, list2.size());
+		Assertions.assertEquals(1, list2.size());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
@@ -1,23 +1,23 @@
 package cn.hutool.core.math;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MoneyTest {
 
 	@Test
 	public void yuanToCentTest() {
 		final Money money = new Money("1234.56");
-		Assert.assertEquals(123456, money.getCent());
+		Assertions.assertEquals(123456, money.getCent());
 
-		Assert.assertEquals(123456, MathUtil.yuanToCent(1234.56));
+		Assertions.assertEquals(123456, MathUtil.yuanToCent(1234.56));
 	}
 
 	@Test
 	public void centToYuanTest() {
 		final Money money = new Money(1234, 56);
-		Assert.assertEquals(1234.56D, money.getAmount().doubleValue(), 2);
+		Assertions.assertEquals(1234.56D, money.getAmount().doubleValue(), 2);
 
-		Assert.assertEquals(1234.56D, MathUtil.centToYuan(123456), 2);
+		Assertions.assertEquals(1234.56D, MathUtil.centToYuan(123456), 2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/FormUrlencodedTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/FormUrlencodedTest.java
@@ -1,17 +1,17 @@
 package cn.hutool.core.net;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FormUrlencodedTest {
 
 	@Test
 	public void encodeParamTest(){
 		String encode = FormUrlencoded.ALL.encode("a+b", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a%2Bb", encode);
+		Assertions.assertEquals("a%2Bb", encode);
 
 		encode = FormUrlencoded.ALL.encode("a b", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a+b", encode);
+		Assertions.assertEquals("a+b", encode);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/Ipv4UtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/Ipv4UtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.net;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
 
@@ -11,19 +11,19 @@ public class Ipv4UtilTest {
 	@Test
 	public void getMaskBitByMaskTest(){
 		final int maskBitByMask = Ipv4Util.getMaskBitByMask("255.255.255.0");
-		Assert.assertEquals(24, maskBitByMask);
+		Assertions.assertEquals(24, maskBitByMask);
 	}
 
 	@Test
 	public void getMaskBitByIllegalMaskTest() {
-		ThrowingRunnable getMaskBitByMaskRunnable = () -> Ipv4Util.getMaskBitByMask("255.255.0.255");
-		Assert.assertThrows("非法掩码测试", IllegalArgumentException.class, getMaskBitByMaskRunnable);
+		Executable getMaskBitByMaskExecutable = () -> Ipv4Util.getMaskBitByMask("255.255.0.255");
+		Assertions.assertThrows(IllegalArgumentException.class, getMaskBitByMaskExecutable, "非法掩码测试");
 	}
 
 	@Test
 	public void getMaskByMaskBitTest(){
 		final String mask = Ipv4Util.getMaskByMaskBit(24);
-		Assert.assertEquals("255.255.255.0", mask);
+		Assertions.assertEquals("255.255.255.0", mask);
 	}
 
 	@Test
@@ -31,7 +31,7 @@ public class Ipv4UtilTest {
 		String ip = "192.168.1.255";
 		final long ipLong = Ipv4Util.ipv4ToLong(ip);
 		String ipv4 = Ipv4Util.longToIpv4(ipLong);
-		Assert.assertEquals(ip, ipv4);
+		Assertions.assertEquals(ip, ipv4);
 	}
 
 	@Test
@@ -39,51 +39,51 @@ public class Ipv4UtilTest {
 		String ip = "192.168.1.1";
 		final int maskBitByMask = Ipv4Util.getMaskBitByMask("255.255.255.0");
 		final String endIpStr = Ipv4Util.getEndIpStr(ip, maskBitByMask);
-		Assert.assertEquals("192.168.1.255", endIpStr);
+		Assertions.assertEquals("192.168.1.255", endIpStr);
 	}
 
 	@Test
 	public void listTest(){
 		int maskBit = Ipv4Util.getMaskBitByMask("255.255.255.0");
 		final List<String> list = Ipv4Util.list("192.168.100.2", maskBit, false);
-		Assert.assertEquals(254, list.size());
+		Assertions.assertEquals(254, list.size());
 	}
 
 	@Test
 	public void isMaskValidTest() {
 		boolean maskValid = Ipv4Util.isMaskValid("255.255.255.0");
-		Assert.assertTrue("掩码合法检验", maskValid);
+		Assertions.assertTrue(maskValid, "掩码合法检验");
 	}
 
 	@Test
 	public void isMaskInvalidTest() {
-		Assert.assertFalse("掩码非法检验 - 255.255.0.255", Ipv4Util.isMaskValid("255.255.0.255"));
-		Assert.assertFalse("掩码非法检验 - null值", Ipv4Util.isMaskValid(null));
-		Assert.assertFalse("掩码非法检验 - 空字符串", Ipv4Util.isMaskValid(""));
-		Assert.assertFalse("掩码非法检验 - 空白字符串", Ipv4Util.isMaskValid(" "));
+		Assertions.assertFalse(Ipv4Util.isMaskValid("255.255.0.255"), "掩码非法检验 - 255.255.0.255");
+		Assertions.assertFalse(Ipv4Util.isMaskValid(null), "掩码非法检验 - null值");
+		Assertions.assertFalse(Ipv4Util.isMaskValid(""), "掩码非法检验 - 空字符串");
+		Assertions.assertFalse(Ipv4Util.isMaskValid(" "), "掩码非法检验 - 空白字符串");
 	}
 
 	@Test
 	public void isMaskBitValidTest() {
 		boolean maskBitValid = Ipv4Util.isMaskBitValid(32);
-		Assert.assertTrue("掩码位合法检验", maskBitValid);
+		Assertions.assertTrue(maskBitValid, "掩码位合法检验");
 	}
 
 	@Test
 	public void isMaskBitInvalidTest() {
 		boolean maskBitValid = Ipv4Util.isMaskBitValid(33);
-		Assert.assertFalse("掩码位非法检验", maskBitValid);
+		Assertions.assertFalse(maskBitValid, "掩码位非法检验");
 	}
 
 	@Test
 	public void ipv4ToLongTest(){
 		long l = Ipv4Util.ipv4ToLong("127.0.0.1");
-		Assert.assertEquals(2130706433L, l);
+		Assertions.assertEquals(2130706433L, l);
 		l = Ipv4Util.ipv4ToLong("114.114.114.114");
-		Assert.assertEquals(1920103026L, l);
+		Assertions.assertEquals(1920103026L, l);
 		l = Ipv4Util.ipv4ToLong("0.0.0.0");
-		Assert.assertEquals(0L, l);
+		Assertions.assertEquals(0L, l);
 		l = Ipv4Util.ipv4ToLong("255.255.255.255");
-		Assert.assertEquals(4294967295L, l);
+		Assertions.assertEquals(4294967295L, l);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/NetUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/NetUtilTest.java
@@ -3,9 +3,9 @@ package cn.hutool.core.net;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.lang.PatternPool;
 import cn.hutool.core.util.ReUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.net.HttpCookie;
 import java.net.InetAddress;
@@ -21,81 +21,81 @@ import java.util.List;
 public class NetUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getLocalhostStrTest() {
 		String localhost = NetUtil.getLocalhostStr();
-		Assert.assertNotNull(localhost);
+		Assertions.assertNotNull(localhost);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getLocalhostTest() {
 		InetAddress localhost = NetUtil.getLocalhost();
-		Assert.assertNotNull(localhost);
+		Assertions.assertNotNull(localhost);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getLocalMacAddressTest() {
 		String macAddress = NetUtil.getLocalMacAddress();
-		Assert.assertNotNull(macAddress);
+		Assertions.assertNotNull(macAddress);
 
 		// 验证MAC地址正确
 		boolean match = ReUtil.isMatch(PatternPool.MAC_ADDRESS, macAddress);
-		Assert.assertTrue(match);
+		Assertions.assertTrue(match);
 	}
 
 	@Test
 	public void longToIpTest() {
 		String ipv4 = NetUtil.longToIpv4(2130706433L);
-		Assert.assertEquals("127.0.0.1", ipv4);
+		Assertions.assertEquals("127.0.0.1", ipv4);
 	}
 
 	@Test
 	public void ipToLongTest() {
 		long ipLong = NetUtil.ipv4ToLong("127.0.0.1");
-		Assert.assertEquals(2130706433L, ipLong);
+		Assertions.assertEquals(2130706433L, ipLong);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void isUsableLocalPortTest(){
-		Assert.assertTrue(NetUtil.isUsableLocalPort(80));
+		Assertions.assertTrue(NetUtil.isUsableLocalPort(80));
 	}
 
 	@Test
 	public void parseCookiesTest(){
 		String cookieStr = "cookieName=\"cookieValue\";Path=\"/\";Domain=\"cookiedomain.com\"";
 		final List<HttpCookie> httpCookies = NetUtil.parseCookies(cookieStr);
-		Assert.assertEquals(1, httpCookies.size());
+		Assertions.assertEquals(1, httpCookies.size());
 
 		final HttpCookie httpCookie = httpCookies.get(0);
-		Assert.assertEquals(0, httpCookie.getVersion());
-		Assert.assertEquals("cookieName", httpCookie.getName());
-		Assert.assertEquals("cookieValue", httpCookie.getValue());
-		Assert.assertEquals("/", httpCookie.getPath());
-		Assert.assertEquals("cookiedomain.com", httpCookie.getDomain());
+		Assertions.assertEquals(0, httpCookie.getVersion());
+		Assertions.assertEquals("cookieName", httpCookie.getName());
+		Assertions.assertEquals("cookieValue", httpCookie.getValue());
+		Assertions.assertEquals("/", httpCookie.getPath());
+		Assertions.assertEquals("cookiedomain.com", httpCookie.getDomain());
 	}
 
 	@Test
 	public void getLocalHostNameTest() {
-		Assert.assertNotNull(NetUtil.getLocalHostName());
+		Assertions.assertNotNull(NetUtil.getLocalHostName());
 	}
 
 	@Test
 	public void pingTest(){
-		Assert.assertTrue(NetUtil.ping("127.0.0.1"));
+		Assertions.assertTrue(NetUtil.ping("127.0.0.1"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void isOpenTest(){
 		InetSocketAddress address = new InetSocketAddress("www.hutool.cn", 443);
-		Assert.assertTrue(NetUtil.isOpen(address, 200));
+		Assertions.assertTrue(NetUtil.isOpen(address, 200));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getDnsInfoTest(){
 		final List<String> txt = NetUtil.getDnsInfo("hutool.cn", "TXT");
 		Console.log(txt);
@@ -103,13 +103,13 @@ public class NetUtilTest {
 
 	@Test
 	public void isInRangeTest(){
-		Assert.assertTrue(NetUtil.isInRange("114.114.114.114","0.0.0.0/0"));
-		Assert.assertTrue(NetUtil.isInRange("192.168.3.4","192.0.0.0/8"));
-		Assert.assertTrue(NetUtil.isInRange("192.168.3.4","192.168.0.0/16"));
-		Assert.assertTrue(NetUtil.isInRange("192.168.3.4","192.168.3.0/24"));
-		Assert.assertTrue(NetUtil.isInRange("192.168.3.4","192.168.3.4/32"));
-		Assert.assertFalse(NetUtil.isInRange("8.8.8.8","192.0.0.0/8"));
-		Assert.assertFalse(NetUtil.isInRange("114.114.114.114","192.168.3.4/32"));
+		Assertions.assertTrue(NetUtil.isInRange("114.114.114.114","0.0.0.0/0"));
+		Assertions.assertTrue(NetUtil.isInRange("192.168.3.4","192.0.0.0/8"));
+		Assertions.assertTrue(NetUtil.isInRange("192.168.3.4","192.168.0.0/16"));
+		Assertions.assertTrue(NetUtil.isInRange("192.168.3.4","192.168.3.0/24"));
+		Assertions.assertTrue(NetUtil.isInRange("192.168.3.4","192.168.3.4/32"));
+		Assertions.assertFalse(NetUtil.isInRange("8.8.8.8","192.0.0.0/8"));
+		Assertions.assertFalse(NetUtil.isInRange("114.114.114.114","192.168.3.4/32"));
 	}
 
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/RFC3986Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/RFC3986Test.java
@@ -1,14 +1,14 @@
 package cn.hutool.core.net;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RFC3986Test {
 
 	@Test
 	public void encodeQueryTest(){
 		final String encode = RFC3986.QUERY_PARAM_VALUE.encode("a=b", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=b", encode);
+		Assertions.assertEquals("a=b", encode);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/UrlBuilderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/UrlBuilderTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.net;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.net.url.UrlBuilder;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -15,14 +15,14 @@ public class UrlBuilderTest {
 	@Test
 	public void buildTest() {
 		String buildUrl = UrlBuilder.create().setHost("www.hutool.cn").build();
-		Assert.assertEquals("http://www.hutool.cn/", buildUrl);
+		Assertions.assertEquals("http://www.hutool.cn/", buildUrl);
 	}
 
 	@Test
 	public void buildTest2() {
 		// path中的+不做处理
 		String buildUrl = UrlBuilder.ofHttp("http://www.hutool.cn/+8618888888888", CharsetUtil.CHARSET_UTF_8).build();
-		Assert.assertEquals("http://www.hutool.cn/+8618888888888", buildUrl);
+		Assertions.assertEquals("http://www.hutool.cn/+8618888888888", buildUrl);
 	}
 
 	@Test
@@ -30,7 +30,7 @@ public class UrlBuilderTest {
 		String buildUrl = UrlBuilder.create()
 				.setScheme("https")
 				.setHost("www.hutool.cn").build();
-		Assert.assertEquals("https://www.hutool.cn/", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/", buildUrl);
 	}
 
 	@Test
@@ -40,7 +40,7 @@ public class UrlBuilderTest {
 				.setHost("www.hutool.cn")
 				.setPort(8080)
 				.build();
-		Assert.assertEquals("https://www.hutool.cn:8080/", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn:8080/", buildUrl);
 	}
 
 	@Test
@@ -53,7 +53,7 @@ public class UrlBuilderTest {
 				.addQuery("wd", "test")
 				.build();
 
-		Assert.assertEquals("https://www.hutool.cn/aaa/bbb?ie=UTF-8&wd=test", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/aaa/bbb?ie=UTF-8&wd=test", buildUrl);
 	}
 
 	@Test
@@ -66,7 +66,7 @@ public class UrlBuilderTest {
 				.addQuery("wd", "测试")
 				.build();
 
-		Assert.assertEquals("https://www.hutool.cn/aaa/bbb?ie=UTF-8&wd=%E6%B5%8B%E8%AF%95", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/aaa/bbb?ie=UTF-8&wd=%E6%B5%8B%E8%AF%95", buildUrl);
 	}
 
 	@Test
@@ -80,7 +80,7 @@ public class UrlBuilderTest {
 				.addQuery("wd", "测试")
 				.build();
 
-		Assert.assertEquals("https://www.hutool.cn/s?ie=UTF-8&ie=GBK&wd=%E6%B5%8B%E8%AF%95", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/s?ie=UTF-8&ie=GBK&wd=%E6%B5%8B%E8%AF%95", buildUrl);
 	}
 
 	@Test
@@ -89,7 +89,7 @@ public class UrlBuilderTest {
 				.setScheme("https")
 				.setHost("www.hutool.cn")
 				.setFragment("abc").build();
-		Assert.assertEquals("https://www.hutool.cn/#abc", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/#abc", buildUrl);
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class UrlBuilderTest {
 				.setScheme("https")
 				.setHost("www.hutool.cn")
 				.setFragment("测试").build();
-		Assert.assertEquals("https://www.hutool.cn/#%E6%B5%8B%E8%AF%95", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/#%E6%B5%8B%E8%AF%95", buildUrl);
 	}
 
 	@Test
@@ -108,7 +108,7 @@ public class UrlBuilderTest {
 				.setHost("www.hutool.cn")
 				.addPath("/s")
 				.setFragment("测试").build();
-		Assert.assertEquals("https://www.hutool.cn/s#%E6%B5%8B%E8%AF%95", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/s#%E6%B5%8B%E8%AF%95", buildUrl);
 	}
 
 	@Test
@@ -119,68 +119,68 @@ public class UrlBuilderTest {
 				.addPath("/s")
 				.addQuery("wd", "test")
 				.setFragment("测试").build();
-		Assert.assertEquals("https://www.hutool.cn/s?wd=test#%E6%B5%8B%E8%AF%95", buildUrl);
+		Assertions.assertEquals("https://www.hutool.cn/s?wd=test#%E6%B5%8B%E8%AF%95", buildUrl);
 	}
 
 	@Test
 	public void ofTest() {
 		final UrlBuilder builder = UrlBuilder.of("http://www.hutool.cn/aaa/bbb/?a=1&b=2#frag1", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http", builder.getScheme());
-		Assert.assertEquals("www.hutool.cn", builder.getHost());
+		Assertions.assertEquals("http", builder.getScheme());
+		Assertions.assertEquals("www.hutool.cn", builder.getHost());
 
-		Assert.assertEquals("aaa", builder.getPath().getSegment(0));
-		Assert.assertEquals("bbb", builder.getPath().getSegment(1));
+		Assertions.assertEquals("aaa", builder.getPath().getSegment(0));
+		Assertions.assertEquals("bbb", builder.getPath().getSegment(1));
 
-		Assert.assertEquals("1", builder.getQuery().get("a"));
-		Assert.assertEquals("2", builder.getQuery().get("b"));
+		Assertions.assertEquals("1", builder.getQuery().get("a"));
+		Assertions.assertEquals("2", builder.getQuery().get("b"));
 
-		Assert.assertEquals("frag1", builder.getFragment());
+		Assertions.assertEquals("frag1", builder.getFragment());
 	}
 
 	@Test
 	public void ofWithChineseTest() {
 		final UrlBuilder builder = UrlBuilder.ofHttp("www.hutool.cn/aaa/bbb/?a=张三&b=%e6%9d%8e%e5%9b%9b#frag1", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http", builder.getScheme());
-		Assert.assertEquals("www.hutool.cn", builder.getHost());
+		Assertions.assertEquals("http", builder.getScheme());
+		Assertions.assertEquals("www.hutool.cn", builder.getHost());
 
-		Assert.assertEquals("aaa", builder.getPath().getSegment(0));
-		Assert.assertEquals("bbb", builder.getPath().getSegment(1));
+		Assertions.assertEquals("aaa", builder.getPath().getSegment(0));
+		Assertions.assertEquals("bbb", builder.getPath().getSegment(1));
 
-		Assert.assertEquals("张三", builder.getQuery().get("a"));
-		Assert.assertEquals("李四", builder.getQuery().get("b"));
+		Assertions.assertEquals("张三", builder.getQuery().get("a"));
+		Assertions.assertEquals("李四", builder.getQuery().get("b"));
 
-		Assert.assertEquals("frag1", builder.getFragment());
+		Assertions.assertEquals("frag1", builder.getFragment());
 	}
 
 	@Test
 	public void ofWithBlankTest() {
 		final UrlBuilder builder = UrlBuilder.ofHttp(" www.hutool.cn/aaa/bbb/?a=张三&b=%e6%9d%8e%e5%9b%9b#frag1", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http", builder.getScheme());
-		Assert.assertEquals("www.hutool.cn", builder.getHost());
+		Assertions.assertEquals("http", builder.getScheme());
+		Assertions.assertEquals("www.hutool.cn", builder.getHost());
 
-		Assert.assertEquals("aaa", builder.getPath().getSegment(0));
-		Assert.assertEquals("bbb", builder.getPath().getSegment(1));
+		Assertions.assertEquals("aaa", builder.getPath().getSegment(0));
+		Assertions.assertEquals("bbb", builder.getPath().getSegment(1));
 
-		Assert.assertEquals("张三", builder.getQuery().get("a"));
-		Assert.assertEquals("李四", builder.getQuery().get("b"));
+		Assertions.assertEquals("张三", builder.getQuery().get("a"));
+		Assertions.assertEquals("李四", builder.getQuery().get("b"));
 
-		Assert.assertEquals("frag1", builder.getFragment());
+		Assertions.assertEquals("frag1", builder.getFragment());
 	}
 
 	@Test
 	public void ofSpecialTest() {
 		//测试不规范的或者无需解码的字符串是否成功解码
 		final UrlBuilder builder = UrlBuilder.ofHttp(" www.hutool.cn/aaa/bbb/?a=张三&b=%%e5%9b%9b#frag1", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http", builder.getScheme());
-		Assert.assertEquals("www.hutool.cn", builder.getHost());
+		Assertions.assertEquals("http", builder.getScheme());
+		Assertions.assertEquals("www.hutool.cn", builder.getHost());
 
-		Assert.assertEquals("aaa", builder.getPath().getSegment(0));
-		Assert.assertEquals("bbb", builder.getPath().getSegment(1));
+		Assertions.assertEquals("aaa", builder.getPath().getSegment(0));
+		Assertions.assertEquals("bbb", builder.getPath().getSegment(1));
 
-		Assert.assertEquals("张三", builder.getQuery().get("a"));
-		Assert.assertEquals("%四", builder.getQuery().get("b"));
+		Assertions.assertEquals("张三", builder.getQuery().get("a"));
+		Assertions.assertEquals("%四", builder.getQuery().get("b"));
 
-		Assert.assertEquals("frag1", builder.getFragment());
+		Assertions.assertEquals("frag1", builder.getFragment());
 	}
 
 	@Test
@@ -193,7 +193,7 @@ public class UrlBuilderTest {
 				"&amp;chksm=6cbda3a25bca2ab4516410db6ce6e125badaac2f8c5548ea6e18eab6dc3c5422cb8cbe1095f7";
 		final UrlBuilder builder = UrlBuilder.ofHttp(urlStr, CharsetUtil.CHARSET_UTF_8);
 		// 原URL中的&amp;替换为&
-		Assert.assertEquals("https://mp.weixin.qq.com/s?" +
+		Assertions.assertEquals("https://mp.weixin.qq.com/s?" +
 				"__biz=MzI5NjkyNTIxMg==" +
 				"&mid=100000465&idx=1" +
 				"&sn=1044c0d19723f74f04f4c1da34eefa35" +
@@ -207,40 +207,40 @@ public class UrlBuilderTest {
 		final String today = DateUtil.date().toString("yyyyMMdd");
 		final String getWorkDayUrl = "https://tool.bitefu.net/jiari/?info=1&d=" + today;
 		final UrlBuilder builder = UrlBuilder.ofHttp(getWorkDayUrl, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(getWorkDayUrl, builder.toString());
+		Assertions.assertEquals(getWorkDayUrl, builder.toString());
 	}
 
 	@Test
 	public void blankEncodeTest(){
 		final UrlBuilder urlBuilder = UrlBuilder.ofHttp("http://a.com/aaa bbb.html", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http://a.com/aaa%20bbb.html", urlBuilder.toString());
+		Assertions.assertEquals("http://a.com/aaa%20bbb.html", urlBuilder.toString());
 	}
 
 	@Test
 	public void dotEncodeTest(){
 		final UrlBuilder urlBuilder = UrlBuilder.ofHttp("http://xtbgyy.digitalgd.com.cn/ebus/../../..", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http://xtbgyy.digitalgd.com.cn/ebus/../../..", urlBuilder.toString());
+		Assertions.assertEquals("http://xtbgyy.digitalgd.com.cn/ebus/../../..", urlBuilder.toString());
 	}
 
 	@Test
 	public void multiSlashTest(){
 		//issue#I25MZL，某些URL中有多个斜杠，此为合法路径
 		final UrlBuilder urlBuilder = UrlBuilder.ofHttp("https://hutool.cn//file/test.jpg", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("https://hutool.cn//file/test.jpg", urlBuilder.toString());
+		Assertions.assertEquals("https://hutool.cn//file/test.jpg", urlBuilder.toString());
 	}
 
 	@Test
 	public void toURITest() throws URISyntaxException {
 		String webUrl = "http://exmple.com/patha/pathb?a=123"; // 报错数据
 		final UrlBuilder urlBuilder = UrlBuilder.of(webUrl, StandardCharsets.UTF_8);
-		Assert.assertEquals(new URI(webUrl), urlBuilder.toURI());
+		Assertions.assertEquals(new URI(webUrl), urlBuilder.toURI());
 	}
 
 	@Test
 	public void testEncodeInQuery() {
 		String webUrl = "http://exmple.com/patha/pathb?a=123&b=4?6&c=789"; // b=4?6  参数中有未编码的？
 		final UrlBuilder urlBuilder = UrlBuilder.of(webUrl, StandardCharsets.UTF_8);
-		Assert.assertEquals("a=123&b=4?6&c=789", urlBuilder.getQueryStr());
+		Assertions.assertEquals("a=123&b=4?6&c=789", urlBuilder.getQueryStr());
 	}
 
 	@Test
@@ -248,7 +248,7 @@ public class UrlBuilderTest {
 		// Path中的某些符号无需转义，比如=
 		final String urlStr = "http://hq.sinajs.cn/list=sh600519";
 		final UrlBuilder urlBuilder = UrlBuilder.ofHttp(urlStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(urlStr, urlBuilder.toString());
+		Assertions.assertEquals(urlStr, urlBuilder.toString());
 	}
 
 	@Test
@@ -257,7 +257,7 @@ public class UrlBuilderTest {
 		final UrlBuilder urlBuilder = UrlBuilder.of(url);
 
 
-		Assert.assertEquals(url, urlBuilder.toString());
+		Assertions.assertEquals(url, urlBuilder.toString());
 	}
 
 	@Test
@@ -266,10 +266,10 @@ public class UrlBuilderTest {
 		// 见：https://stackoverflow.com/questions/26088849/url-fragment-allowed-characters
 		String url = "https://hutool.cn/docs/#/?id=简介";
 		UrlBuilder urlBuilder = UrlBuilder.ofHttp(url);
-		Assert.assertEquals("https://hutool.cn/docs/#/?id=%E7%AE%80%E4%BB%8B", urlBuilder.toString());
+		Assertions.assertEquals("https://hutool.cn/docs/#/?id=%E7%AE%80%E4%BB%8B", urlBuilder.toString());
 
 		urlBuilder = UrlBuilder.ofHttp(urlBuilder.toString());
-		Assert.assertEquals(urlBuilder.toString(), urlBuilder.toString());
+		Assertions.assertEquals(urlBuilder.toString(), urlBuilder.toString());
 	}
 
 	@Test
@@ -279,7 +279,7 @@ public class UrlBuilderTest {
 		// 见：https://www.rfc-editor.org/rfc/rfc3986.html#section-3.4
 		String url = "https://invoice.maycur.com/2b27a802-8423-4d41-86f5-63a6b259f61e.xlsx?download/2b27a802-8423-4d41-86f5-63a6b259f61e.xlsx&e=1630491088";
 		final UrlBuilder urlBuilder = UrlBuilder.ofHttp(url);
-		Assert.assertEquals(url, urlBuilder.toString());
+		Assertions.assertEquals(url, urlBuilder.toString());
 	}
 
 	@Test
@@ -292,7 +292,7 @@ public class UrlBuilderTest {
 				.addPath("bbb")
 				.build();
 
-		Assert.assertEquals("https://domain.cn/api/xxx/bbb", url);
+		Assertions.assertEquals("https://domain.cn/api/xxx/bbb", url);
 	}
 
 	@Test
@@ -304,21 +304,21 @@ public class UrlBuilderTest {
 				.addPath("/api/xxx/bbb")
 				.build();
 
-		Assert.assertEquals("https://domain.cn/api/xxx/bbb", url);
+		Assertions.assertEquals("https://domain.cn/api/xxx/bbb", url);
 	}
 
 	@Test
 	public void percent2BTest(){
 		String url = "http://xxx.cn/a?Signature=3R013Bj9Uq4YeISzAs2iC%2BTVCL8%3D";
 		final UrlBuilder of = UrlBuilder.ofHttpWithoutEncode(url);
-		Assert.assertEquals(url, of.toString());
+		Assertions.assertEquals(url, of.toString());
 	}
 
 	@Test
 	public void paramTest(){
 		String url = "http://ci.xiaohongshu.com/spectrum/c136c98aa2047babe25b994a26ffa7b492bd8058?imageMogr2/thumbnail/x800/format/jpg";
 		final UrlBuilder builder = UrlBuilder.ofHttp(url);
-		Assert.assertEquals(url, builder.toString());
+		Assertions.assertEquals(url, builder.toString());
 	}
 
 	@Test
@@ -327,7 +327,7 @@ public class UrlBuilderTest {
 		String url = "https://www.hutool.cn/#/a/b?timestamp=1640391380204";
 		final UrlBuilder builder = UrlBuilder.ofHttp(url);
 
-		Assert.assertEquals(url, builder.toString());
+		Assertions.assertEquals(url, builder.toString());
 	}
 
 	@Test
@@ -336,6 +336,6 @@ public class UrlBuilderTest {
 		String url = "https://www.hutool.cn/#/a/b";
 		final UrlBuilder builder = UrlBuilder.ofHttp(url);
 		builder.setFragment(builder.getFragment() + "?timestamp=1640391380204");
-		Assert.assertEquals("https://www.hutool.cn/#/a/b?timestamp=1640391380204", builder.toString());
+		Assertions.assertEquals("https://www.hutool.cn/#/a/b?timestamp=1640391380204", builder.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/UrlDecoderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/UrlDecoderTest.java
@@ -1,12 +1,12 @@
 package cn.hutool.core.net;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class UrlDecoderTest {
 	@Test
 	public void decodeForPathTest(){
-		Assert.assertEquals("+", URLDecoder.decodeForPath("+", CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("+", URLDecoder.decodeForPath("+", CharsetUtil.CHARSET_UTF_8));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/net/UrlQueryTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/UrlQueryTest.java
@@ -5,8 +5,8 @@ import cn.hutool.core.net.url.UrlBuilder;
 import cn.hutool.core.net.url.UrlQuery;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.URLUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -21,8 +21,8 @@ public class UrlQueryTest {
 		String queryStr = "a=1&b=111==";
 		UrlQuery q = new UrlQuery();
 		UrlQuery parse = q.parse(queryStr, Charset.defaultCharset());
-		Assert.assertEquals("111==", parse.get("b"));
-		Assert.assertEquals("a=1&b=111==", parse.toString());
+		Assertions.assertEquals("111==", parse.get("b"));
+		Assertions.assertEquals("a=1&b=111==", parse.toString());
 	}
 
 	@Test
@@ -31,7 +31,7 @@ public class UrlQueryTest {
 		String url = "https://img-cloud.voc.com.cn/140/2020/09/03/c3d41b93e0d32138574af8e8b50928b376ca5ba61599127028157.png?imageMogr2/auto-orient/thumbnail/500&pid=259848";
 		final UrlBuilder urlBuilder = UrlBuilder.ofHttpWithoutEncode(url);
 		final String queryStr = urlBuilder.getQueryStr();
-		Assert.assertEquals("imageMogr2/auto-orient/thumbnail/500&pid=259848", queryStr);
+		Assertions.assertEquals("imageMogr2/auto-orient/thumbnail/500&pid=259848", queryStr);
 	}
 
 	@Test
@@ -39,7 +39,7 @@ public class UrlQueryTest {
 		String requestUrl = "http://192.168.1.1:8080/pc?=d52i5837i4ed=o39-ap9e19s5--=72e54*ll0lodl-f338868d2";
 		UrlQuery q = new UrlQuery();
 		UrlQuery parse = q.parse(requestUrl, Charset.defaultCharset());
-		Assert.assertEquals("=d52i5837i4ed=o39-ap9e19s5--=72e54*ll0lodl-f338868d2", parse.toString());
+		Assertions.assertEquals("=d52i5837i4ed=o39-ap9e19s5--=72e54*ll0lodl-f338868d2", parse.toString());
 	}
 
 	@Test
@@ -47,7 +47,7 @@ public class UrlQueryTest {
 		// issue#1688@Github
 		String u = "https://www.baidu.com/proxy";
 		final UrlQuery query = UrlQuery.of(URLUtil.url(u).getQuery(), Charset.defaultCharset());
-		Assert.assertTrue(MapUtil.isEmpty(query.getQueryMap()));
+		Assertions.assertTrue(MapUtil.isEmpty(query.getQueryMap()));
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class UrlQueryTest {
 		// https://github.com/dromara/hutool/issues/1989
 		String queryStr = "imageMogr2/thumbnail/x800/format/jpg";
 		final UrlQuery query = UrlQuery.of(queryStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(queryStr, query.toString());
+		Assertions.assertEquals(queryStr, query.toString());
 	}
 
 	@Test
@@ -64,13 +64,13 @@ public class UrlQueryTest {
 		map.put("username", "SSM");
 		map.put("password", "123456");
 		String query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("username=SSM&password=123456", query);
+		Assertions.assertEquals("username=SSM&password=123456", query);
 
 		map = new TreeMap<>();
 		map.put("username", "SSM");
 		map.put("password", "123456");
 		query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("password=123456&username=SSM", query);
+		Assertions.assertEquals("password=123456&username=SSM", query);
 	}
 
 	@Test
@@ -79,19 +79,19 @@ public class UrlQueryTest {
 		map.put(null, "SSM");
 		map.put("password", "123456");
 		String query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("password=123456", query);
+		Assertions.assertEquals("password=123456", query);
 
 		map = new TreeMap<>();
 		map.put("username", "SSM");
 		map.put("password", "");
 		query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("password=&username=SSM", query);
+		Assertions.assertEquals("password=&username=SSM", query);
 
 		map = new TreeMap<>();
 		map.put("username", "SSM");
 		map.put("password", null);
 		query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("password&username=SSM", query);
+		Assertions.assertEquals("password&username=SSM", query);
 	}
 
 	@Test
@@ -100,20 +100,20 @@ public class UrlQueryTest {
 		map.put("key1&", "SSM");
 		map.put("key2", "123456&");
 		String query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("key1%26=SSM&key2=123456%26", query);
+		Assertions.assertEquals("key1%26=SSM&key2=123456%26", query);
 
 		map = new TreeMap<>();
 		map.put("username=", "SSM");
 		map.put("password", "=");
 		query = URLUtil.buildQuery(map, StandardCharsets.UTF_8);
-		Assert.assertEquals("password==&username%3D=SSM", query);
+		Assertions.assertEquals("password==&username%3D=SSM", query);
 	}
 
 	@Test
 	public void plusTest(){
 		// 根据RFC3986，在URL中，+是安全字符，即此符号不转义
 		final String a = UrlQuery.of(MapUtil.of("a+b", "1+2")).build(CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a+b=1+2", a);
+		Assertions.assertEquals("a+b=1+2", a);
 	}
 
 	@Test
@@ -121,20 +121,20 @@ public class UrlQueryTest {
 		// 根据RFC3986，在URL中，+是安全字符，即此符号不转义
 		final String a = UrlQuery.of("a+b=1+2", CharsetUtil.CHARSET_UTF_8)
 				.build(CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a+b=1+2", a);
+		Assertions.assertEquals("a+b=1+2", a);
 	}
 
 	@Test
 	public void spaceTest(){
 		// 根据RFC3986，在URL中，空格编码为"%20"
 		final String a = UrlQuery.of(MapUtil.of("a ", " ")).build(CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a%20=%20", a);
+		Assertions.assertEquals("a%20=%20", a);
 	}
 
 	@Test
 	public void parsePercentTest(){
 		String queryStr = "a%2B=ccc";
 		final UrlQuery query = UrlQuery.of(queryStr, null);
-		Assert.assertEquals(queryStr, query.toString());
+		Assertions.assertEquals(queryStr, query.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/stream/StreamUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/stream/StreamUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.stream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
 
@@ -11,6 +11,6 @@ public class StreamUtilTest {
 	public void ofTest(){
 		final Stream<Integer> stream = StreamUtil.of(2, x -> x * 2, 4);
 		final String result = stream.collect(CollectorUtil.joining(","));
-		Assert.assertEquals("2,4,8,16", result);
+		Assertions.assertEquals("2,4,8,16", result);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/swing/ClipboardMonitorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/swing/ClipboardMonitorTest.java
@@ -2,13 +2,13 @@ package cn.hutool.core.swing;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.swing.clipboard.ClipboardUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ClipboardMonitorTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void monitorTest() {
 		// 第一个监听
 		ClipboardUtil.listen((clipboard, contents) -> {
@@ -16,7 +16,7 @@ public class ClipboardMonitorTest {
 			Console.log("1# {}", object);
 			return contents;
 		}, false);
-		
+
 		// 第二个监听
 		ClipboardUtil.listen((clipboard, contents) -> {
 			Object object = ClipboardUtil.getStr(contents);

--- a/hutool-core/src/test/java/cn/hutool/core/swing/ClipboardUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/swing/ClipboardUtilTest.java
@@ -1,13 +1,13 @@
 package cn.hutool.core.swing;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.swing.clipboard.ClipboardUtil;
 
 /**
  * 剪贴板工具类单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -19,7 +19,7 @@ public class ClipboardUtilTest {
 			ClipboardUtil.setStr("test");
 
 			String test = ClipboardUtil.getStr();
-			Assert.assertEquals("test", test);
+			Assertions.assertEquals("test", test);
 		} catch (java.awt.HeadlessException e) {
 			// 忽略 No X11 DISPLAY variable was set, but this program performed an operation which requires it.
 			// ignore

--- a/hutool-core/src/test/java/cn/hutool/core/swing/DesktopUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/swing/DesktopUtilTest.java
@@ -1,12 +1,12 @@
 package cn.hutool.core.swing;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class DesktopUtilTest {
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void browseTest() {
 		DesktopUtil.browse("https://www.hutool.club");
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/swing/RobotUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/swing/RobotUtilTest.java
@@ -1,14 +1,14 @@
 package cn.hutool.core.swing;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.FileUtil;
 
 public class RobotUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void captureScreenTest() {
 		RobotUtil.captureScreen(FileUtil.file("e:/screen.jpg"));
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.text;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.regex.Pattern;
 
@@ -11,7 +11,7 @@ public class CharSequenceUtilTest {
 	@Test
 	public void replaceTest() {
 		String actual = CharSequenceUtil.replace("SSM15930297701BeryAllen", Pattern.compile("[0-9]"), matcher -> "");
-		Assert.assertEquals("SSMBeryAllen", actual);
+		Assertions.assertEquals("SSMBeryAllen", actual);
 	}
 
 	@Test
@@ -19,31 +19,31 @@ public class CharSequenceUtilTest {
 		// https://gitee.com/dromara/hutool/issues/I4M16G
 		String replace = "#{A}";
 		String result = CharSequenceUtil.replace(replace, "#{AAAAAAA}", "1");
-		Assert.assertEquals(replace, result);
+		Assertions.assertEquals(replace, result);
 	}
 
 	@Test
 	public void addPrefixIfNotTest(){
 		String str = "hutool";
 		String result = CharSequenceUtil.addPrefixIfNot(str, "hu");
-		Assert.assertEquals(str, result);
+		Assertions.assertEquals(str, result);
 
 		result = CharSequenceUtil.addPrefixIfNot(str, "Good");
-		Assert.assertEquals("Good" + str, result);
+		Assertions.assertEquals("Good" + str, result);
 	}
 
 	@Test
 	public void addSuffixIfNotTest(){
 		String str = "hutool";
 		String result = CharSequenceUtil.addSuffixIfNot(str, "tool");
-		Assert.assertEquals(str, result);
+		Assertions.assertEquals(str, result);
 
 		result = CharSequenceUtil.addSuffixIfNot(str, " is Good");
-		Assert.assertEquals( str + " is Good", result);
+		Assertions.assertEquals( str + " is Good", result);
 
 		// https://gitee.com/dromara/hutool/issues/I4NS0F
 		result = CharSequenceUtil.addSuffixIfNot("", "/");
-		Assert.assertEquals( "/", result);
+		Assertions.assertEquals( "/", result);
 	}
 
 	@Test
@@ -53,30 +53,30 @@ public class CharSequenceUtilTest {
 		String str1 = "\u00C1";
 		String str2 = "\u0041\u0301";
 
-		Assert.assertNotEquals(str1, str2);
+		Assertions.assertNotEquals(str1, str2);
 
 		str1 = CharSequenceUtil.normalize(str1);
 		str2 = CharSequenceUtil.normalize(str2);
-		Assert.assertEquals(str1, str2);
+		Assertions.assertEquals(str1, str2);
 	}
 
 	@Test
 	public void indexOfTest(){
 		int index = CharSequenceUtil.indexOf("abc123", '1');
-		Assert.assertEquals(3, index);
+		Assertions.assertEquals(3, index);
 		index = CharSequenceUtil.indexOf("abc123", '3');
-		Assert.assertEquals(5, index);
+		Assertions.assertEquals(5, index);
 		index = CharSequenceUtil.indexOf("abc123", 'a');
-		Assert.assertEquals(0, index);
+		Assertions.assertEquals(0, index);
 	}
 
 	@Test
 	public void indexOfTest2(){
 		int index = CharSequenceUtil.indexOf("abc123", '1', 0, 3);
-		Assert.assertEquals(-1, index);
+		Assertions.assertEquals(-1, index);
 
 		index = CharSequenceUtil.indexOf("abc123", 'b', 0, 3);
-		Assert.assertEquals(1, index);
+		Assertions.assertEquals(1, index);
 	}
 
 	@Test
@@ -85,16 +85,16 @@ public class CharSequenceUtilTest {
 		String s = "华硕K42Intel酷睿i31代2G以下独立显卡不含机械硬盘固态硬盘120GB-192GB4GB-6GB";
 
 		String v = CharSequenceUtil.subPreGbk(s, 40, false);
-		Assert.assertEquals(39, v.getBytes(CharsetUtil.CHARSET_GBK).length);
+		Assertions.assertEquals(39, v.getBytes(CharsetUtil.CHARSET_GBK).length);
 
 		v = CharSequenceUtil.subPreGbk(s, 40, true);
-		Assert.assertEquals(41, v.getBytes(CharsetUtil.CHARSET_GBK).length);
+		Assertions.assertEquals(41, v.getBytes(CharsetUtil.CHARSET_GBK).length);
 	}
 
 	@Test
 	public void startWithTest(){
 		// https://gitee.com/dromara/hutool/issues/I4MV7Q
-		Assert.assertFalse(CharSequenceUtil.startWith("123", "123", false, true));
-		Assert.assertFalse(CharSequenceUtil.startWith(null, null, false, true));
+		Assertions.assertFalse(CharSequenceUtil.startWith("123", "123", false, true));
+		Assertions.assertFalse(CharSequenceUtil.startWith(null, null, false, true));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/PasswdStrengthTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/PasswdStrengthTest.java
@@ -1,18 +1,18 @@
 package cn.hutool.core.text;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PasswdStrengthTest {
 	@Test
 	public void strengthTest(){
 		String passwd = "2hAj5#mne-ix.86H";
-		Assert.assertEquals(13, PasswdStrength.check(passwd));
+		Assertions.assertEquals(13, PasswdStrength.check(passwd));
 	}
 
 	@Test
 	public void strengthNumberTest(){
 		String passwd = "9999999999999";
-		Assert.assertEquals(0, PasswdStrength.check(passwd));
+		Assertions.assertEquals(0, PasswdStrength.check(passwd));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrBuilderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrBuilderTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.text;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.date.TimeInterval;
@@ -19,7 +19,7 @@ public class StrBuilderTest {
 	 * StrBuilder的性能测试
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void benchTest() {
 		TimeInterval timer = DateUtil.timer();
 		StrBuilder builder = StrBuilder.create();
@@ -42,7 +42,7 @@ public class StrBuilderTest {
 	public void appendTest() {
 		StrBuilder builder = StrBuilder.create();
 		builder.append("aaa").append("你好").append('r');
-		Assert.assertEquals("aaa你好r", builder.toString());
+		Assertions.assertEquals("aaa你好r", builder.toString());
 	}
 
 	@Test
@@ -50,7 +50,7 @@ public class StrBuilderTest {
 		StrBuilder builder = StrBuilder.create(1);
 		builder.append("aaa").append("你好").append('r');
 		builder.insert(3, "数据插入");
-		Assert.assertEquals("aaa数据插入你好r", builder.toString());
+		Assertions.assertEquals("aaa数据插入你好r", builder.toString());
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class StrBuilderTest {
 		StrBuilder builder = StrBuilder.create(1);
 		builder.append("aaa").append("你好").append('r');
 		builder.insert(8, "数据插入");
-		Assert.assertEquals("aaa你好r  数据插入", builder.toString());
+		Assertions.assertEquals("aaa你好r  数据插入", builder.toString());
 	}
 
 	@Test
@@ -67,7 +67,7 @@ public class StrBuilderTest {
 		builder.append("aaa").append("你好").append('r');
 		builder.insert(3, "数据插入");
 		builder.reset();
-		Assert.assertEquals("", builder.toString());
+		Assertions.assertEquals("", builder.toString());
 	}
 
 	@Test
@@ -77,14 +77,14 @@ public class StrBuilderTest {
 		builder.insert(3, "数据插入");
 		builder.reset();
 		builder.append("bbb".toCharArray());
-		Assert.assertEquals("bbb", builder.toString());
+		Assertions.assertEquals("bbb", builder.toString());
 	}
 
 	@Test
 	public void appendObjectTest() {
 		StrBuilder builder = StrBuilder.create(1);
 		builder.append(123).append(456.123D).append(true).append('\n');
-		Assert.assertEquals("123456.123true\n", builder.toString());
+		Assertions.assertEquals("123456.123true\n", builder.toString());
 	}
 
 	@Test
@@ -93,7 +93,7 @@ public class StrBuilderTest {
 		StrBuilder strBuilder = new StrBuilder("ABCDEFG");
 		int length = strBuilder.length();
 		StrBuilder builder = strBuilder.del(0, length);
-		Assert.assertEquals("", builder.toString());
+		Assertions.assertEquals("", builder.toString());
 	}
 
 	@Test
@@ -101,7 +101,7 @@ public class StrBuilderTest {
 		// 删除中间部分测试
 		StrBuilder strBuilder = new StrBuilder("ABCDEFG");
 		StrBuilder builder = strBuilder.del(2,6);
-		Assert.assertEquals("ABG", builder.toString());
+		Assertions.assertEquals("ABG", builder.toString());
 	}
 
 	@Test
@@ -110,10 +110,10 @@ public class StrBuilderTest {
 
 		// 不处理
 		StrBuilder builder = strBuilder.delTo(7);
-		Assert.assertEquals("ABCDEFG", builder.toString());
+		Assertions.assertEquals("ABCDEFG", builder.toString());
 
 		// 删除全部
 		builder = strBuilder.delTo(0);
-		Assert.assertEquals("", builder.toString());
+		Assertions.assertEquals("", builder.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrJoinerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrJoinerTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.text;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.ListUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,20 +14,20 @@ public class StrJoinerTest {
 	public void joinIntArrayTest(){
 		int[] a = {1,2,3,4,5};
 		final StrJoiner append = StrJoiner.of(",").append(a);
-		Assert.assertEquals("1,2,3,4,5", append.toString());
+		Assertions.assertEquals("1,2,3,4,5", append.toString());
 	}
 
 	@Test
 	public void joinEmptyTest(){
 		List<String> list = new ArrayList<>();
 		final StrJoiner append = StrJoiner.of(",").append(list);
-		Assert.assertEquals("", append.toString());
+		Assertions.assertEquals("", append.toString());
 	}
 
 	@Test
 	public void noJoinTest(){
 		final StrJoiner append = StrJoiner.of(",");
-		Assert.assertEquals("", append.toString());
+		Assertions.assertEquals("", append.toString());
 	}
 
 	@Test
@@ -36,7 +36,7 @@ public class StrJoinerTest {
 		append.append(new Object[]{ListUtil.of("1", "2"),
 				CollUtil.newLinkedHashSet("3", "4")
 		});
-		Assert.assertEquals("1,2,3,4", append.toString());
+		Assertions.assertEquals("1,2,3,4", append.toString());
 	}
 
 	@Test
@@ -46,21 +46,21 @@ public class StrJoinerTest {
 				.append("1")
 				.append((Object)null)
 				.append("3");
-		Assert.assertEquals("1,3", append.toString());
+		Assertions.assertEquals("1,3", append.toString());
 
 		append = StrJoiner.of(",")
 				.setNullMode(StrJoiner.NullMode.TO_EMPTY)
 				.append("1")
 				.append((Object)null)
 				.append("3");
-		Assert.assertEquals("1,,3", append.toString());
+		Assertions.assertEquals("1,,3", append.toString());
 
 		append = StrJoiner.of(",")
 				.setNullMode(StrJoiner.NullMode.NULL_STRING)
 				.append("1")
 				.append((Object)null)
 				.append("3");
-		Assert.assertEquals("1,null,3", append.toString());
+		Assertions.assertEquals("1,null,3", append.toString());
 	}
 
 	@Test
@@ -69,13 +69,13 @@ public class StrJoinerTest {
 				.append("1")
 				.append("2")
 				.append("3");
-		Assert.assertEquals("[1,2,3]", append.toString());
+		Assertions.assertEquals("[1,2,3]", append.toString());
 
 		append = StrJoiner.of(",", "[", "]")
 				.setWrapElement(true)
 				.append("1")
 				.append("2")
 				.append("3");
-		Assert.assertEquals("[1],[2],[3]", append.toString());
+		Assertions.assertEquals("[1],[2],[3]", append.toString());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrMatcherTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrMatcherTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.text;
 
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -12,13 +12,13 @@ public class StrMatcherTest {
 	public void matcherTest(){
 		final StrMatcher strMatcher = new StrMatcher("${name}-${age}-${gender}-${country}-${province}-${city}-${status}");
 		final Map<String, String> match = strMatcher.match("小明-19-男-中国-河南-郑州-已婚");
-		Assert.assertEquals("小明", match.get("name"));
-		Assert.assertEquals("19", match.get("age"));
-		Assert.assertEquals("男", match.get("gender"));
-		Assert.assertEquals("中国", match.get("country"));
-		Assert.assertEquals("河南", match.get("province"));
-		Assert.assertEquals("郑州", match.get("city"));
-		Assert.assertEquals("已婚", match.get("status"));
+		Assertions.assertEquals("小明", match.get("name"));
+		Assertions.assertEquals("19", match.get("age"));
+		Assertions.assertEquals("男", match.get("gender"));
+		Assertions.assertEquals("中国", match.get("country"));
+		Assertions.assertEquals("河南", match.get("province"));
+		Assertions.assertEquals("郑州", match.get("city"));
+		Assertions.assertEquals("已婚", match.get("status"));
 	}
 
 	@Test
@@ -26,7 +26,7 @@ public class StrMatcherTest {
 		// 当有无匹配项的时候，按照全不匹配对待
 		final StrMatcher strMatcher = new StrMatcher("${name}-${age}-${gender}-${country}-${province}-${city}-${status}");
 		final Map<String, String> match = strMatcher.match("小明-19-男-中国-河南-郑州");
-		Assert.assertEquals(0, match.size());
+		Assertions.assertEquals(0, match.size());
 	}
 
 	@Test
@@ -35,7 +35,7 @@ public class StrMatcherTest {
 		final StrMatcher strMatcher = new StrMatcher("${name}经过${year}年");
 		final Map<String, String> match = strMatcher.match("小明经过20年，成长为一个大人。");
 		Console.log(match);
-		Assert.assertEquals("小明", match.get("name"));
-		Assert.assertEquals("20", match.get("year"));
+		Assertions.assertEquals("小明", match.get("name"));
+		Assertions.assertEquals("20", match.get("year"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/TextSimilarityTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/TextSimilarityTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.text;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 文本相似度计算工具类单元测试
@@ -16,10 +16,10 @@ public class TextSimilarityTest {
 		String b = "一个文本，独一无二的文本";
 
 		double degree = TextSimilarity.similar(a, b);
-		Assert.assertEquals(0.8571428571428571D, degree, 16);
+		Assertions.assertEquals(0.8571428571428571D, degree, 16);
 
 		String similarPercent = TextSimilarity.similar(a, b, 2);
-		Assert.assertEquals("84.62%", similarPercent);
+		Assertions.assertEquals("84.62%", similarPercent);
 	}
 
 	@Test
@@ -28,15 +28,15 @@ public class TextSimilarityTest {
 		String b = "一个文本，独一无二的文本,#,>>?#$%^%$&^&^%";
 
 		double degree = TextSimilarity.similar(a, b);
-		Assert.assertEquals(0.8571428571428571D, degree, 16);
+		Assertions.assertEquals(0.8571428571428571D, degree, 16);
 
 		String similarPercent = TextSimilarity.similar(a, b, 2);
-		Assert.assertEquals("84.62%", similarPercent);
+		Assertions.assertEquals("84.62%", similarPercent);
 	}
 
 	@Test
 	public void similarTest(){
 		final double abd = TextSimilarity.similar("abd", "1111");
-		Assert.assertEquals(0, abd, 1);
+		Assertions.assertEquals(0, abd, 1);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/UnicodeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/UnicodeUtilTest.java
@@ -1,11 +1,11 @@
 package cn.hutool.core.text;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * UnicodeUtil 单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -13,37 +13,37 @@ public class UnicodeUtilTest {
 	@Test
 	public void convertTest() {
 		String s = UnicodeUtil.toUnicode("aaa123中文", true);
-		Assert.assertEquals("aaa123\\u4e2d\\u6587", s);
+		Assertions.assertEquals("aaa123\\u4e2d\\u6587", s);
 
 		String s1 = UnicodeUtil.toString(s);
-		Assert.assertEquals("aaa123中文", s1);
+		Assertions.assertEquals("aaa123中文", s1);
 	}
 
 	@Test
 	public void convertTest2() {
 		String str = "aaaa\\u0026bbbb\\u0026cccc";
 		String unicode = UnicodeUtil.toString(str);
-		Assert.assertEquals("aaaa&bbbb&cccc", unicode);
+		Assertions.assertEquals("aaaa&bbbb&cccc", unicode);
 	}
-	
+
 	@Test
 	public void convertTest3() {
 		String str = "aaa\\u111";
 		String res = UnicodeUtil.toString(str);
-		Assert.assertEquals("aaa\\u111", res);
+		Assertions.assertEquals("aaa\\u111", res);
 	}
-	
+
 	@Test
 	public void convertTest4() {
 		String str = "aaa\\U4e2d\\u6587\\u111\\urtyu\\u0026";
 		String res = UnicodeUtil.toString(str);
-		Assert.assertEquals("aaa中文\\u111\\urtyu&", res);
+		Assertions.assertEquals("aaa中文\\u111\\urtyu&", res);
 	}
-	
+
 	@Test
 	public void convertTest5() {
 		String str = "{\"code\":403,\"enmsg\":\"Product not found\",\"cnmsg\":\"\\u4ea7\\u54c1\\u4e0d\\u5b58\\u5728\\uff0c\\u6216\\u5df2\\u5220\\u9664\",\"data\":null}";
 		String res = UnicodeUtil.toString(str);
-		Assert.assertEquals("{\"code\":403,\"enmsg\":\"Product not found\",\"cnmsg\":\"产品不存在，或已删除\",\"data\":null}", res);
+		Assertions.assertEquals("{\"code\":403,\"enmsg\":\"Product not found\",\"cnmsg\":\"产品不存在，或已删除\",\"data\":null}", res);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvParserTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvParserTest.java
@@ -2,50 +2,50 @@ package cn.hutool.core.text.csv;
 
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
 
 public class CsvParserTest {
-	
+
 	@Test
 	public void parseTest1() {
 		StringReader reader = StrUtil.getReader("aaa,b\"bba\",ccc");
 		CsvParser parser = new CsvParser(reader, null);
 		CsvRow row = parser.nextRow();
 		//noinspection ConstantConditions
-		Assert.assertEquals("b\"bba\"", row.getRawList().get(1));
+		Assertions.assertEquals("b\"bba\"", row.getRawList().get(1));
 		IoUtil.close(parser);
 	}
-	
+
 	@Test
 	public void parseTest2() {
 		StringReader reader = StrUtil.getReader("aaa,\"bba\"bbb,ccc");
 		CsvParser parser = new CsvParser(reader, null);
 		CsvRow row = parser.nextRow();
 		//noinspection ConstantConditions
-		Assert.assertEquals("\"bba\"bbb", row.getRawList().get(1));
+		Assertions.assertEquals("\"bba\"bbb", row.getRawList().get(1));
 		IoUtil.close(parser);
 	}
-	
+
 	@Test
 	public void parseTest3() {
 		StringReader reader = StrUtil.getReader("aaa,\"bba\",ccc");
 		CsvParser parser = new CsvParser(reader, null);
 		CsvRow row = parser.nextRow();
 		//noinspection ConstantConditions
-		Assert.assertEquals("bba", row.getRawList().get(1));
+		Assertions.assertEquals("bba", row.getRawList().get(1));
 		IoUtil.close(parser);
 	}
-	
+
 	@Test
 	public void parseTest4() {
 		StringReader reader = StrUtil.getReader("aaa,\"\",ccc");
 		CsvParser parser = new CsvParser(reader, null);
 		CsvRow row = parser.nextRow();
 		//noinspection ConstantConditions
-		Assert.assertEquals("", row.getRawList().get(1));
+		Assertions.assertEquals("", row.getRawList().get(1));
 		IoUtil.close(parser);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
@@ -133,7 +133,7 @@ public class CsvReaderTest {
 		Assertions.assertEquals("a,b,c,d", CollUtil.join(data.getRow(0), ","));
 
 		Assertions.assertEquals(4, data.getRow(2).getOriginalLineNumber());
-		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(2), ","));
+		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(2), ",").replace("\r", ""));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
 		Assertions.assertEquals(6, data.getRow(3).getOriginalLineNumber());
@@ -150,7 +150,7 @@ public class CsvReaderTest {
 		Assertions.assertEquals("1,2,3,4", CollUtil.join(data.getRow(0), ","));
 
 		Assertions.assertEquals(4, data.getRow(1).getOriginalLineNumber());
-		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(1), ","));
+		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(1), ",").replace("\r", ""));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
 		Assertions.assertEquals(6, data.getRow(2).getOriginalLineNumber());
@@ -164,7 +164,7 @@ public class CsvReaderTest {
 		CsvData data = reader.read(ResourceUtil.getReader("test_lines.csv", CharsetUtil.CHARSET_UTF_8));
 
 		Assertions.assertEquals(4, data.getRow(0).getOriginalLineNumber());
-		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(0), ","));
+		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(0), ",").replace("\r", ""));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
 		Assertions.assertEquals(6, data.getRow(1).getOriginalLineNumber());

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
@@ -7,9 +7,9 @@ import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import java.util.List;
 import java.util.Map;
 
@@ -19,10 +19,10 @@ public class CsvReaderTest {
 	public void readTest() {
 		CsvReader reader = new CsvReader();
 		CsvData data = reader.read(ResourceUtil.getReader("test.csv", CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals("sss,sss", data.getRow(0).get(0));
-		Assert.assertEquals(1, data.getRow(0).getOriginalLineNumber());
-		Assert.assertEquals("性别", data.getRow(0).get(2));
-		Assert.assertEquals("关注\"对象\"", data.getRow(0).get(3));
+		Assertions.assertEquals("sss,sss", data.getRow(0).get(0));
+		Assertions.assertEquals(1, data.getRow(0).getOriginalLineNumber());
+		Assertions.assertEquals("性别", data.getRow(0).get(2));
+		Assertions.assertEquals("关注\"对象\"", data.getRow(0).get(3));
 	}
 
 	@Test
@@ -31,20 +31,20 @@ public class CsvReaderTest {
 		final List<Map<String, String>> result = reader.readMapList(
 				ResourceUtil.getUtf8Reader("test_bean.csv"));
 
-		Assert.assertEquals("张三", result.get(0).get("姓名"));
-		Assert.assertEquals("男", result.get(0).get("gender"));
-		Assert.assertEquals("无", result.get(0).get("focus"));
-		Assert.assertEquals("33", result.get(0).get("age"));
+		Assertions.assertEquals("张三", result.get(0).get("姓名"));
+		Assertions.assertEquals("男", result.get(0).get("gender"));
+		Assertions.assertEquals("无", result.get(0).get("focus"));
+		Assertions.assertEquals("33", result.get(0).get("age"));
 
-		Assert.assertEquals("李四", result.get(1).get("姓名"));
-		Assert.assertEquals("男", result.get(1).get("gender"));
-		Assert.assertEquals("好对象", result.get(1).get("focus"));
-		Assert.assertEquals("23", result.get(1).get("age"));
+		Assertions.assertEquals("李四", result.get(1).get("姓名"));
+		Assertions.assertEquals("男", result.get(1).get("gender"));
+		Assertions.assertEquals("好对象", result.get(1).get("focus"));
+		Assertions.assertEquals("23", result.get(1).get("age"));
 
-		Assert.assertEquals("王妹妹", result.get(2).get("姓名"));
-		Assert.assertEquals("女", result.get(2).get("gender"));
-		Assert.assertEquals("特别关注", result.get(2).get("focus"));
-		Assert.assertEquals("22", result.get(2).get("age"));
+		Assertions.assertEquals("王妹妹", result.get(2).get("姓名"));
+		Assertions.assertEquals("女", result.get(2).get("gender"));
+		Assertions.assertEquals("特别关注", result.get(2).get("focus"));
+		Assertions.assertEquals("22", result.get(2).get("age"));
 	}
 
 	@Test
@@ -56,20 +56,20 @@ public class CsvReaderTest {
 		final List<Map<String, String>> result = reader.readMapList(
 				ResourceUtil.getUtf8Reader("test_bean.csv"));
 
-		Assert.assertEquals("张三", result.get(0).get("name"));
-		Assert.assertEquals("男", result.get(0).get("gender"));
-		Assert.assertEquals("无", result.get(0).get("focus"));
-		Assert.assertEquals("33", result.get(0).get("age"));
+		Assertions.assertEquals("张三", result.get(0).get("name"));
+		Assertions.assertEquals("男", result.get(0).get("gender"));
+		Assertions.assertEquals("无", result.get(0).get("focus"));
+		Assertions.assertEquals("33", result.get(0).get("age"));
 
-		Assert.assertEquals("李四", result.get(1).get("name"));
-		Assert.assertEquals("男", result.get(1).get("gender"));
-		Assert.assertEquals("好对象", result.get(1).get("focus"));
-		Assert.assertEquals("23", result.get(1).get("age"));
+		Assertions.assertEquals("李四", result.get(1).get("name"));
+		Assertions.assertEquals("男", result.get(1).get("gender"));
+		Assertions.assertEquals("好对象", result.get(1).get("focus"));
+		Assertions.assertEquals("23", result.get(1).get("age"));
 
-		Assert.assertEquals("王妹妹", result.get(2).get("name"));
-		Assert.assertEquals("女", result.get(2).get("gender"));
-		Assert.assertEquals("特别关注", result.get(2).get("focus"));
-		Assert.assertEquals("22", result.get(2).get("age"));
+		Assertions.assertEquals("王妹妹", result.get(2).get("name"));
+		Assertions.assertEquals("女", result.get(2).get("gender"));
+		Assertions.assertEquals("特别关注", result.get(2).get("focus"));
+		Assertions.assertEquals("22", result.get(2).get("age"));
 	}
 
 	@Test
@@ -78,20 +78,20 @@ public class CsvReaderTest {
 		final List<TestBean> result = reader.read(
 				ResourceUtil.getUtf8Reader("test_bean.csv"), TestBean.class);
 
-		Assert.assertEquals("张三", result.get(0).getName());
-		Assert.assertEquals("男", result.get(0).getGender());
-		Assert.assertEquals("无", result.get(0).getFocus());
-		Assert.assertEquals(Integer.valueOf(33), result.get(0).getAge());
+		Assertions.assertEquals("张三", result.get(0).getName());
+		Assertions.assertEquals("男", result.get(0).getGender());
+		Assertions.assertEquals("无", result.get(0).getFocus());
+		Assertions.assertEquals(Integer.valueOf(33), result.get(0).getAge());
 
-		Assert.assertEquals("李四", result.get(1).getName());
-		Assert.assertEquals("男", result.get(1).getGender());
-		Assert.assertEquals("好对象", result.get(1).getFocus());
-		Assert.assertEquals(Integer.valueOf(23), result.get(1).getAge());
+		Assertions.assertEquals("李四", result.get(1).getName());
+		Assertions.assertEquals("男", result.get(1).getGender());
+		Assertions.assertEquals("好对象", result.get(1).getFocus());
+		Assertions.assertEquals(Integer.valueOf(23), result.get(1).getAge());
 
-		Assert.assertEquals("王妹妹", result.get(2).getName());
-		Assert.assertEquals("女", result.get(2).getGender());
-		Assert.assertEquals("特别关注", result.get(2).getFocus());
-		Assert.assertEquals(Integer.valueOf(22), result.get(2).getAge());
+		Assertions.assertEquals("王妹妹", result.get(2).getName());
+		Assertions.assertEquals("女", result.get(2).getGender());
+		Assertions.assertEquals("特别关注", result.get(2).getFocus());
+		Assertions.assertEquals(Integer.valueOf(22), result.get(2).getAge());
 	}
 
 	@Data
@@ -104,7 +104,7 @@ public class CsvReaderTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readTest2(){
 		final CsvReader reader = CsvUtil.getReader();
 		final CsvData read = reader.read(FileUtil.file("d:/test/test.csv"));
@@ -114,7 +114,7 @@ public class CsvReaderTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readTest3(){
 		final CsvReadConfig csvReadConfig = CsvReadConfig.defaultConfig();
 		csvReadConfig.setContainsHeader(true);
@@ -129,15 +129,15 @@ public class CsvReaderTest {
 	public void lineNoTest(){
 		CsvReader reader = new CsvReader();
 		CsvData data = reader.read(ResourceUtil.getReader("test_lines.csv", CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals(1, data.getRow(0).getOriginalLineNumber());
-		Assert.assertEquals("a,b,c,d", CollUtil.join(data.getRow(0), ","));
+		Assertions.assertEquals(1, data.getRow(0).getOriginalLineNumber());
+		Assertions.assertEquals("a,b,c,d", CollUtil.join(data.getRow(0), ","));
 
-		Assert.assertEquals(4, data.getRow(2).getOriginalLineNumber());
-		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(2), ","));
+		Assertions.assertEquals(4, data.getRow(2).getOriginalLineNumber());
+		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(2), ","));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
-		Assert.assertEquals(6, data.getRow(3).getOriginalLineNumber());
-		Assert.assertEquals("a,s,d,f", CollUtil.join(data.getRow(3), ","));
+		Assertions.assertEquals(6, data.getRow(3).getOriginalLineNumber());
+		Assertions.assertEquals("a,s,d,f", CollUtil.join(data.getRow(3), ","));
 	}
 
 	@Test
@@ -146,15 +146,15 @@ public class CsvReaderTest {
 		CsvReader reader = new CsvReader(CsvReadConfig.defaultConfig().setBeginLineNo(2));
 		CsvData data = reader.read(ResourceUtil.getReader("test_lines.csv", CharsetUtil.CHARSET_UTF_8));
 
-		Assert.assertEquals(2, data.getRow(0).getOriginalLineNumber());
-		Assert.assertEquals("1,2,3,4", CollUtil.join(data.getRow(0), ","));
+		Assertions.assertEquals(2, data.getRow(0).getOriginalLineNumber());
+		Assertions.assertEquals("1,2,3,4", CollUtil.join(data.getRow(0), ","));
 
-		Assert.assertEquals(4, data.getRow(1).getOriginalLineNumber());
-		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(1), ","));
+		Assertions.assertEquals(4, data.getRow(1).getOriginalLineNumber());
+		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(1), ","));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
-		Assert.assertEquals(6, data.getRow(2).getOriginalLineNumber());
-		Assert.assertEquals("a,s,d,f", CollUtil.join(data.getRow(2), ","));
+		Assertions.assertEquals(6, data.getRow(2).getOriginalLineNumber());
+		Assertions.assertEquals("a,s,d,f", CollUtil.join(data.getRow(2), ","));
 	}
 
 	@Test
@@ -163,12 +163,12 @@ public class CsvReaderTest {
 		CsvReader reader = new CsvReader(CsvReadConfig.defaultConfig().setBeginLineNo(2).setContainsHeader(true));
 		CsvData data = reader.read(ResourceUtil.getReader("test_lines.csv", CharsetUtil.CHARSET_UTF_8));
 
-		Assert.assertEquals(4, data.getRow(0).getOriginalLineNumber());
-		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(0), ","));
+		Assertions.assertEquals(4, data.getRow(0).getOriginalLineNumber());
+		Assertions.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(0), ","));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
-		Assert.assertEquals(6, data.getRow(1).getOriginalLineNumber());
-		Assert.assertEquals("a,s,d,f", CollUtil.join(data.getRow(1), ","));
+		Assertions.assertEquals(6, data.getRow(1).getOriginalLineNumber());
+		Assertions.assertEquals("a,s,d,f", CollUtil.join(data.getRow(1), ","));
 	}
 
 	@Test
@@ -179,9 +179,9 @@ public class CsvReaderTest {
 						.setFieldSeparator(';'));
 		final CsvData csvRows = reader.readFromStr("123;456;'789;0'abc;");
 		final CsvRow row = csvRows.getRow(0);
-		Assert.assertEquals("123", row.get(0));
-		Assert.assertEquals("456", row.get(1));
-		Assert.assertEquals("'789;0'abc", row.get(2));
+		Assertions.assertEquals("123", row.get(0));
+		Assertions.assertEquals("456", row.get(1));
+		Assertions.assertEquals("'789;0'abc", row.get(2));
 	}
 
 	@Test
@@ -189,11 +189,11 @@ public class CsvReaderTest {
 		final CsvReader reader = CsvUtil.getReader(CsvReadConfig.defaultConfig().disableComment());
 		final CsvData read = reader.read(ResourceUtil.getUtf8Reader("test.csv"));
 		final CsvRow row = read.getRow(0);
-		Assert.assertEquals("# 这是一行注释，读取时应忽略", row.get(0));
+		Assertions.assertEquals("# 这是一行注释，读取时应忽略", row.get(0));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void streamTest(){
 		final CsvReader reader = CsvUtil.getReader(ResourceUtil.getUtf8Reader("test_bean.csv"));
 		reader.stream().limit(2).forEach(Console::log);

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvUtilTest.java
@@ -7,9 +7,9 @@ import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -26,13 +26,13 @@ public class CsvUtilTest {
 		CsvData data = reader.read(FileUtil.file("test.csv"));
 		List<CsvRow> rows = data.getRows();
 		final CsvRow row0 = rows.get(0);
-		Assert.assertEquals("sss,sss", row0.get(0));
-		Assert.assertEquals("姓名", row0.get(1));
-		Assert.assertEquals("性别", row0.get(2));
-		Assert.assertEquals("关注\"对象\"", row0.get(3));
-		Assert.assertEquals("年龄", row0.get(4));
-		Assert.assertEquals("", row0.get(5));
-		Assert.assertEquals("\"", row0.get(6));
+		Assertions.assertEquals("sss,sss", row0.get(0));
+		Assertions.assertEquals("姓名", row0.get(1));
+		Assertions.assertEquals("性别", row0.get(2));
+		Assertions.assertEquals("关注\"对象\"", row0.get(3));
+		Assertions.assertEquals("年龄", row0.get(4));
+		Assertions.assertEquals("", row0.get(5));
+		Assertions.assertEquals("\"", row0.get(6));
 	}
 
 	@Test
@@ -40,18 +40,18 @@ public class CsvUtilTest {
 		CsvReader reader = CsvUtil.getReader();
 		reader.read(FileUtil.getUtf8Reader("test.csv"), (csvRow)-> {
 			// 只有一行，所以直接判断
-			Assert.assertEquals("sss,sss", csvRow.get(0));
-			Assert.assertEquals("姓名", csvRow.get(1));
-			Assert.assertEquals("性别", csvRow.get(2));
-			Assert.assertEquals("关注\"对象\"", csvRow.get(3));
-			Assert.assertEquals("年龄", csvRow.get(4));
-			Assert.assertEquals("", csvRow.get(5));
-			Assert.assertEquals("\"", csvRow.get(6));
+			Assertions.assertEquals("sss,sss", csvRow.get(0));
+			Assertions.assertEquals("姓名", csvRow.get(1));
+			Assertions.assertEquals("性别", csvRow.get(2));
+			Assertions.assertEquals("关注\"对象\"", csvRow.get(3));
+			Assertions.assertEquals("年龄", csvRow.get(4));
+			Assertions.assertEquals("", csvRow.get(5));
+			Assertions.assertEquals("\"", csvRow.get(6));
 		});
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readTest3() {
 		CsvReader reader = CsvUtil.getReader();
 		String path = FileUtil.isWindows() ? "d:/test/test.csv" : "~/test/test.csv";
@@ -64,13 +64,13 @@ public class CsvUtilTest {
 				"\"sss,sss\",姓名,\"性别\",关注\"对象\",年龄,\"\",\"\"\"\n");
 		List<CsvRow> rows = data.getRows();
 		final CsvRow row0 = rows.get(0);
-		Assert.assertEquals("sss,sss", row0.get(0));
-		Assert.assertEquals("姓名", row0.get(1));
-		Assert.assertEquals("性别", row0.get(2));
-		Assert.assertEquals("关注\"对象\"", row0.get(3));
-		Assert.assertEquals("年龄", row0.get(4));
-		Assert.assertEquals("", row0.get(5));
-		Assert.assertEquals("\"", row0.get(6));
+		Assertions.assertEquals("sss,sss", row0.get(0));
+		Assertions.assertEquals("姓名", row0.get(1));
+		Assertions.assertEquals("性别", row0.get(2));
+		Assertions.assertEquals("关注\"对象\"", row0.get(3));
+		Assertions.assertEquals("年龄", row0.get(4));
+		Assertions.assertEquals("", row0.get(5));
+		Assertions.assertEquals("\"", row0.get(6));
 	}
 
 	@Test
@@ -78,18 +78,18 @@ public class CsvUtilTest {
 		CsvUtil.getReader().readFromStr("# 这是一行注释，读取时应忽略\n" +
 				"\"sss,sss\",姓名,\"性别\",关注\"对象\",年龄,\"\",\"\"\"\n",(csvRow)-> {
 			// 只有一行，所以直接判断
-			Assert.assertEquals("sss,sss", csvRow.get(0));
-			Assert.assertEquals("姓名", csvRow.get(1));
-			Assert.assertEquals("性别", csvRow.get(2));
-			Assert.assertEquals("关注\"对象\"", csvRow.get(3));
-			Assert.assertEquals("年龄", csvRow.get(4));
-			Assert.assertEquals("", csvRow.get(5));
-			Assert.assertEquals("\"", csvRow.get(6));
+			Assertions.assertEquals("sss,sss", csvRow.get(0));
+			Assertions.assertEquals("姓名", csvRow.get(1));
+			Assertions.assertEquals("性别", csvRow.get(2));
+			Assertions.assertEquals("关注\"对象\"", csvRow.get(3));
+			Assertions.assertEquals("年龄", csvRow.get(4));
+			Assertions.assertEquals("", csvRow.get(5));
+			Assertions.assertEquals("\"", csvRow.get(6));
 		});
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		String path = FileUtil.isWindows() ? "d:/test/testWrite.csv" : "~/test/testWrite.csv";
 		CsvWriter writer = CsvUtil.getWriter(path, CharsetUtil.CHARSET_UTF_8);
@@ -101,7 +101,7 @@ public class CsvUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeBeansTest() {
 
 		@Data
@@ -137,7 +137,7 @@ public class CsvUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readLfTest(){
 		final CsvReader reader = CsvUtil.getReader();
 		String path = FileUtil.isWindows() ? "d:/test/rw_test.csv" : "~/test/rw_test.csv";
@@ -148,7 +148,7 @@ public class CsvUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeWrapTest(){
 		List<List<Object>> resultList=new ArrayList<>();
 		List<Object> list =new ArrayList<>();
@@ -167,7 +167,7 @@ public class CsvUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeDataTest(){
 		@Data
 		@AllArgsConstructor

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvWriterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvWriterTest.java
@@ -2,13 +2,13 @@ package cn.hutool.core.text.csv;
 
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class CsvWriterTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeWithAliasTest(){
 		final CsvWriteConfig csvWriteConfig = CsvWriteConfig.defaultConfig()
 				.addHeaderAlias("name", "姓名")

--- a/hutool-core/src/test/java/cn/hutool/core/text/finder/CharFinderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/finder/CharFinderTest.java
@@ -1,30 +1,30 @@
 package cn.hutool.core.text.finder;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CharFinderTest {
 
 	@Test
 	public void startTest(){
 		int start = new CharFinder('a').setText("cba123").start(2);
-		Assert.assertEquals(2, start);
+		Assertions.assertEquals(2, start);
 
 		start = new CharFinder('c').setText("cba123").start(2);
-		Assert.assertEquals(-1, start);
+		Assertions.assertEquals(-1, start);
 
 		start = new CharFinder('3').setText("cba123").start(2);
-		Assert.assertEquals(5, start);
+		Assertions.assertEquals(5, start);
 	}
 	@Test
 	public void negativeStartTest(){
 		int start = new CharFinder('a').setText("cba123").setNegative(true).start(2);
-		Assert.assertEquals(2, start);
+		Assertions.assertEquals(2, start);
 
 		start = new CharFinder('2').setText("cba123").setNegative(true).start(2);
-		Assert.assertEquals(-1, start);
+		Assertions.assertEquals(-1, start);
 
 		start = new CharFinder('c').setText("cba123").setNegative(true).start(2);
-		Assert.assertEquals(0, start);
+		Assertions.assertEquals(0, start);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
@@ -1,6 +1,5 @@
 package cn.hutool.core.text.split;
 
-import cn.hutool.core.lang.id.NanoId;
 import cn.hutool.core.text.finder.CharFinder;
 import cn.hutool.core.text.finder.LengthFinder;
 import cn.hutool.core.text.finder.PatternFinder;
@@ -8,7 +7,6 @@ import cn.hutool.core.text.finder.StrFinder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.security.SecureRandom;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
@@ -1,12 +1,14 @@
 package cn.hutool.core.text.split;
 
+import cn.hutool.core.lang.id.NanoId;
 import cn.hutool.core.text.finder.CharFinder;
 import cn.hutool.core.text.finder.LengthFinder;
 import cn.hutool.core.text.finder.PatternFinder;
 import cn.hutool.core.text.finder.StrFinder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
+import java.security.SecureRandom;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -22,7 +24,7 @@ public class SplitIterTest {
 				Integer.MAX_VALUE,
 				false
 		);
-		Assert.assertEquals(6, splitIter.toList(false).size());
+		Assertions.assertEquals(6, splitIter.toList(false).size());
 	}
 
 	@Test
@@ -35,7 +37,7 @@ public class SplitIterTest {
 				Integer.MAX_VALUE,
 				false
 		);
-		Assert.assertEquals(4, splitIter.toList(false).size());
+		Assertions.assertEquals(4, splitIter.toList(false).size());
 	}
 
 	@Test
@@ -49,7 +51,7 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(4, strings.size());
+		Assertions.assertEquals(4, strings.size());
 	}
 
 	@Test
@@ -63,10 +65,10 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(true);
-		Assert.assertEquals(3, strings.size());
-		Assert.assertEquals("a", strings.get(0));
-		Assert.assertEquals("efedsfs", strings.get(1));
-		Assert.assertEquals("ddf", strings.get(2));
+		Assertions.assertEquals(3, strings.size());
+		Assertions.assertEquals("a", strings.get(0));
+		Assertions.assertEquals("efedsfs", strings.get(1));
+		Assertions.assertEquals("ddf", strings.get(2));
 	}
 
 	@Test
@@ -80,7 +82,7 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(3, strings.size());
+		Assertions.assertEquals(3, strings.size());
 	}
 
 	@Test
@@ -94,7 +96,7 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(3, strings.size());
+		Assertions.assertEquals(3, strings.size());
 	}
 
 	@Test
@@ -107,7 +109,7 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(4, strings.size());
+		Assertions.assertEquals(4, strings.size());
 	}
 
 	@Test
@@ -120,7 +122,7 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(3, strings.size());
+		Assertions.assertEquals(3, strings.size());
 	}
 
 	@Test
@@ -133,20 +135,22 @@ public class SplitIterTest {
 		);
 
 		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(1, strings.size());
+		Assertions.assertEquals(1, strings.size());
 	}
 
 	// 切割字符串是空字符串时报错
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void splitByEmptyTest(){
-		String text = "aa,bb,cc";
-		SplitIter splitIter = new SplitIter(text,
-				new StrFinder("", false),
-				3,
-				false
-		);
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			String text = "aa,bb,cc";
+			SplitIter splitIter = new SplitIter(text,
+					new StrFinder("", false),
+					3,
+					false
+			);
 
-		final List<String> strings = splitIter.toList(false);
-		Assert.assertEquals(1, strings.size());
+			final List<String> strings = splitIter.toList(false);
+			Assertions.assertEquals(1, strings.size());
+		});
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/split/StrSpliterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/split/StrSpliterTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.text.split;
 
 import cn.hutool.core.text.StrSplitter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -18,41 +18,41 @@ public class StrSpliterTest {
 		String str1 = "a, ,efedsfs,   ddf";
 		List<String> split = StrSplitter.split(str1, ',', 0, true, true);
 
-		Assert.assertEquals("ddf", split.get(2));
-		Assert.assertEquals(3, split.size());
+		Assertions.assertEquals("ddf", split.get(2));
+		Assertions.assertEquals(3, split.size());
 	}
 
 	@Test
 	public void splitByStrTest(){
 		String str1 = "aabbccaaddaaee";
 		List<String> split = StrSplitter.split(str1, "aa", 0, true, true);
-		Assert.assertEquals("ee", split.get(2));
-		Assert.assertEquals(3, split.size());
+		Assertions.assertEquals("ee", split.get(2));
+		Assertions.assertEquals(3, split.size());
 	}
 
 	@Test
 	public void splitByBlankTest(){
 		String str1 = "aa bbccaa     ddaaee";
 		List<String> split = StrSplitter.split(str1, 0);
-		Assert.assertEquals("ddaaee", split.get(2));
-		Assert.assertEquals(3, split.size());
+		Assertions.assertEquals("ddaaee", split.get(2));
+		Assertions.assertEquals(3, split.size());
 	}
 
 	@Test
 	public void splitPathTest(){
 		String str1 = "/use/local/bin";
 		List<String> split = StrSplitter.splitPath(str1, 0);
-		Assert.assertEquals("bin", split.get(2));
-		Assert.assertEquals(3, split.size());
+		Assertions.assertEquals("bin", split.get(2));
+		Assertions.assertEquals(3, split.size());
 	}
 
 	@Test
 	public void splitMappingTest() {
 		String str = "1.2.";
 		List<Long> split = StrSplitter.split(str, '.', 0, true, true, Long::parseLong);
-		Assert.assertEquals(2, split.size());
-		Assert.assertEquals(Long.valueOf(1L), split.get(0));
-		Assert.assertEquals(Long.valueOf(2L), split.get(1));
+		Assertions.assertEquals(2, split.size());
+		Assertions.assertEquals(Long.valueOf(1L), split.get(0));
+		Assertions.assertEquals(Long.valueOf(2L), split.get(1));
 	}
 
 	@Test
@@ -60,6 +60,6 @@ public class StrSpliterTest {
 		String str = "";
 		final String[] split = str.split(",");
 		final String[] strings = StrSplitter.splitToArray(str, ",", -1, false, false);
-		Assert.assertArrayEquals(split, strings);
+		Assertions.assertArrayEquals(split, strings);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/thread/AsyncUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/thread/AsyncUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.thread;
 
-import cn.hutool.core.lang.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public class AsyncUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void waitAndGetTest() {
 		CompletableFuture<String> hutool = CompletableFuture.supplyAsync(() -> {
 			ThreadUtil.sleep(1, TimeUnit.SECONDS);
@@ -33,6 +33,6 @@ public class AsyncUtilTest {
 		// 等待完成
 		AsyncUtil.waitAll(hutool, sweater, warm);
 		// 获取结果
-		Assert.isTrue("hutool卫衣真暖和".equals(AsyncUtil.get(hutool) + AsyncUtil.get(sweater) + AsyncUtil.get(warm)));
+		Assertions.assertEquals("hutool卫衣真暖和", AsyncUtil.get(hutool) + AsyncUtil.get(sweater) + AsyncUtil.get(warm));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/thread/ConcurrencyTesterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/thread/ConcurrencyTesterTest.java
@@ -3,13 +3,13 @@ package cn.hutool.core.thread;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.RandomUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ConcurrencyTesterTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void concurrencyTesterTest() {
 		ConcurrencyTester tester = ThreadUtil.concurrencyTest(100, () -> {
 			long delay = RandomUtil.randomLong(100, 1000);
@@ -20,7 +20,7 @@ public class ConcurrencyTesterTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void multiTest(){
 		ConcurrencyTester ct = new ConcurrencyTester(5);
 		for(int i=0;i<3;i++){

--- a/hutool-core/src/test/java/cn/hutool/core/thread/ThreadUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/thread/ThreadUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.thread;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ThreadUtilTest {
 
@@ -9,6 +9,6 @@ public class ThreadUtilTest {
 	public void executeTest() {
 		final boolean isValid = true;
 
-		ThreadUtil.execute(() -> Assert.assertTrue(isValid));
+		ThreadUtil.execute(() -> Assertions.assertTrue(isValid));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ArrayUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ArrayUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.util;
 
 import cn.hutool.core.collection.CollUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -20,134 +20,134 @@ public class ArrayUtilTest {
 	@Test
 	public void isEmptyTest() {
 		int[] a = {};
-		Assert.assertTrue(ArrayUtil.isEmpty(a));
-		Assert.assertTrue(ArrayUtil.isEmpty((Object) a));
+		Assertions.assertTrue(ArrayUtil.isEmpty(a));
+		Assertions.assertTrue(ArrayUtil.isEmpty((Object) a));
 		int[] b = null;
 		//noinspection ConstantConditions
-		Assert.assertTrue(ArrayUtil.isEmpty(b));
+		Assertions.assertTrue(ArrayUtil.isEmpty(b));
 		Object c = null;
 		//noinspection ConstantConditions
-		Assert.assertTrue(ArrayUtil.isEmpty(c));
+		Assertions.assertTrue(ArrayUtil.isEmpty(c));
 
 		Object d = new Object[]{"1", "2", 3, 4D};
 		boolean isEmpty = ArrayUtil.isEmpty(d);
-		Assert.assertFalse(isEmpty);
+		Assertions.assertFalse(isEmpty);
 		d = new Object[0];
 		isEmpty = ArrayUtil.isEmpty(d);
-		Assert.assertTrue(isEmpty);
+		Assertions.assertTrue(isEmpty);
 		d = null;
 		//noinspection ConstantConditions
 		isEmpty = ArrayUtil.isEmpty(d);
 		//noinspection ConstantConditions
-		Assert.assertTrue(isEmpty);
+		Assertions.assertTrue(isEmpty);
 
 		// Object数组
 		Object[] e = new Object[]{"1", "2", 3, 4D};
 		final boolean empty = ArrayUtil.isEmpty(e);
-		Assert.assertFalse(empty);
+		Assertions.assertFalse(empty);
 	}
 
 	@Test
 	public void isNotEmptyTest() {
 		int[] a = {1, 2};
-		Assert.assertTrue(ArrayUtil.isNotEmpty(a));
+		Assertions.assertTrue(ArrayUtil.isNotEmpty(a));
 
 		String[] b = {"a", "b", "c"};
-		Assert.assertTrue(ArrayUtil.isNotEmpty(b));
+		Assertions.assertTrue(ArrayUtil.isNotEmpty(b));
 
 		Object c = new Object[]{"1", "2", 3, 4D};
-		Assert.assertTrue(ArrayUtil.isNotEmpty(c));
+		Assertions.assertTrue(ArrayUtil.isNotEmpty(c));
 	}
 
 	@Test
 	public void newArrayTest() {
 		String[] newArray = ArrayUtil.newArray(String.class, 3);
-		Assert.assertEquals(3, newArray.length);
+		Assertions.assertEquals(3, newArray.length);
 	}
 
 	@Test
 	public void cloneTest() {
 		Integer[] b = {1, 2, 3};
 		Integer[] cloneB = ArrayUtil.clone(b);
-		Assert.assertArrayEquals(b, cloneB);
+		Assertions.assertArrayEquals(b, cloneB);
 
 		int[] a = {1, 2, 3};
 		int[] clone = ArrayUtil.clone(a);
-		Assert.assertArrayEquals(a, clone);
+		Assertions.assertArrayEquals(a, clone);
 	}
 
 	@Test
 	public void filterEditTest() {
 		Integer[] a = {1, 2, 3, 4, 5, 6};
 		Integer[] filter = ArrayUtil.edit(a, t -> (t % 2 == 0) ? t : null);
-		Assert.assertArrayEquals(filter, new Integer[]{2, 4, 6});
+		Assertions.assertArrayEquals(filter, new Integer[]{2, 4, 6});
 	}
 
 	@Test
 	public void filterTestForFilter() {
 		Integer[] a = {1, 2, 3, 4, 5, 6};
 		Integer[] filter = ArrayUtil.filter(a, t -> t % 2 == 0);
-		Assert.assertArrayEquals(filter, new Integer[]{2, 4, 6});
+		Assertions.assertArrayEquals(filter, new Integer[]{2, 4, 6});
 	}
 
 	@Test
 	public void editTest() {
 		Integer[] a = {1, 2, 3, 4, 5, 6};
 		Integer[] filter = ArrayUtil.edit(a, t -> (t % 2 == 0) ? t * 10 : t);
-		Assert.assertArrayEquals(filter, new Integer[]{1, 20, 3, 40, 5, 60});
+		Assertions.assertArrayEquals(filter, new Integer[]{1, 20, 3, 40, 5, 60});
 	}
 
 	@Test
 	public void indexOfTest() {
 		Integer[] a = {1, 2, 3, 4, 5, 6};
 		int index = ArrayUtil.indexOf(a, 3);
-		Assert.assertEquals(2, index);
+		Assertions.assertEquals(2, index);
 
 		long[] b = {1, 2, 3, 4, 5, 6};
 		int index2 = ArrayUtil.indexOf(b, 3);
-		Assert.assertEquals(2, index2);
+		Assertions.assertEquals(2, index2);
 	}
 
 	@Test
 	public void lastIndexOfTest() {
 		Integer[] a = {1, 2, 3, 4, 3, 6};
 		int index = ArrayUtil.lastIndexOf(a, 3);
-		Assert.assertEquals(4, index);
+		Assertions.assertEquals(4, index);
 
 		long[] b = {1, 2, 3, 4, 3, 6};
 		int index2 = ArrayUtil.lastIndexOf(b, 3);
-		Assert.assertEquals(4, index2);
+		Assertions.assertEquals(4, index2);
 	}
 
 	@Test
 	public void containsTest() {
 		Integer[] a = {1, 2, 3, 4, 3, 6};
 		boolean contains = ArrayUtil.contains(a, 3);
-		Assert.assertTrue(contains);
+		Assertions.assertTrue(contains);
 
 		long[] b = {1, 2, 3, 4, 3, 6};
 		boolean contains2 = ArrayUtil.contains(b, 3);
-		Assert.assertTrue(contains2);
+		Assertions.assertTrue(contains2);
 	}
 
 	@Test
 	public void containsAnyTest() {
 		Integer[] a = {1, 2, 3, 4, 3, 6};
 		boolean contains = ArrayUtil.containsAny(a, 4, 10, 40);
-		Assert.assertTrue(contains);
+		Assertions.assertTrue(contains);
 
 		contains = ArrayUtil.containsAny(a, 10, 40);
-		Assert.assertFalse(contains);
+		Assertions.assertFalse(contains);
 	}
 
 	@Test
 	public void containsAllTest() {
 		Integer[] a = {1, 2, 3, 4, 3, 6};
 		boolean contains = ArrayUtil.containsAll(a, 4, 2, 6);
-		Assert.assertTrue(contains);
+		Assertions.assertTrue(contains);
 
 		contains = ArrayUtil.containsAll(a, 1, 2, 3, 5);
-		Assert.assertFalse(contains);
+		Assertions.assertFalse(contains);
 	}
 
 	@Test
@@ -155,49 +155,50 @@ public class ArrayUtilTest {
 		String[] keys = {"a", "b", "c"};
 		Integer[] values = {1, 2, 3};
 		Map<String, Integer> map = ArrayUtil.zip(keys, values, true);
-		Assert.assertEquals(Objects.requireNonNull(map).toString(), "{a=1, b=2, c=3}");
+		Assertions.assertEquals(Objects.requireNonNull(map).toString(), "{a=1, b=2, c=3}");
 	}
 
 	@Test
 	public void castTest() {
 		Object[] values = {"1", "2", "3"};
 		String[] cast = (String[]) ArrayUtil.cast(String.class, values);
-		Assert.assertEquals(values[0], cast[0]);
-		Assert.assertEquals(values[1], cast[1]);
-		Assert.assertEquals(values[2], cast[2]);
+		Assertions.assertEquals(values[0], cast[0]);
+		Assertions.assertEquals(values[1], cast[1]);
+		Assertions.assertEquals(values[2], cast[2]);
 	}
 
 	@Test
 	public void rangeTest() {
 		int[] range = ArrayUtil.range(0, 10);
-		Assert.assertEquals(0, range[0]);
-		Assert.assertEquals(1, range[1]);
-		Assert.assertEquals(2, range[2]);
-		Assert.assertEquals(3, range[3]);
-		Assert.assertEquals(4, range[4]);
-		Assert.assertEquals(5, range[5]);
-		Assert.assertEquals(6, range[6]);
-		Assert.assertEquals(7, range[7]);
-		Assert.assertEquals(8, range[8]);
-		Assert.assertEquals(9, range[9]);
+		Assertions.assertEquals(0, range[0]);
+		Assertions.assertEquals(1, range[1]);
+		Assertions.assertEquals(2, range[2]);
+		Assertions.assertEquals(3, range[3]);
+		Assertions.assertEquals(4, range[4]);
+		Assertions.assertEquals(5, range[5]);
+		Assertions.assertEquals(6, range[6]);
+		Assertions.assertEquals(7, range[7]);
+		Assertions.assertEquals(8, range[8]);
+		Assertions.assertEquals(9, range[9]);
 	}
 
-	@Test(expected = NegativeArraySizeException.class)
+	@Test
 	public void rangeMinTest() {
-		//noinspection ResultOfMethodCallIgnored
-		ArrayUtil.range(0, Integer.MIN_VALUE);
+		Assertions.assertThrows(NegativeArraySizeException.class, () -> {
+			ArrayUtil.range(0, Integer.MIN_VALUE);
+		});
 	}
 
 	@Test
 	public void maxTest() {
 		int max = ArrayUtil.max(1, 2, 13, 4, 5);
-		Assert.assertEquals(13, max);
+		Assertions.assertEquals(13, max);
 
 		long maxLong = ArrayUtil.max(1L, 2L, 13L, 4L, 5L);
-		Assert.assertEquals(13, maxLong);
+		Assertions.assertEquals(13, maxLong);
 
 		double maxDouble = ArrayUtil.max(1D, 2.4D, 13.0D, 4.55D, 5D);
-		Assert.assertEquals(13.0, maxDouble, 2);
+		Assertions.assertEquals(13.0, maxDouble, 2);
 
 		BigDecimal one = new BigDecimal("1.00");
 		BigDecimal two = new BigDecimal("2.0");
@@ -205,22 +206,22 @@ public class ArrayUtilTest {
 		BigDecimal[] bigDecimals = {two, one, three};
 
 		BigDecimal minAccuracy = ArrayUtil.min(bigDecimals, Comparator.comparingInt(BigDecimal::scale));
-		Assert.assertEquals(minAccuracy, three);
+		Assertions.assertEquals(minAccuracy, three);
 
 		BigDecimal maxAccuracy = ArrayUtil.max(bigDecimals, Comparator.comparingInt(BigDecimal::scale));
-		Assert.assertEquals(maxAccuracy, one);
+		Assertions.assertEquals(maxAccuracy, one);
 	}
 
 	@Test
 	public void minTest() {
 		int min = ArrayUtil.min(1, 2, 13, 4, 5);
-		Assert.assertEquals(1, min);
+		Assertions.assertEquals(1, min);
 
 		long minLong = ArrayUtil.min(1L, 2L, 13L, 4L, 5L);
-		Assert.assertEquals(1, minLong);
+		Assertions.assertEquals(1, minLong);
 
 		double minDouble = ArrayUtil.min(1D, 2.4D, 13.0D, 4.55D, 5D);
-		Assert.assertEquals(1.0, minDouble, 2);
+		Assertions.assertEquals(1.0, minDouble, 2);
 	}
 
 	@Test
@@ -229,7 +230,7 @@ public class ArrayUtilTest {
 		String[] b = {"a", "b", "c"};
 
 		String[] result = ArrayUtil.append(a, b);
-		Assert.assertArrayEquals(new String[]{"1", "2", "3", "4", "a", "b", "c"}, result);
+		Assertions.assertArrayEquals(new String[]{"1", "2", "3", "4", "a", "b", "c"}, result);
 	}
 
 	@Test
@@ -239,97 +240,97 @@ public class ArrayUtilTest {
 
 		// 在-1位置插入，相当于在3位置插入
 		String[] result = ArrayUtil.insert(a, -1, b);
-		Assert.assertArrayEquals(new String[]{"1", "2", "3", "a", "b", "c", "4"}, result);
+		Assertions.assertArrayEquals(new String[]{"1", "2", "3", "a", "b", "c", "4"}, result);
 
 		// 在第0个位置插入，即在数组前追加
 		result = ArrayUtil.insert(a, 0, b);
-		Assert.assertArrayEquals(new String[]{"a", "b", "c", "1", "2", "3", "4"}, result);
+		Assertions.assertArrayEquals(new String[]{"a", "b", "c", "1", "2", "3", "4"}, result);
 
 		// 在第2个位置插入，即"3"之前
 		result = ArrayUtil.insert(a, 2, b);
-		Assert.assertArrayEquals(new String[]{"1", "2", "a", "b", "c", "3", "4"}, result);
+		Assertions.assertArrayEquals(new String[]{"1", "2", "a", "b", "c", "3", "4"}, result);
 
 		// 在第4个位置插入，即"4"之后，相当于追加
 		result = ArrayUtil.insert(a, 4, b);
-		Assert.assertArrayEquals(new String[]{"1", "2", "3", "4", "a", "b", "c"}, result);
+		Assertions.assertArrayEquals(new String[]{"1", "2", "3", "4", "a", "b", "c"}, result);
 
 		// 在第5个位置插入，由于数组长度为4，因此补null
 		result = ArrayUtil.insert(a, 5, b);
-		Assert.assertArrayEquals(new String[]{"1", "2", "3", "4", null, "a", "b", "c"}, result);
+		Assertions.assertArrayEquals(new String[]{"1", "2", "3", "4", null, "a", "b", "c"}, result);
 	}
 
 	@Test
 	public void joinTest() {
 		String[] array = {"aa", "bb", "cc", "dd"};
 		String join = ArrayUtil.join(array, ",", "[", "]");
-		Assert.assertEquals("[aa],[bb],[cc],[dd]", join);
+		Assertions.assertEquals("[aa],[bb],[cc],[dd]", join);
 
 		Object array2 = new String[]{"aa", "bb", "cc", "dd"};
 		String join2 = ArrayUtil.join(array2, ",");
-		Assert.assertEquals("aa,bb,cc,dd", join2);
+		Assertions.assertEquals("aa,bb,cc,dd", join2);
 	}
 
 	@Test
 	public void getArrayTypeTest() {
 		Class<?> arrayType = ArrayUtil.getArrayType(int.class);
-		Assert.assertSame(int[].class, arrayType);
+		Assertions.assertSame(int[].class, arrayType);
 
 		arrayType = ArrayUtil.getArrayType(String.class);
-		Assert.assertSame(String[].class, arrayType);
+		Assertions.assertSame(String[].class, arrayType);
 	}
 
 	@Test
 	public void distinctTest() {
 		String[] array = {"aa", "bb", "cc", "dd", "bb", "dd"};
 		String[] distinct = ArrayUtil.distinct(array);
-		Assert.assertArrayEquals(new String[]{"aa", "bb", "cc", "dd"}, distinct);
+		Assertions.assertArrayEquals(new String[]{"aa", "bb", "cc", "dd"}, distinct);
 	}
 
 	@Test
 	public void toStingTest() {
 		int[] a = {1, 3, 56, 6, 7};
-		Assert.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(a));
+		Assertions.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(a));
 		long[] b = {1, 3, 56, 6, 7};
-		Assert.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(b));
+		Assertions.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(b));
 		short[] c = {1, 3, 56, 6, 7};
-		Assert.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(c));
+		Assertions.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(c));
 		double[] d = {1, 3, 56, 6, 7};
-		Assert.assertEquals("[1.0, 3.0, 56.0, 6.0, 7.0]", ArrayUtil.toString(d));
+		Assertions.assertEquals("[1.0, 3.0, 56.0, 6.0, 7.0]", ArrayUtil.toString(d));
 		byte[] e = {1, 3, 56, 6, 7};
-		Assert.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(e));
+		Assertions.assertEquals("[1, 3, 56, 6, 7]", ArrayUtil.toString(e));
 		boolean[] f = {true, false, true, true, true};
-		Assert.assertEquals("[true, false, true, true, true]", ArrayUtil.toString(f));
+		Assertions.assertEquals("[true, false, true, true, true]", ArrayUtil.toString(f));
 		float[] g = {1, 3, 56, 6, 7};
-		Assert.assertEquals("[1.0, 3.0, 56.0, 6.0, 7.0]", ArrayUtil.toString(g));
+		Assertions.assertEquals("[1.0, 3.0, 56.0, 6.0, 7.0]", ArrayUtil.toString(g));
 		char[] h = {'a', 'b', '你', '好', '1'};
-		Assert.assertEquals("[a, b, 你, 好, 1]", ArrayUtil.toString(h));
+		Assertions.assertEquals("[a, b, 你, 好, 1]", ArrayUtil.toString(h));
 
 		String[] array = {"aa", "bb", "cc", "dd", "bb", "dd"};
-		Assert.assertEquals("[aa, bb, cc, dd, bb, dd]", ArrayUtil.toString(array));
+		Assertions.assertEquals("[aa, bb, cc, dd, bb, dd]", ArrayUtil.toString(array));
 	}
 
 	@Test
 	public void toArrayTest() {
 		final ArrayList<String> list = CollUtil.newArrayList("A", "B", "C", "D");
 		final String[] array = ArrayUtil.toArray(list, String.class);
-		Assert.assertEquals("A", array[0]);
-		Assert.assertEquals("B", array[1]);
-		Assert.assertEquals("C", array[2]);
-		Assert.assertEquals("D", array[3]);
+		Assertions.assertEquals("A", array[0]);
+		Assertions.assertEquals("B", array[1]);
+		Assertions.assertEquals("C", array[2]);
+		Assertions.assertEquals("D", array[3]);
 	}
 
 	@Test
 	public void addAllTest() {
 		final int[] ints = ArrayUtil.addAll(new int[]{1, 2, 3}, new int[]{4, 5, 6});
-		Assert.assertArrayEquals(new int[]{1, 2, 3, 4, 5, 6}, ints);
+		Assertions.assertArrayEquals(new int[]{1, 2, 3, 4, 5, 6}, ints);
 	}
 
 	@Test
 	public void isAllNotNullTest() {
 		String[] allNotNull = {"aa", "bb", "cc", "dd", "bb", "dd"};
-		Assert.assertTrue(ArrayUtil.isAllNotNull(allNotNull));
+		Assertions.assertTrue(ArrayUtil.isAllNotNull(allNotNull));
 		String[] hasNull = {"aa", "bb", "cc", null, "bb", "dd"};
-		Assert.assertFalse(ArrayUtil.isAllNotNull(hasNull));
+		Assertions.assertFalse(ArrayUtil.isAllNotNull(hasNull));
 	}
 
 	@Test
@@ -341,25 +342,25 @@ public class ArrayUtilTest {
 		Integer[] e = {0x78, 0x9A, 0x10};
 
 		int i = ArrayUtil.indexOfSub(a, b);
-		Assert.assertEquals(2, i);
+		Assertions.assertEquals(2, i);
 
 		i = ArrayUtil.indexOfSub(a, c);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.indexOfSub(a, d);
-		Assert.assertEquals(3, i);
+		Assertions.assertEquals(3, i);
 
 		i = ArrayUtil.indexOfSub(a, e);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.indexOfSub(a, null);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.indexOfSub(null, null);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.indexOfSub(null, b);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 	}
 
 	@Test
@@ -367,7 +368,7 @@ public class ArrayUtilTest {
 		Integer[] a = {0x12, 0x56, 0x34, 0x56, 0x78, 0x9A};
 		Integer[] b = {0x56, 0x78};
 		int i = ArrayUtil.indexOfSub(a, b);
-		Assert.assertEquals(3, i);
+		Assertions.assertEquals(3, i);
 	}
 
 	@Test
@@ -379,25 +380,25 @@ public class ArrayUtilTest {
 		Integer[] e = {0x78, 0x9A, 0x10};
 
 		int i = ArrayUtil.lastIndexOfSub(a, b);
-		Assert.assertEquals(2, i);
+		Assertions.assertEquals(2, i);
 
 		i = ArrayUtil.lastIndexOfSub(a, c);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.lastIndexOfSub(a, d);
-		Assert.assertEquals(3, i);
+		Assertions.assertEquals(3, i);
 
 		i = ArrayUtil.lastIndexOfSub(a, e);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.lastIndexOfSub(a, null);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.lastIndexOfSub(null, null);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 
 		i = ArrayUtil.lastIndexOfSub(null, b);
-		Assert.assertEquals(-1, i);
+		Assertions.assertEquals(-1, i);
 	}
 
 	@Test
@@ -405,42 +406,42 @@ public class ArrayUtilTest {
 		Integer[] a = {0x12, 0x56, 0x78, 0x56, 0x21, 0x9A};
 		Integer[] b = {0x56, 0x78};
 		int i = ArrayUtil.indexOfSub(a, b);
-		Assert.assertEquals(1, i);
+		Assertions.assertEquals(1, i);
 	}
 
 	@Test
 	public void reverseTest(){
 		int[] a = {1,2,3,4};
 		final int[] reverse = ArrayUtil.reverse(a);
-		Assert.assertArrayEquals(new int[]{4,3,2,1}, reverse);
+		Assertions.assertArrayEquals(new int[]{4,3,2,1}, reverse);
 	}
 
 	@Test
 	public void reverseTest2s(){
 		Object[] a = {"1",'2',"3",4};
 		final Object[] reverse = ArrayUtil.reverse(a);
-		Assert.assertArrayEquals(new Object[]{4,"3",'2',"1"}, reverse);
+		Assertions.assertArrayEquals(new Object[]{4,"3",'2',"1"}, reverse);
 	}
 
 	@Test
 	public void removeEmptyTest() {
 		String[] a = {"a", "b", "", null, " ", "c"};
 		String[] resultA = {"a", "b", " ", "c"};
-		Assert.assertArrayEquals(ArrayUtil.removeEmpty(a), resultA);
+		Assertions.assertArrayEquals(ArrayUtil.removeEmpty(a), resultA);
 	}
 
 	@Test
 	public void removeBlankTest() {
 		String[] a = {"a", "b", "", null, " ", "c"};
 		String[] resultA = {"a", "b", "c"};
-		Assert.assertArrayEquals(ArrayUtil.removeBlank(a), resultA);
+		Assertions.assertArrayEquals(ArrayUtil.removeBlank(a), resultA);
 	}
 
 	@Test
 	public void nullToEmptyTest() {
 		String[] a = {"a", "b", "", null, " ", "c"};
 		String[] resultA = {"a", "b", "", "", " ", "c"};
-		Assert.assertArrayEquals(ArrayUtil.nullToEmpty(a), resultA);
+		Assertions.assertArrayEquals(ArrayUtil.nullToEmpty(a), resultA);
 	}
 
 	@Test
@@ -448,7 +449,7 @@ public class ArrayUtilTest {
 		Object a = new int[]{1, 2, 3, 4};
 		Object[] wrapA = ArrayUtil.wrap(a);
 		for (Object o : wrapA) {
-			Assert.assertTrue(o instanceof Integer);
+			Assertions.assertTrue(o instanceof Integer);
 		}
 	}
 
@@ -456,7 +457,7 @@ public class ArrayUtilTest {
 	public void splitTest() {
 		byte[] array = new byte[1024];
 		byte[][] arrayAfterSplit = ArrayUtil.split(array, 500);
-		Assert.assertEquals(3, arrayAfterSplit.length);
-		Assert.assertEquals(24, arrayAfterSplit[2].length);
+		Assertions.assertEquals(3, arrayAfterSplit.length);
+		Assertions.assertEquals(24, arrayAfterSplit[2].length);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/BooleanUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/BooleanUtilTest.java
@@ -1,42 +1,42 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BooleanUtilTest {
-	
+
 	@Test
 	public void toBooleanTest() {
-		Assert.assertTrue(BooleanUtil.toBoolean("true"));
-		Assert.assertTrue(BooleanUtil.toBoolean("yes"));
-		Assert.assertTrue(BooleanUtil.toBoolean("t"));
-		Assert.assertTrue(BooleanUtil.toBoolean("OK"));
-		Assert.assertTrue(BooleanUtil.toBoolean("1"));
-		Assert.assertTrue(BooleanUtil.toBoolean("On"));
-		Assert.assertTrue(BooleanUtil.toBoolean("是"));
-		Assert.assertTrue(BooleanUtil.toBoolean("对"));
-		Assert.assertTrue(BooleanUtil.toBoolean("真"));
-		
-		Assert.assertFalse(BooleanUtil.toBoolean("false"));
-		Assert.assertFalse(BooleanUtil.toBoolean("6455434"));
-		Assert.assertFalse(BooleanUtil.toBoolean(""));
+		Assertions.assertTrue(BooleanUtil.toBoolean("true"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("yes"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("t"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("OK"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("1"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("On"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("是"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("对"));
+		Assertions.assertTrue(BooleanUtil.toBoolean("真"));
+
+		Assertions.assertFalse(BooleanUtil.toBoolean("false"));
+		Assertions.assertFalse(BooleanUtil.toBoolean("6455434"));
+		Assertions.assertFalse(BooleanUtil.toBoolean(""));
 	}
 
 	@Test
 	public void andTest(){
-		Assert.assertFalse(BooleanUtil.and(true,false));
-		Assert.assertFalse(BooleanUtil.andOfWrap(true,false));
+		Assertions.assertFalse(BooleanUtil.and(true,false));
+		Assertions.assertFalse(BooleanUtil.andOfWrap(true,false));
 	}
 
 	@Test
 	public void orTest(){
-		Assert.assertTrue(BooleanUtil.or(true,false));
-		Assert.assertTrue(BooleanUtil.orOfWrap(true,false));
+		Assertions.assertTrue(BooleanUtil.or(true,false));
+		Assertions.assertTrue(BooleanUtil.orOfWrap(true,false));
 	}
 
 	@Test
 	public void xorTest(){
-		Assert.assertTrue(BooleanUtil.xor(true,false));
-		Assert.assertTrue(BooleanUtil.xorOfWrap(true,false));
+		Assertions.assertTrue(BooleanUtil.xor(true,false));
+		Assertions.assertTrue(BooleanUtil.xorOfWrap(true,false));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ByteUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ByteUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -14,15 +14,15 @@ public class ByteUtilTest {
 
 		byte[] bytesInt = ByteUtil.intToBytes(int1, ByteOrder.LITTLE_ENDIAN);
 		int int2 = ByteUtil.bytesToInt(bytesInt, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(int1, int2);
+		Assertions.assertEquals(int1, int2);
 
 		byte[] bytesInt2 = ByteUtil.intToBytes(int1, ByteOrder.LITTLE_ENDIAN);
 		int int3 = ByteUtil.bytesToInt(bytesInt2, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(int1, int3);
+		Assertions.assertEquals(int1, int3);
 
 		byte[] bytesInt3 = ByteUtil.intToBytes(int1, ByteOrder.LITTLE_ENDIAN);
 		int int4 = ByteUtil.bytesToInt(bytesInt3, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(int1, int4);
+		Assertions.assertEquals(int1, int4);
 	}
 
 	@Test
@@ -33,7 +33,7 @@ public class ByteUtilTest {
 
 		// 测试大端序 byte 数组转 int
 		int int3 = ByteUtil.bytesToInt(bytesInt, ByteOrder.BIG_ENDIAN);
-		Assert.assertEquals(int2, int3);
+		Assertions.assertEquals(int2, int3);
 	}
 
 	@Test
@@ -43,15 +43,15 @@ public class ByteUtilTest {
 
 		byte[] bytesLong = ByteUtil.longToBytes(long1, ByteOrder.LITTLE_ENDIAN);
 		long long2 = ByteUtil.bytesToLong(bytesLong, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(long1, long2);
+		Assertions.assertEquals(long1, long2);
 
 		byte[] bytesLong2 = ByteUtil.longToBytes(long1);
 		long long3 = ByteUtil.bytesToLong(bytesLong2, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(long1, long3);
+		Assertions.assertEquals(long1, long3);
 
 		byte[] bytesLong3 = ByteUtil.longToBytes(long1, ByteOrder.LITTLE_ENDIAN);
 		long long4 = ByteUtil.bytesToLong(bytesLong3);
-		Assert.assertEquals(long1, long4);
+		Assertions.assertEquals(long1, long4);
 	}
 
 	@Test
@@ -62,7 +62,7 @@ public class ByteUtilTest {
 		byte[] bytesLong = ByteUtil.longToBytes(long1, ByteOrder.BIG_ENDIAN);
 		long long2 = ByteUtil.bytesToLong(bytesLong, ByteOrder.BIG_ENDIAN);
 
-		Assert.assertEquals(long1, long2);
+		Assertions.assertEquals(long1, long2);
 	}
 
 	@Test
@@ -72,7 +72,7 @@ public class ByteUtilTest {
 
 		byte[] bytesLong = ByteUtil.floatToBytes(f1, ByteOrder.LITTLE_ENDIAN);
 		float f2 = ByteUtil.bytesToFloat(bytesLong, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(f1, f2, 2);
+		Assertions.assertEquals(f1, f2, 2);
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class ByteUtilTest {
 		byte[] bytesLong = ByteUtil.floatToBytes(f1, ByteOrder.BIG_ENDIAN);
 		float f2 = ByteUtil.bytesToFloat(bytesLong, ByteOrder.BIG_ENDIAN);
 
-		Assert.assertEquals(f1, f2, 2);
+		Assertions.assertEquals(f1, f2, 2);
 	}
 
 	@Test
@@ -92,15 +92,15 @@ public class ByteUtilTest {
 
 		byte[] bytes = ByteUtil.shortToBytes(short1, ByteOrder.LITTLE_ENDIAN);
 		short short2 = ByteUtil.bytesToShort(bytes, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(short2, short1);
+		Assertions.assertEquals(short2, short1);
 
 		byte[] bytes2 = ByteUtil.shortToBytes(short1);
 		short short3 = ByteUtil.bytesToShort(bytes2, ByteOrder.LITTLE_ENDIAN);
-		Assert.assertEquals(short3, short1);
+		Assertions.assertEquals(short3, short1);
 
 		byte[] bytes3 = ByteUtil.shortToBytes(short1, ByteOrder.LITTLE_ENDIAN);
 		short short4 = ByteUtil.bytesToShort(bytes3);
-		Assert.assertEquals(short4, short1);
+		Assertions.assertEquals(short4, short1);
 	}
 
 	@Test
@@ -109,7 +109,7 @@ public class ByteUtilTest {
 		byte[] bytes = ByteUtil.shortToBytes(short1, ByteOrder.BIG_ENDIAN);
 		short short2 = ByteUtil.bytesToShort(bytes, ByteOrder.BIG_ENDIAN);
 
-		Assert.assertEquals(short2, short1);
+		Assertions.assertEquals(short2, short1);
 	}
 
 	@Test
@@ -118,12 +118,12 @@ public class ByteUtilTest {
 		ByteBuffer wrap = ByteBuffer.wrap(ByteUtil.longToBytes(a));
 		wrap.order(ByteOrder.LITTLE_ENDIAN);
 		long aLong = wrap.getLong();
-		Assert.assertEquals(a, aLong);
+		Assertions.assertEquals(a, aLong);
 
 		wrap = ByteBuffer.wrap(ByteUtil.longToBytes(a, ByteOrder.BIG_ENDIAN));
 		wrap.order(ByteOrder.BIG_ENDIAN);
 		aLong = wrap.getLong();
-		Assert.assertEquals(a, aLong);
+		Assertions.assertEquals(a, aLong);
 	}
 
 	@Test
@@ -132,12 +132,12 @@ public class ByteUtilTest {
 		ByteBuffer wrap = ByteBuffer.wrap(ByteUtil.intToBytes(a));
 		wrap.order(ByteOrder.LITTLE_ENDIAN);
 		int aInt = wrap.getInt();
-		Assert.assertEquals(a, aInt);
+		Assertions.assertEquals(a, aInt);
 
 		wrap = ByteBuffer.wrap(ByteUtil.intToBytes(a, ByteOrder.BIG_ENDIAN));
 		wrap.order(ByteOrder.BIG_ENDIAN);
 		aInt = wrap.getInt();
-		Assert.assertEquals(a, aInt);
+		Assertions.assertEquals(a, aInt);
 	}
 
 	@Test
@@ -147,11 +147,11 @@ public class ByteUtilTest {
 		ByteBuffer wrap = ByteBuffer.wrap(ByteUtil.shortToBytes(a));
 		wrap.order(ByteOrder.LITTLE_ENDIAN);
 		short aShort = wrap.getShort();
-		Assert.assertEquals(a, aShort);
+		Assertions.assertEquals(a, aShort);
 
 		wrap = ByteBuffer.wrap(ByteUtil.shortToBytes(a, ByteOrder.BIG_ENDIAN));
 		wrap.order(ByteOrder.BIG_ENDIAN);
 		aShort = wrap.getShort();
-		Assert.assertEquals(a, aShort);
+		Assertions.assertEquals(a, aShort);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/CharUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/CharUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CharUtilTest {
 
@@ -9,50 +9,50 @@ public class CharUtilTest {
 	public void trimTest() {
 		//此字符串中的第一个字符为不可见字符: '\u202a'
 		String str = "‪C:/Users/maple/Desktop/tone.txt";
-		Assert.assertEquals('\u202a', str.charAt(0));
-		Assert.assertTrue(CharUtil.isBlankChar(str.charAt(0)));
+		Assertions.assertEquals('\u202a', str.charAt(0));
+		Assertions.assertTrue(CharUtil.isBlankChar(str.charAt(0)));
 	}
 
 	@Test
 	public void isEmojiTest() {
 		String a = "莉🌹";
-		Assert.assertFalse(CharUtil.isEmoji(a.charAt(0)));
-		Assert.assertTrue(CharUtil.isEmoji(a.charAt(1)));
+		Assertions.assertFalse(CharUtil.isEmoji(a.charAt(0)));
+		Assertions.assertTrue(CharUtil.isEmoji(a.charAt(1)));
 
 	}
 
 	@Test
 	public void isCharTest(){
 		char a = 'a';
-		Assert.assertTrue(CharUtil.isChar(a));
+		Assertions.assertTrue(CharUtil.isChar(a));
 	}
 
 	@Test
 	public void isBlankCharTest(){
 		char a = '\u00A0';
-		Assert.assertTrue(CharUtil.isBlankChar(a));
+		Assertions.assertTrue(CharUtil.isBlankChar(a));
 
 		char a2 = '\u0020';
-		Assert.assertTrue(CharUtil.isBlankChar(a2));
+		Assertions.assertTrue(CharUtil.isBlankChar(a2));
 
 		char a3 = '\u3000';
-		Assert.assertTrue(CharUtil.isBlankChar(a3));
+		Assertions.assertTrue(CharUtil.isBlankChar(a3));
 
 		char a4 = '\u0000';
-		Assert.assertTrue(CharUtil.isBlankChar(a4));
+		Assertions.assertTrue(CharUtil.isBlankChar(a4));
 	}
 
 	@Test
 	public void toCloseCharTest(){
-		Assert.assertEquals('②', CharUtil.toCloseChar('2'));
-		Assert.assertEquals('Ⓜ', CharUtil.toCloseChar('M'));
-		Assert.assertEquals('ⓡ', CharUtil.toCloseChar('r'));
+		Assertions.assertEquals('②', CharUtil.toCloseChar('2'));
+		Assertions.assertEquals('Ⓜ', CharUtil.toCloseChar('M'));
+		Assertions.assertEquals('ⓡ', CharUtil.toCloseChar('r'));
 	}
 
 	@Test
 	public void toCloseByNumberTest(){
-		Assert.assertEquals('②', CharUtil.toCloseByNumber(2));
-		Assert.assertEquals('⑫', CharUtil.toCloseByNumber(12));
-		Assert.assertEquals('⑳', CharUtil.toCloseByNumber(20));
+		Assertions.assertEquals('②', CharUtil.toCloseByNumber(2));
+		Assertions.assertEquals('⑫', CharUtil.toCloseByNumber(12));
+		Assertions.assertEquals('⑳', CharUtil.toCloseByNumber(20));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ClassLoaderUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ClassLoaderUtilTest.java
@@ -1,16 +1,16 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ClassLoaderUtilTest {
-	
+
 	@Test
 	public void loadClassTest() {
 		String name = ClassLoaderUtil.loadClass("java.lang.Thread.State").getName();
-		Assert.assertEquals("java.lang.Thread$State", name);
-		
+		Assertions.assertEquals("java.lang.Thread$State", name);
+
 		name = ClassLoaderUtil.loadClass("java.lang.Thread$State").getName();
-		Assert.assertEquals("java.lang.Thread$State", name);
+		Assertions.assertEquals("java.lang.Thread$State", name);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ClassUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ClassUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -9,19 +9,19 @@ import java.util.Objects;
 
 /**
  * {@link ClassUtil} 单元测试
- * 
+ *
  * @author Looly
  *
  */
 public class ClassUtilTest {
-	
+
 	@Test
 	public void getClassNameTest() {
 		String className = ClassUtil.getClassName(ClassUtil.class, false);
-		Assert.assertEquals("cn.hutool.core.util.ClassUtil", className);
+		Assertions.assertEquals("cn.hutool.core.util.ClassUtil", className);
 
 		String simpleClassName = ClassUtil.getClassName(ClassUtil.class, true);
-		Assert.assertEquals("ClassUtil", simpleClassName);
+		Assertions.assertEquals("ClassUtil", simpleClassName);
 	}
 
 	@SuppressWarnings("unused")
@@ -39,7 +39,7 @@ public class ClassUtilTest {
 	@SuppressWarnings({"unused", "InnerClassMayBeStatic"})
 	class TestSubClass extends TestClass {
 		private String subField;
-		
+
 		private void privateSubMethod() {
 		}
 
@@ -51,62 +51,62 @@ public class ClassUtilTest {
 	@Test
 	public void getPublicMethod() {
 		Method superPublicMethod = ClassUtil.getPublicMethod(TestSubClass.class, "publicMethod");
-		Assert.assertNotNull(superPublicMethod);
+		Assertions.assertNotNull(superPublicMethod);
 		Method superPrivateMethod = ClassUtil.getPublicMethod(TestSubClass.class, "privateMethod");
-		Assert.assertNull(superPrivateMethod);
+		Assertions.assertNull(superPrivateMethod);
 
 		Method publicMethod = ClassUtil.getPublicMethod(TestSubClass.class, "publicSubMethod");
-		Assert.assertNotNull(publicMethod);
+		Assertions.assertNotNull(publicMethod);
 		Method privateMethod = ClassUtil.getPublicMethod(TestSubClass.class, "privateSubMethod");
-		Assert.assertNull(privateMethod);
+		Assertions.assertNull(privateMethod);
 	}
 
 	@Test
 	public void getDeclaredMethod() {
 		Method noMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "noMethod");
-		Assert.assertNull(noMethod);
+		Assertions.assertNull(noMethod);
 
 		Method privateMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "privateMethod");
-		Assert.assertNotNull(privateMethod);
+		Assertions.assertNotNull(privateMethod);
 		Method publicMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "publicMethod");
-		Assert.assertNotNull(publicMethod);
+		Assertions.assertNotNull(publicMethod);
 
 		Method publicSubMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "publicSubMethod");
-		Assert.assertNotNull(publicSubMethod);
+		Assertions.assertNotNull(publicSubMethod);
 		Method privateSubMethod = ClassUtil.getDeclaredMethod(TestSubClass.class, "privateSubMethod");
-		Assert.assertNotNull(privateSubMethod);
+		Assertions.assertNotNull(privateSubMethod);
 
 	}
 
 	@Test
 	public void getDeclaredField() {
 		Field noField = ClassUtil.getDeclaredField(TestSubClass.class, "noField");
-		Assert.assertNull(noField);
+		Assertions.assertNull(noField);
 
 		// 获取不到父类字段
 		Field field = ClassUtil.getDeclaredField(TestSubClass.class, "field");
-		Assert.assertNull(field);
+		Assertions.assertNull(field);
 
 		Field subField = ClassUtil.getDeclaredField(TestSubClass.class, "subField");
-		Assert.assertNotNull(subField);
+		Assertions.assertNotNull(subField);
 	}
-	
+
 	@Test
 	public void getClassPathTest() {
 		String classPath = ClassUtil.getClassPath();
-		Assert.assertNotNull(classPath);
+		Assertions.assertNotNull(classPath);
 	}
-	
+
 	@Test
 	public void getShortClassNameTest() {
 		String className = "cn.hutool.core.util.StrUtil";
 		String result = ClassUtil.getShortClassName(className);
-		Assert.assertEquals("c.h.c.u.StrUtil", result);
+		Assertions.assertEquals("c.h.c.u.StrUtil", result);
 	}
 
 	@Test
 	public void getLocationPathTest(){
 		final String classDir = ClassUtil.getLocationPath(ClassUtilTest.class);
-		Assert.assertTrue(Objects.requireNonNull(classDir).endsWith("/hutool-core/target/test-classes/"));
+		Assertions.assertTrue(Objects.requireNonNull(classDir).endsWith("/hutool-core/target/test-classes/"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/CoordinateUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/CoordinateUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 坐标转换工具类单元测试<br>
@@ -14,29 +14,29 @@ public class CoordinateUtilTest {
 	@Test
 	public void gcj02ToBd09Test() {
 		final CoordinateUtil.Coordinate gcj02 = CoordinateUtil.gcj02ToBd09(116.404, 39.915);
-		Assert.assertEquals(116.41036949371029D, gcj02.getLng(), 15);
-		Assert.assertEquals(39.92133699351021D, gcj02.getLat(), 15);
+		Assertions.assertEquals(116.41036949371029D, gcj02.getLng(), 15);
+		Assertions.assertEquals(39.92133699351021D, gcj02.getLat(), 15);
 	}
 
 	@Test
 	public void bd09toGcj02Test(){
 		final CoordinateUtil.Coordinate gcj02 = CoordinateUtil.bd09ToGcj02(116.404, 39.915);
-		Assert.assertEquals(116.39762729119315D, gcj02.getLng(), 15);
-		Assert.assertEquals(39.90865673957631D, gcj02.getLat(), 15);
+		Assertions.assertEquals(116.39762729119315D, gcj02.getLng(), 15);
+		Assertions.assertEquals(39.90865673957631D, gcj02.getLat(), 15);
 	}
 
 	@Test
 	public void gcj02ToWgs84(){
 		final CoordinateUtil.Coordinate gcj02 = CoordinateUtil.wgs84ToGcj02(116.404, 39.915);
-		Assert.assertEquals(116.39775550083061D, gcj02.getLng(), 15);
-		Assert.assertEquals(39.91359571849836D, gcj02.getLat(), 15);
+		Assertions.assertEquals(116.39775550083061D, gcj02.getLng(), 15);
+		Assertions.assertEquals(39.91359571849836D, gcj02.getLat(), 15);
 	}
 
 	@Test
 	public void wgs84ToGcj02Test(){
 		final CoordinateUtil.Coordinate gcj02 = CoordinateUtil.wgs84ToGcj02(116.404, 39.915);
-		Assert.assertEquals(116.41024449916938D, gcj02.getLng(), 15);
-		Assert.assertEquals(39.91640428150164D, gcj02.getLat(), 15);
+		Assertions.assertEquals(116.41024449916938D, gcj02.getLng(), 15);
+		Assertions.assertEquals(39.91640428150164D, gcj02.getLat(), 15);
 	}
 
 	@Test

--- a/hutool-core/src/test/java/cn/hutool/core/util/CreditCodeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/CreditCodeUtilTest.java
@@ -1,25 +1,25 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CreditCodeUtilTest {
 
 	@Test
 	public void isCreditCodeBySimple() {
 		String testCreditCode = "91310115591693856A";
-		Assert.assertTrue(CreditCodeUtil.isCreditCodeSimple(testCreditCode));
+		Assertions.assertTrue(CreditCodeUtil.isCreditCodeSimple(testCreditCode));
 	}
 
 	@Test
 	public void isCreditCode() {
 		String testCreditCode = "91310110666007217T";
-		Assert.assertTrue(CreditCodeUtil.isCreditCode(testCreditCode));
+		Assertions.assertTrue(CreditCodeUtil.isCreditCode(testCreditCode));
 	}
 
 	@Test
 	public void randomCreditCode() {
 		final String s = CreditCodeUtil.randomCreditCode();
-		Assert.assertTrue(CreditCodeUtil.isCreditCode(s));
+		Assertions.assertTrue(CreditCodeUtil.isCreditCode(s));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/DesensitizedUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/DesensitizedUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 脱敏工具类 DesensitizedUtils 安全测试
@@ -13,78 +13,78 @@ public class DesensitizedUtilTest {
 
 	@Test
 	public void desensitizedTest() {
-		Assert.assertEquals("0", DesensitizedUtil.desensitized("100", DesensitizedUtil.DesensitizedType.USER_ID));
-		Assert.assertEquals("段**", DesensitizedUtil.desensitized("段正淳", DesensitizedUtil.DesensitizedType.CHINESE_NAME));
-		Assert.assertEquals("5***************1X", DesensitizedUtil.desensitized("51343620000320711X", DesensitizedUtil.DesensitizedType.ID_CARD));
-		Assert.assertEquals("0915*****79", DesensitizedUtil.desensitized("09157518479", DesensitizedUtil.DesensitizedType.FIXED_PHONE));
-		Assert.assertEquals("180****1999", DesensitizedUtil.desensitized("18049531999", DesensitizedUtil.DesensitizedType.MOBILE_PHONE));
-		Assert.assertEquals("北京市海淀区马********", DesensitizedUtil.desensitized("北京市海淀区马连洼街道289号", DesensitizedUtil.DesensitizedType.ADDRESS));
-		Assert.assertEquals("d*************@gmail.com.cn", DesensitizedUtil.desensitized("duandazhi-jack@gmail.com.cn", DesensitizedUtil.DesensitizedType.EMAIL));
-		Assert.assertEquals("**********", DesensitizedUtil.desensitized("1234567890", DesensitizedUtil.DesensitizedType.PASSWORD));
+		Assertions.assertEquals("0", DesensitizedUtil.desensitized("100", DesensitizedUtil.DesensitizedType.USER_ID));
+		Assertions.assertEquals("段**", DesensitizedUtil.desensitized("段正淳", DesensitizedUtil.DesensitizedType.CHINESE_NAME));
+		Assertions.assertEquals("5***************1X", DesensitizedUtil.desensitized("51343620000320711X", DesensitizedUtil.DesensitizedType.ID_CARD));
+		Assertions.assertEquals("0915*****79", DesensitizedUtil.desensitized("09157518479", DesensitizedUtil.DesensitizedType.FIXED_PHONE));
+		Assertions.assertEquals("180****1999", DesensitizedUtil.desensitized("18049531999", DesensitizedUtil.DesensitizedType.MOBILE_PHONE));
+		Assertions.assertEquals("北京市海淀区马********", DesensitizedUtil.desensitized("北京市海淀区马连洼街道289号", DesensitizedUtil.DesensitizedType.ADDRESS));
+		Assertions.assertEquals("d*************@gmail.com.cn", DesensitizedUtil.desensitized("duandazhi-jack@gmail.com.cn", DesensitizedUtil.DesensitizedType.EMAIL));
+		Assertions.assertEquals("**********", DesensitizedUtil.desensitized("1234567890", DesensitizedUtil.DesensitizedType.PASSWORD));
 
-		Assert.assertEquals("0", DesensitizedUtil.desensitized("100", DesensitizedUtil.DesensitizedType.USER_ID));
-		Assert.assertEquals("段**", DesensitizedUtil.desensitized("段正淳", DesensitizedUtil.DesensitizedType.CHINESE_NAME));
-		Assert.assertEquals("5***************1X", DesensitizedUtil.desensitized("51343620000320711X", DesensitizedUtil.DesensitizedType.ID_CARD));
-		Assert.assertEquals("0915*****79", DesensitizedUtil.desensitized("09157518479", DesensitizedUtil.DesensitizedType.FIXED_PHONE));
-		Assert.assertEquals("180****1999", DesensitizedUtil.desensitized("18049531999", DesensitizedUtil.DesensitizedType.MOBILE_PHONE));
-		Assert.assertEquals("北京市海淀区马********", DesensitizedUtil.desensitized("北京市海淀区马连洼街道289号", DesensitizedUtil.DesensitizedType.ADDRESS));
-		Assert.assertEquals("d*************@gmail.com.cn", DesensitizedUtil.desensitized("duandazhi-jack@gmail.com.cn", DesensitizedUtil.DesensitizedType.EMAIL));
-		Assert.assertEquals("**********", DesensitizedUtil.desensitized("1234567890", DesensitizedUtil.DesensitizedType.PASSWORD));
-		Assert.assertEquals("1101 **** **** **** 3256", DesensitizedUtil.desensitized("11011111222233333256", DesensitizedUtil.DesensitizedType.BANK_CARD));
-		Assert.assertEquals("6227 **** **** *** 5123", DesensitizedUtil.desensitized("6227880100100105123", DesensitizedUtil.DesensitizedType.BANK_CARD));
+		Assertions.assertEquals("0", DesensitizedUtil.desensitized("100", DesensitizedUtil.DesensitizedType.USER_ID));
+		Assertions.assertEquals("段**", DesensitizedUtil.desensitized("段正淳", DesensitizedUtil.DesensitizedType.CHINESE_NAME));
+		Assertions.assertEquals("5***************1X", DesensitizedUtil.desensitized("51343620000320711X", DesensitizedUtil.DesensitizedType.ID_CARD));
+		Assertions.assertEquals("0915*****79", DesensitizedUtil.desensitized("09157518479", DesensitizedUtil.DesensitizedType.FIXED_PHONE));
+		Assertions.assertEquals("180****1999", DesensitizedUtil.desensitized("18049531999", DesensitizedUtil.DesensitizedType.MOBILE_PHONE));
+		Assertions.assertEquals("北京市海淀区马********", DesensitizedUtil.desensitized("北京市海淀区马连洼街道289号", DesensitizedUtil.DesensitizedType.ADDRESS));
+		Assertions.assertEquals("d*************@gmail.com.cn", DesensitizedUtil.desensitized("duandazhi-jack@gmail.com.cn", DesensitizedUtil.DesensitizedType.EMAIL));
+		Assertions.assertEquals("**********", DesensitizedUtil.desensitized("1234567890", DesensitizedUtil.DesensitizedType.PASSWORD));
+		Assertions.assertEquals("1101 **** **** **** 3256", DesensitizedUtil.desensitized("11011111222233333256", DesensitizedUtil.DesensitizedType.BANK_CARD));
+		Assertions.assertEquals("6227 **** **** *** 5123", DesensitizedUtil.desensitized("6227880100100105123", DesensitizedUtil.DesensitizedType.BANK_CARD));
 	}
 
 	@Test
 	public void userIdTest() {
-		Assert.assertEquals(Long.valueOf(0L), DesensitizedUtil.userId());
+		Assertions.assertEquals(Long.valueOf(0L), DesensitizedUtil.userId());
 	}
 
 	@Test
 	public void chineseNameTest() {
-		Assert.assertEquals("段**", DesensitizedUtil.chineseName("段正淳"));
+		Assertions.assertEquals("段**", DesensitizedUtil.chineseName("段正淳"));
 	}
 
 	@Test
 	public void idCardNumTest() {
-		Assert.assertEquals("5***************1X", DesensitizedUtil.idCardNum("51343620000320711X", 1, 2));
+		Assertions.assertEquals("5***************1X", DesensitizedUtil.idCardNum("51343620000320711X", 1, 2));
 	}
 
 	@Test
 	public void fixedPhoneTest() {
-		Assert.assertEquals("0915*****79", DesensitizedUtil.fixedPhone("09157518479"));
+		Assertions.assertEquals("0915*****79", DesensitizedUtil.fixedPhone("09157518479"));
 	}
 
 	@Test
 	public void mobilePhoneTest() {
-		Assert.assertEquals("180****1999", DesensitizedUtil.mobilePhone("18049531999"));
+		Assertions.assertEquals("180****1999", DesensitizedUtil.mobilePhone("18049531999"));
 	}
 
 	@Test
 	public void addressTest() {
-		Assert.assertEquals("北京市海淀区马连洼街*****", DesensitizedUtil.address("北京市海淀区马连洼街道289号", 5));
-		Assert.assertEquals("***************", DesensitizedUtil.address("北京市海淀区马连洼街道289号", 50));
-		Assert.assertEquals("北京市海淀区马连洼街道289号", DesensitizedUtil.address("北京市海淀区马连洼街道289号", 0));
-		Assert.assertEquals("北京市海淀区马连洼街道289号", DesensitizedUtil.address("北京市海淀区马连洼街道289号", -1));
+		Assertions.assertEquals("北京市海淀区马连洼街*****", DesensitizedUtil.address("北京市海淀区马连洼街道289号", 5));
+		Assertions.assertEquals("***************", DesensitizedUtil.address("北京市海淀区马连洼街道289号", 50));
+		Assertions.assertEquals("北京市海淀区马连洼街道289号", DesensitizedUtil.address("北京市海淀区马连洼街道289号", 0));
+		Assertions.assertEquals("北京市海淀区马连洼街道289号", DesensitizedUtil.address("北京市海淀区马连洼街道289号", -1));
 	}
 
 	@Test
 	public void emailTest() {
-		Assert.assertEquals("d********@126.com", DesensitizedUtil.email("duandazhi@126.com"));
-		Assert.assertEquals("d********@gmail.com.cn", DesensitizedUtil.email("duandazhi@gmail.com.cn"));
-		Assert.assertEquals("d*************@gmail.com.cn", DesensitizedUtil.email("duandazhi-jack@gmail.com.cn"));
+		Assertions.assertEquals("d********@126.com", DesensitizedUtil.email("duandazhi@126.com"));
+		Assertions.assertEquals("d********@gmail.com.cn", DesensitizedUtil.email("duandazhi@gmail.com.cn"));
+		Assertions.assertEquals("d*************@gmail.com.cn", DesensitizedUtil.email("duandazhi-jack@gmail.com.cn"));
 	}
 
 	@Test
 	public void passwordTest() {
-		Assert.assertEquals("**********", DesensitizedUtil.password("1234567890"));
+		Assertions.assertEquals("**********", DesensitizedUtil.password("1234567890"));
 	}
 
 	@Test
 	public void carLicenseTest() {
-		Assert.assertEquals("", DesensitizedUtil.carLicense(null));
-		Assert.assertEquals("", DesensitizedUtil.carLicense(""));
-		Assert.assertEquals("苏D4***0", DesensitizedUtil.carLicense("苏D40000"));
-		Assert.assertEquals("陕A1****D", DesensitizedUtil.carLicense("陕A12345D"));
-		Assert.assertEquals("京A123", DesensitizedUtil.carLicense("京A123"));
+		Assertions.assertEquals("", DesensitizedUtil.carLicense(null));
+		Assertions.assertEquals("", DesensitizedUtil.carLicense(""));
+		Assertions.assertEquals("苏D4***0", DesensitizedUtil.carLicense("苏D40000"));
+		Assertions.assertEquals("陕A1****D", DesensitizedUtil.carLicense("陕A12345D"));
+		Assertions.assertEquals("京A123", DesensitizedUtil.carLicense("京A123"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
@@ -1,15 +1,15 @@
 package cn.hutool.core.util;
 
 import cn.hutool.core.collection.CollUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
 /**
  * EnumUtil单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -18,41 +18,41 @@ public class EnumUtilTest {
 	@Test
 	public void getNamesTest() {
 		List<String> names = EnumUtil.getNames(TestEnum.class);
-		Assert.assertEquals(CollUtil.newArrayList("TEST1", "TEST2", "TEST3"), names);
+		Assertions.assertEquals(CollUtil.newArrayList("TEST1", "TEST2", "TEST3"), names);
 	}
-	
+
 	@Test
 	public void getFieldValuesTest() {
 		List<Object> types = EnumUtil.getFieldValues(TestEnum.class, "type");
-		Assert.assertEquals(CollUtil.newArrayList("type1", "type2", "type3"), types);
+		Assertions.assertEquals(CollUtil.newArrayList("type1", "type2", "type3"), types);
 	}
-	
+
 	@Test
 	public void getFieldNamesTest() {
 		List<String> names = EnumUtil.getFieldNames(TestEnum.class);
-		Assert.assertTrue(names.contains("type"));
-		Assert.assertTrue(names.contains("name"));
+		Assertions.assertTrue(names.contains("type"));
+		Assertions.assertTrue(names.contains("name"));
 	}
-	
+
 	@Test
 	public void likeValueOfTest() {
 		TestEnum value = EnumUtil.likeValueOf(TestEnum.class, "type2");
-		Assert.assertEquals(TestEnum.TEST2, value);
+		Assertions.assertEquals(TestEnum.TEST2, value);
 	}
-	
+
 	@Test
 	public void getEnumMapTest() {
 		Map<String,TestEnum> enumMap = EnumUtil.getEnumMap(TestEnum.class);
-		Assert.assertEquals(TestEnum.TEST1, enumMap.get("TEST1"));
+		Assertions.assertEquals(TestEnum.TEST1, enumMap.get("TEST1"));
 	}
-	
+
 	@Test
 	public void getNameFieldMapTest() {
 		Map<String, Object> enumMap = EnumUtil.getNameFieldMap(TestEnum.class, "type");
 		assert enumMap != null;
-		Assert.assertEquals("type1", enumMap.get("TEST1"));
+		Assertions.assertEquals("type1", enumMap.get("TEST1"));
 	}
-	
+
 	public enum TestEnum{
 		TEST1("type1"), TEST2("type2"), TEST3("type3");
 
@@ -62,11 +62,11 @@ public class EnumUtilTest {
 
 		private final String type;
 		private String name;
-		
+
 		public String getType() {
 			return this.type;
 		}
-		
+
 		public String getName() {
 			return this.name;
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/util/EscapeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/EscapeUtilTest.java
@@ -1,30 +1,30 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EscapeUtilTest {
 
 	@Test
 	public void escapeHtml4Test() {
 		String escapeHtml4 = EscapeUtil.escapeHtml4("<a>你好</a>");
-		Assert.assertEquals("&lt;a&gt;你好&lt;/a&gt;", escapeHtml4);
+		Assertions.assertEquals("&lt;a&gt;你好&lt;/a&gt;", escapeHtml4);
 
 		String result = EscapeUtil.unescapeHtml4("&#25391;&#33633;&#22120;&#31867;&#22411;");
-		Assert.assertEquals("振荡器类型", result);
+		Assertions.assertEquals("振荡器类型", result);
 
 		String escape = EscapeUtil.escapeHtml4("*@-_+./(123你好)");
-		Assert.assertEquals("*@-_+./(123你好)", escape);
+		Assertions.assertEquals("*@-_+./(123你好)", escape);
 	}
 
 	@Test
 	public void escapeTest(){
 		String str = "*@-_+./(123你好)ABCabc";
 		String escape = EscapeUtil.escape(str);
-		Assert.assertEquals("*@-_+./%28123%u4f60%u597d%29ABCabc", escape);
+		Assertions.assertEquals("*@-_+./%28123%u4f60%u597d%29ABCabc", escape);
 
 		String unescape = EscapeUtil.unescape(escape);
-		Assert.assertEquals(str, unescape);
+		Assertions.assertEquals(str, unescape);
 	}
 
 	@Test
@@ -32,10 +32,10 @@ public class EscapeUtilTest {
 		String str = "*@-_+./(123你好)ABCabc";
 
 		String escape = EscapeUtil.escapeAll(str);
-		Assert.assertEquals("%2a%40%2d%5f%2b%2e%2f%28%31%32%33%u4f60%u597d%29%41%42%43%61%62%63", escape);
+		Assertions.assertEquals("%2a%40%2d%5f%2b%2e%2f%28%31%32%33%u4f60%u597d%29%41%42%43%61%62%63", escape);
 
 		String unescape = EscapeUtil.unescape(escape);
-		Assert.assertEquals(str, unescape);
+		Assertions.assertEquals(str, unescape);
 	}
 
 	/**
@@ -46,10 +46,10 @@ public class EscapeUtilTest {
 		String str = "٩";
 
 		String escape = EscapeUtil.escapeAll(str);
-		Assert.assertEquals("%u0669", escape);
+		Assertions.assertEquals("%u0669", escape);
 
 		String unescape = EscapeUtil.unescape(escape);
-		Assert.assertEquals(str, unescape);
+		Assertions.assertEquals(str, unescape);
 	}
 
 	@Test
@@ -57,13 +57,13 @@ public class EscapeUtilTest {
 		// 单引号不做转义
 		String str = "'some text with single quotes'";
 		final String s = EscapeUtil.escapeHtml4(str);
-		Assert.assertEquals("'some text with single quotes'", s);
+		Assertions.assertEquals("'some text with single quotes'", s);
 	}
 
 	@Test
 	public void unescapeSingleQuotesTest(){
 		String str = "&apos;some text with single quotes&apos;";
 		final String s = EscapeUtil.unescapeHtml4(str);
-		Assert.assertEquals("'some text with single quotes'", s);
+		Assertions.assertEquals("'some text with single quotes'", s);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/HashUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/HashUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HashUtilTest {
 
@@ -9,21 +9,21 @@ public class HashUtilTest {
 	public void cityHash128Test(){
 		String s="Google发布的Hash计算算法：CityHash64 与 CityHash128";
 		final long[] hash = HashUtil.cityHash128(StrUtil.utf8Bytes(s));
-		Assert.assertEquals(0x5944f1e788a18db0L, hash[0]);
-		Assert.assertEquals(0xc2f68d8b2bf4a5cfL, hash[1]);
+		Assertions.assertEquals(0x5944f1e788a18db0L, hash[0]);
+		Assertions.assertEquals(0xc2f68d8b2bf4a5cfL, hash[1]);
 	}
 
 	@Test
 	public void cityHash64Test(){
 		String s="Google发布的Hash计算算法：CityHash64 与 CityHash128";
 		final long hash = HashUtil.cityHash64(StrUtil.utf8Bytes(s));
-		Assert.assertEquals(0x1d408f2bbf967e2aL, hash);
+		Assertions.assertEquals(0x1d408f2bbf967e2aL, hash);
 	}
 
 	@Test
 	public void cityHash32Test(){
 		String s="Google发布的Hash计算算法：CityHash64 与 CityHash128";
 		final int hash = HashUtil.cityHash32(StrUtil.utf8Bytes(s));
-		Assert.assertEquals(0xa8944fbe, hash);
+		Assertions.assertEquals(0xa8944fbe, hash);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/HexUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/HexUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * HexUtil单元测试
@@ -17,29 +17,29 @@ public class HexUtilTest {
 		String hex = HexUtil.encodeHexStr(str, CharsetUtil.CHARSET_UTF_8);
 		String decodedStr = HexUtil.decodeHexStr(hex);
 
-		Assert.assertEquals(str, decodedStr);
+		Assertions.assertEquals(str, decodedStr);
 	}
 
 	@Test
 	public void toUnicodeHexTest() {
 		String unicodeHex = HexUtil.toUnicodeHex('\u2001');
-		Assert.assertEquals("\\u2001", unicodeHex);
+		Assertions.assertEquals("\\u2001", unicodeHex);
 
 		unicodeHex = HexUtil.toUnicodeHex('你');
-		Assert.assertEquals("\\u4f60", unicodeHex);
+		Assertions.assertEquals("\\u4f60", unicodeHex);
 	}
 
 	@Test
 	public void isHexNumberTest() {
 		String a = "0x3544534F444";
 		boolean isHex = HexUtil.isHexNumber(a);
-		Assert.assertTrue(isHex);
+		Assertions.assertTrue(isHex);
 	}
 
 	@Test
 	public void decodeTest(){
 		String str = "e8c670380cb220095268f40221fc748fa6ac39d6e930e63c30da68bad97f885d";
-		Assert.assertArrayEquals(HexUtil.decodeHex(str),
+		Assertions.assertArrayEquals(HexUtil.decodeHex(str),
 				HexUtil.decodeHex(str.toUpperCase()));
 	}
 
@@ -47,13 +47,13 @@ public class HexUtilTest {
 	public void formatHexTest(){
 		String hex = "e8c670380cb220095268f40221fc748fa6ac39d6e930e63c30da68bad97f885d";
 		String formatHex = HexUtil.format(hex);
-		Assert.assertEquals("e8 c6 70 38 0c b2 20 09 52 68 f4 02 21 fc 74 8f a6 ac 39 d6 e9 30 e6 3c 30 da 68 ba d9 7f 88 5d", formatHex);
+		Assertions.assertEquals("e8 c6 70 38 0c b2 20 09 52 68 f4 02 21 fc 74 8f a6 ac 39 d6 e9 30 e6 3c 30 da 68 ba d9 7f 88 5d", formatHex);
 	}
 
 	@Test
 	public void decodeHexTest(){
 		String s = HexUtil.encodeHexStr("6");
 		final String s1 = HexUtil.decodeHexStr(s);
-		Assert.assertEquals("6", s1);
+		Assertions.assertEquals("6", s1);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/IdUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/IdUtilTest.java
@@ -7,9 +7,9 @@ import cn.hutool.core.exceptions.UtilException;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.lang.Snowflake;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.UUID;
@@ -26,26 +26,26 @@ public class IdUtilTest {
 	@Test
 	public void randomUUIDTest() {
 		String simpleUUID = IdUtil.simpleUUID();
-		Assert.assertEquals(32, simpleUUID.length());
+		Assertions.assertEquals(32, simpleUUID.length());
 
 		String randomUUID = IdUtil.randomUUID();
-		Assert.assertEquals(36, randomUUID.length());
+		Assertions.assertEquals(36, randomUUID.length());
 	}
 
 	@Test
 	public void fastUUIDTest() {
 		String simpleUUID = IdUtil.fastSimpleUUID();
-		Assert.assertEquals(32, simpleUUID.length());
+		Assertions.assertEquals(32, simpleUUID.length());
 
 		String randomUUID = IdUtil.fastUUID();
-		Assert.assertEquals(36, randomUUID.length());
+		Assertions.assertEquals(36, randomUUID.length());
 	}
 
 	/**
 	 * UUID的性能测试
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void benchTest() {
 		TimeInterval timer = DateUtil.timer();
 		for (int i = 0; i < 1000000; i++) {
@@ -64,18 +64,18 @@ public class IdUtilTest {
 	@Test
 	public void objectIdTest() {
 		String id = IdUtil.objectId();
-		Assert.assertEquals(24, id.length());
+		Assertions.assertEquals(24, id.length());
 	}
 
 	@Test
 	public void getSnowflakeTest() {
 		Snowflake snowflake = IdUtil.getSnowflake(1, 1);
 		long id = snowflake.nextId();
-		Assert.assertTrue(id > 0);
+		Assertions.assertTrue(id > 0);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void snowflakeBenchTest() {
 		final Set<Long> set = new ConcurrentHashSet<>();
 		final Snowflake snowflake = IdUtil.getSnowflake(1, 1);
@@ -102,11 +102,11 @@ public class IdUtilTest {
 		} catch (InterruptedException e) {
 			throw new UtilException(e);
 		}
-		Assert.assertEquals(threadCount * idCountPerThread, set.size());
+		Assertions.assertEquals(threadCount * idCountPerThread, set.size());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void snowflakeBenchTest2() {
 		final Set<Long> set = new ConcurrentHashSet<>();
 
@@ -132,12 +132,12 @@ public class IdUtilTest {
 		} catch (InterruptedException e) {
 			throw new UtilException(e);
 		}
-		Assert.assertEquals(threadCount * idCountPerThread, set.size());
+		Assertions.assertEquals(threadCount * idCountPerThread, set.size());
 	}
 
 	@Test
 	public void getDataCenterIdTest(){
 		final long dataCenterId = IdUtil.getDataCenterId(Long.MAX_VALUE);
-		Assert.assertTrue(dataCenterId > 1);
+		Assertions.assertTrue(dataCenterId > 1);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/IdcardUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/IdcardUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.util;
 
 import cn.hutool.core.date.DateTime;
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 身份证单元测试
@@ -19,31 +19,31 @@ public class IdcardUtilTest {
 	@Test
 	public void isValidCardTest() {
 		boolean valid = IdcardUtil.isValidCard(ID_18);
-		Assert.assertTrue(valid);
+		Assertions.assertTrue(valid);
 
 		boolean valid15 = IdcardUtil.isValidCard(ID_15);
-		Assert.assertTrue(valid15);
+		Assertions.assertTrue(valid15);
 
 		// 无效
 		String idCard = "360198910283844";
-		Assert.assertFalse(IdcardUtil.isValidCard(idCard));
+		Assertions.assertFalse(IdcardUtil.isValidCard(idCard));
 
 		// 生日无效
 		idCard = "201511221897205960";
-		Assert.assertFalse(IdcardUtil.isValidCard(idCard));
+		Assertions.assertFalse(IdcardUtil.isValidCard(idCard));
 
 		// 生日无效
 		idCard = "815727834224151";
-		Assert.assertFalse(IdcardUtil.isValidCard(idCard));
+		Assertions.assertFalse(IdcardUtil.isValidCard(idCard));
 	}
 
 	@Test
 	public void convert15To18Test() {
 		String convert15To18 = IdcardUtil.convert15To18(ID_15);
-		Assert.assertEquals("150102198807303035", convert15To18);
+		Assertions.assertEquals("150102198807303035", convert15To18);
 
 		String convert15To18Second = IdcardUtil.convert15To18("330102200403064");
-		Assert.assertEquals("33010219200403064X", convert15To18Second);
+		Assertions.assertEquals("33010219200403064X", convert15To18Second);
 	}
 
 	@Test
@@ -51,89 +51,89 @@ public class IdcardUtilTest {
 		DateTime date = DateUtil.parse("2017-04-10");
 
 		int age = IdcardUtil.getAgeByIdCard(ID_18, date);
-		Assert.assertEquals(age, 38);
+		Assertions.assertEquals(age, 38);
 
 		int age2 = IdcardUtil.getAgeByIdCard(ID_15, date);
-		Assert.assertEquals(age2, 28);
+		Assertions.assertEquals(age2, 28);
 	}
 
 	@Test
 	public void getBirthByIdCardTest() {
 		String birth = IdcardUtil.getBirthByIdCard(ID_18);
-		Assert.assertEquals(birth, "19781216");
+		Assertions.assertEquals(birth, "19781216");
 
 		String birth2 = IdcardUtil.getBirthByIdCard(ID_15);
-		Assert.assertEquals(birth2, "19880730");
+		Assertions.assertEquals(birth2, "19880730");
 	}
 
 	@Test
 	public void getProvinceByIdCardTest() {
 		String province = IdcardUtil.getProvinceByIdCard(ID_18);
-		Assert.assertEquals(province, "江苏");
+		Assertions.assertEquals(province, "江苏");
 
 		String province2 = IdcardUtil.getProvinceByIdCard(ID_15);
-		Assert.assertEquals(province2, "内蒙古");
+		Assertions.assertEquals(province2, "内蒙古");
 	}
 
 	@Test
 	public void getCityCodeByIdCardTest() {
 		String codeByIdCard = IdcardUtil.getCityCodeByIdCard(ID_18);
-		Assert.assertEquals("32108", codeByIdCard);
+		Assertions.assertEquals("32108", codeByIdCard);
 	}
 
 	@Test
 	public void getGenderByIdCardTest() {
 		int gender = IdcardUtil.getGenderByIdCard(ID_18);
-		Assert.assertEquals(1, gender);
+		Assertions.assertEquals(1, gender);
 	}
 
 	@Test
 	public void isValidCard18Test(){
 		boolean isValidCard18 = IdcardUtil.isValidCard18("3301022011022000D6");
-		Assert.assertFalse(isValidCard18);
+		Assertions.assertFalse(isValidCard18);
 
 		// 不忽略大小写情况下，X严格校验必须大写
 		isValidCard18 = IdcardUtil.isValidCard18("33010219200403064x", false);
-		Assert.assertFalse(isValidCard18);
+		Assertions.assertFalse(isValidCard18);
 		isValidCard18 = IdcardUtil.isValidCard18("33010219200403064X", false);
-		Assert.assertTrue(isValidCard18);
+		Assertions.assertTrue(isValidCard18);
 
 		// 非严格校验下大小写皆可
 		isValidCard18 = IdcardUtil.isValidCard18("33010219200403064x");
-		Assert.assertTrue(isValidCard18);
+		Assertions.assertTrue(isValidCard18);
 		isValidCard18 = IdcardUtil.isValidCard18("33010219200403064X");
-		Assert.assertTrue(isValidCard18);
+		Assertions.assertTrue(isValidCard18);
 
 		// 香港人在大陆身份证
 		isValidCard18 = IdcardUtil.isValidCard18("81000019980902013X");
-		Assert.assertTrue(isValidCard18);
+		Assertions.assertTrue(isValidCard18);
 
 		// 澳门人在大陆身份证
 		isValidCard18 = IdcardUtil.isValidCard18("820000200009100032");
-		Assert.assertTrue(isValidCard18);
+		Assertions.assertTrue(isValidCard18);
 
 		// 台湾人在大陆身份证
 		isValidCard18 = IdcardUtil.isValidCard18("830000200209060065");
-		Assert.assertTrue(isValidCard18);
+		Assertions.assertTrue(isValidCard18);
 	}
 
 	@Test
 	public void isValidHKCardIdTest(){
 		String hkCard="P174468(6)";
 		boolean flag=IdcardUtil.isValidHKCard(hkCard);
-		Assert.assertTrue(flag);
+		Assertions.assertTrue(flag);
 	}
 
 	@Test
 	public void isValidTWCardIdTest() {
 		String twCard = "B221690311";
 		boolean flag = IdcardUtil.isValidTWCard(twCard);
-		Assert.assertTrue(flag);
+		Assertions.assertTrue(flag);
 		String errTwCard1 = "M517086311";
 		flag = IdcardUtil.isValidTWCard(errTwCard1);
-		Assert.assertFalse(flag);
+		Assertions.assertFalse(flag);
 		String errTwCard2 = "B2216903112";
 		flag = IdcardUtil.isValidTWCard(errTwCard2);
-		Assert.assertFalse(flag);
+		Assertions.assertFalse(flag);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/JAXBUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/JAXBUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.bind.annotation.*;
 
@@ -34,18 +34,18 @@ public class JAXBUtilTest {
 		roomVo.setRoomNo("101");
 		schoolVo.setRoom(roomVo);
 
-		Assert.assertEquals(xmlStr, JAXBUtil.beanToXml(schoolVo));
+		Assertions.assertEquals(xmlStr, JAXBUtil.beanToXml(schoolVo));
 	}
 
 	@Test
 	public void xmlToBeanTest() {
 		final SchoolVo schoolVo = JAXBUtil.xmlToBean(xmlStr, SchoolVo.class);
-		Assert.assertNotNull(schoolVo);
-		Assert.assertEquals("西安市第一中学", schoolVo.getSchoolName());
-		Assert.assertEquals("西安市雁塔区长安堡一号", schoolVo.getSchoolAddress());
+		Assertions.assertNotNull(schoolVo);
+		Assertions.assertEquals("西安市第一中学", schoolVo.getSchoolName());
+		Assertions.assertEquals("西安市雁塔区长安堡一号", schoolVo.getSchoolAddress());
 
-		Assert.assertEquals("101教室", schoolVo.getRoom().getRoomName());
-		Assert.assertEquals("101", schoolVo.getRoom().getRoomNo());
+		Assertions.assertEquals("101教室", schoolVo.getRoom().getRoomName());
+		Assertions.assertEquals("101", schoolVo.getRoom().getRoomNo());
 	}
 
 	@XmlRootElement(name = "school")

--- a/hutool-core/src/test/java/cn/hutool/core/util/JNDIUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/JNDIUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.util;
 
 import cn.hutool.core.collection.EnumerationIter;
 import cn.hutool.core.lang.Console;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
@@ -12,7 +12,7 @@ import javax.naming.directory.Attributes;
 public class JNDIUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getDnsTest() throws NamingException {
 		final Attributes attributes = JNDIUtil.getAttributes("dns:paypal.com", "TXT");
 		for (Attribute attribute: new EnumerationIter<>(attributes.getAll())){

--- a/hutool-core/src/test/java/cn/hutool/core/util/ModifierUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ModifierUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 
@@ -10,8 +10,8 @@ public class ModifierUtilTest {
 	@Test
 	public void hasModifierTest() throws NoSuchMethodException {
 		Method method = ModifierUtilTest.class.getDeclaredMethod("ddd");
-		Assert.assertTrue(ModifierUtil.hasModifier(method, ModifierUtil.ModifierType.PRIVATE));
-		Assert.assertTrue(ModifierUtil.hasModifier(method,
+		Assertions.assertTrue(ModifierUtil.hasModifier(method, ModifierUtil.ModifierType.PRIVATE));
+		Assertions.assertTrue(ModifierUtil.hasModifier(method,
 				ModifierUtil.ModifierType.PRIVATE,
 				ModifierUtil.ModifierType.STATIC)
 		);

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -2,12 +2,14 @@ package cn.hutool.core.util;
 
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Test;
+import cn.hutool.core.lang.id.NanoId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.security.SecureRandom;
 import java.util.Set;
 
 /**
@@ -23,7 +25,7 @@ public class NumberUtilTest {
 		Float a = 3.15f;
 		Double b = 4.22;
 		double result = NumberUtil.add(a, b).doubleValue();
-		Assert.assertEquals(7.37, result, 2);
+		Assertions.assertEquals(7.37, result, 2);
 	}
 
 	@Test
@@ -31,7 +33,7 @@ public class NumberUtilTest {
 		double a = 3.15f;
 		double b = 4.22;
 		double result = NumberUtil.add(a, b);
-		Assert.assertEquals(7.37, result, 2);
+		Assertions.assertEquals(7.37, result, 2);
 	}
 
 	@Test
@@ -39,58 +41,58 @@ public class NumberUtilTest {
 		float a = 3.15f;
 		double b = 4.22;
 		double result = NumberUtil.add(a, b, a, b).doubleValue();
-		Assert.assertEquals(14.74, result, 2);
+		Assertions.assertEquals(14.74, result, 2);
 	}
 
 	@Test
 	public void addTest4() {
 		BigDecimal result = NumberUtil.add(new BigDecimal("133"), new BigDecimal("331"));
-		Assert.assertEquals(new BigDecimal("464"), result);
+		Assertions.assertEquals(new BigDecimal("464"), result);
 	}
 
 	@Test
 	public void addBlankTest(){
 		BigDecimal result = NumberUtil.add("123", " ");
-		Assert.assertEquals(new BigDecimal("123"), result);
+		Assertions.assertEquals(new BigDecimal("123"), result);
 	}
 
 	@Test
 	public void isIntegerTest() {
-		Assert.assertTrue(NumberUtil.isInteger("-12"));
-		Assert.assertTrue(NumberUtil.isInteger("256"));
-		Assert.assertTrue(NumberUtil.isInteger("0256"));
-		Assert.assertTrue(NumberUtil.isInteger("0"));
-		Assert.assertFalse(NumberUtil.isInteger("23.4"));
+		Assertions.assertTrue(NumberUtil.isInteger("-12"));
+		Assertions.assertTrue(NumberUtil.isInteger("256"));
+		Assertions.assertTrue(NumberUtil.isInteger("0256"));
+		Assertions.assertTrue(NumberUtil.isInteger("0"));
+		Assertions.assertFalse(NumberUtil.isInteger("23.4"));
 	}
 
 	@Test
 	public void isLongTest() {
-		Assert.assertTrue(NumberUtil.isLong("-12"));
-		Assert.assertTrue(NumberUtil.isLong("256"));
-		Assert.assertTrue(NumberUtil.isLong("0256"));
-		Assert.assertTrue(NumberUtil.isLong("0"));
-		Assert.assertFalse(NumberUtil.isLong("23.4"));
+		Assertions.assertTrue(NumberUtil.isLong("-12"));
+		Assertions.assertTrue(NumberUtil.isLong("256"));
+		Assertions.assertTrue(NumberUtil.isLong("0256"));
+		Assertions.assertTrue(NumberUtil.isLong("0"));
+		Assertions.assertFalse(NumberUtil.isLong("23.4"));
 	}
 
 	@Test
 	public void isNumberTest() {
-		Assert.assertTrue(NumberUtil.isNumber("28.55"));
-		Assert.assertTrue(NumberUtil.isNumber("0"));
-		Assert.assertTrue(NumberUtil.isNumber("+100.10"));
-		Assert.assertTrue(NumberUtil.isNumber("-22.022"));
-		Assert.assertTrue(NumberUtil.isNumber("0X22"));
+		Assertions.assertTrue(NumberUtil.isNumber("28.55"));
+		Assertions.assertTrue(NumberUtil.isNumber("0"));
+		Assertions.assertTrue(NumberUtil.isNumber("+100.10"));
+		Assertions.assertTrue(NumberUtil.isNumber("-22.022"));
+		Assertions.assertTrue(NumberUtil.isNumber("0X22"));
 	}
 
 	@Test
 	public void divTest() {
 		double result = NumberUtil.div(0, 1);
-		Assert.assertEquals(0.0, result, 0);
+		Assertions.assertEquals(0.0, result, 0);
 	}
 
 	@Test
 	public void divBigDecimalTest() {
 		BigDecimal result = NumberUtil.div(BigDecimal.ZERO, BigDecimal.ONE);
-		Assert.assertEquals(BigDecimal.ZERO, result.stripTrailingZeros());
+		Assertions.assertEquals(BigDecimal.ZERO, result.stripTrailingZeros());
 	}
 
 	@Test
@@ -99,71 +101,71 @@ public class NumberUtilTest {
 		// 四舍
 		String round1 = NumberUtil.roundStr(2.674, 2);
 		String round2 = NumberUtil.roundStr("2.674", 2);
-		Assert.assertEquals("2.67", round1);
-		Assert.assertEquals("2.67", round2);
+		Assertions.assertEquals("2.67", round1);
+		Assertions.assertEquals("2.67", round2);
 
 		// 五入
 		String round3 = NumberUtil.roundStr(2.675, 2);
 		String round4 = NumberUtil.roundStr("2.675", 2);
-		Assert.assertEquals("2.68", round3);
-		Assert.assertEquals("2.68", round4);
+		Assertions.assertEquals("2.68", round3);
+		Assertions.assertEquals("2.68", round4);
 
 		// 四舍六入五成双
 		String round31 = NumberUtil.roundStr(4.245, 2, RoundingMode.HALF_EVEN);
 		String round41 = NumberUtil.roundStr("4.2451", 2, RoundingMode.HALF_EVEN);
-		Assert.assertEquals("4.24", round31);
-		Assert.assertEquals("4.25", round41);
+		Assertions.assertEquals("4.24", round31);
+		Assertions.assertEquals("4.25", round41);
 
 		// 补0
 		String round5 = NumberUtil.roundStr(2.6005, 2);
 		String round6 = NumberUtil.roundStr("2.6005", 2);
-		Assert.assertEquals("2.60", round5);
-		Assert.assertEquals("2.60", round6);
+		Assertions.assertEquals("2.60", round5);
+		Assertions.assertEquals("2.60", round6);
 
 		// 补0
 		String round7 = NumberUtil.roundStr(2.600, 2);
 		String round8 = NumberUtil.roundStr("2.600", 2);
-		Assert.assertEquals("2.60", round7);
-		Assert.assertEquals("2.60", round8);
+		Assertions.assertEquals("2.60", round7);
+		Assertions.assertEquals("2.60", round8);
 	}
 
 	@Test
 	public void roundStrTest() {
 		String roundStr = NumberUtil.roundStr(2.647, 2);
-		Assert.assertEquals(roundStr, "2.65");
+		Assertions.assertEquals(roundStr, "2.65");
 	}
 
 	@Test
 	public void roundHalfEvenTest() {
 		String roundStr = NumberUtil.roundHalfEven(4.245, 2).toString();
-		Assert.assertEquals(roundStr, "4.24");
+		Assertions.assertEquals(roundStr, "4.24");
 		roundStr = NumberUtil.roundHalfEven(4.2450, 2).toString();
-		Assert.assertEquals(roundStr, "4.24");
+		Assertions.assertEquals(roundStr, "4.24");
 		roundStr = NumberUtil.roundHalfEven(4.2451, 2).toString();
-		Assert.assertEquals(roundStr, "4.25");
+		Assertions.assertEquals(roundStr, "4.25");
 		roundStr = NumberUtil.roundHalfEven(4.2250, 2).toString();
-		Assert.assertEquals(roundStr, "4.22");
+		Assertions.assertEquals(roundStr, "4.22");
 
 		roundStr = NumberUtil.roundHalfEven(1.2050, 2).toString();
-		Assert.assertEquals(roundStr, "1.20");
+		Assertions.assertEquals(roundStr, "1.20");
 		roundStr = NumberUtil.roundHalfEven(1.2150, 2).toString();
-		Assert.assertEquals(roundStr, "1.22");
+		Assertions.assertEquals(roundStr, "1.22");
 		roundStr = NumberUtil.roundHalfEven(1.2250, 2).toString();
-		Assert.assertEquals(roundStr, "1.22");
+		Assertions.assertEquals(roundStr, "1.22");
 		roundStr = NumberUtil.roundHalfEven(1.2350, 2).toString();
-		Assert.assertEquals(roundStr, "1.24");
+		Assertions.assertEquals(roundStr, "1.24");
 		roundStr = NumberUtil.roundHalfEven(1.2450, 2).toString();
-		Assert.assertEquals(roundStr, "1.24");
+		Assertions.assertEquals(roundStr, "1.24");
 		roundStr = NumberUtil.roundHalfEven(1.2550, 2).toString();
-		Assert.assertEquals(roundStr, "1.26");
+		Assertions.assertEquals(roundStr, "1.26");
 		roundStr = NumberUtil.roundHalfEven(1.2650, 2).toString();
-		Assert.assertEquals(roundStr, "1.26");
+		Assertions.assertEquals(roundStr, "1.26");
 		roundStr = NumberUtil.roundHalfEven(1.2750, 2).toString();
-		Assert.assertEquals(roundStr, "1.28");
+		Assertions.assertEquals(roundStr, "1.28");
 		roundStr = NumberUtil.roundHalfEven(1.2850, 2).toString();
-		Assert.assertEquals(roundStr, "1.28");
+		Assertions.assertEquals(roundStr, "1.28");
 		roundStr = NumberUtil.roundHalfEven(1.2950, 2).toString();
-		Assert.assertEquals(roundStr, "1.30");
+		Assertions.assertEquals(roundStr, "1.30");
 	}
 
 	@Test
@@ -171,24 +173,28 @@ public class NumberUtilTest {
 		long c = 299792458;// 光速
 
 		String format = NumberUtil.decimalFormat(",###", c);
-		Assert.assertEquals("299,792,458", format);
+		Assertions.assertEquals("299,792,458", format);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void decimalFormatNaNTest(){
-		Double a = 0D;
-		Double b = 0D;
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			Double a = 0D;
+			Double b = 0D;
 
-		Double c = a / b;
-		Console.log(NumberUtil.decimalFormat("#%", c));
+			Double c = a / b;
+			Console.log(NumberUtil.decimalFormat("#%", c));
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void decimalFormatNaNTest2(){
-		Double a = 0D;
-		Double b = 0D;
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			Double a = 0D;
+			Double b = 0D;
 
-		Console.log(NumberUtil.decimalFormat("#%", a / b));
+			Console.log(NumberUtil.decimalFormat("#%", a / b));
+		});
 	}
 
 	@Test
@@ -196,7 +202,7 @@ public class NumberUtilTest {
 		Double c = 467.8101;
 
 		String format = NumberUtil.decimalFormat("0.00", c);
-		Assert.assertEquals("467.81", format);
+		Assertions.assertEquals("467.81", format);
 	}
 
 	@Test
@@ -204,16 +210,16 @@ public class NumberUtilTest {
 		double c = 299792400.543534534;
 
 		String format = NumberUtil.decimalFormatMoney(c);
-		Assert.assertEquals("299,792,400.54", format);
+		Assertions.assertEquals("299,792,400.54", format);
 
 		double value = 0.5;
 		String money = NumberUtil.decimalFormatMoney(value);
-		Assert.assertEquals("0.50", money);
+		Assertions.assertEquals("0.50", money);
 	}
 
 	@Test
 	public void equalsTest() {
-		Assert.assertTrue(NumberUtil.equals(new BigDecimal("0.00"), BigDecimal.ZERO));
+		Assertions.assertTrue(NumberUtil.equals(new BigDecimal("0.00"), BigDecimal.ZERO));
 	}
 
 	@Test
@@ -221,56 +227,56 @@ public class NumberUtilTest {
 		double a = 3.14;
 
 		BigDecimal bigDecimal = NumberUtil.toBigDecimal(a);
-		Assert.assertEquals("3.14", bigDecimal.toString());
+		Assertions.assertEquals("3.14", bigDecimal.toString());
 
 		bigDecimal = NumberUtil.toBigDecimal("1,234.55");
-		Assert.assertEquals("1234.55", bigDecimal.toString());
+		Assertions.assertEquals("1234.55", bigDecimal.toString());
 
 		bigDecimal = NumberUtil.toBigDecimal("1,234.56D");
-		Assert.assertEquals("1234.56", bigDecimal.toString());
+		Assertions.assertEquals("1234.56", bigDecimal.toString());
 	}
 
 	@Test
 	public void maxTest() {
 		int max = NumberUtil.max(5,4,3,6,1);
-		Assert.assertEquals(6, max);
+		Assertions.assertEquals(6, max);
 	}
 
 	@Test
 	public void minTest() {
 		int min = NumberUtil.min(5,4,3,6,1);
-		Assert.assertEquals(1, min);
+		Assertions.assertEquals(1, min);
 	}
 
 	@Test
 	public void parseIntTest() {
 		int number = NumberUtil.parseInt("0xFF");
-		Assert.assertEquals(255, number);
+		Assertions.assertEquals(255, number);
 
 		// 0开头
 		number = NumberUtil.parseInt("010");
-		Assert.assertEquals(10, number);
+		Assertions.assertEquals(10, number);
 
 		number = NumberUtil.parseInt("10");
-		Assert.assertEquals(10, number);
+		Assertions.assertEquals(10, number);
 
 		number = NumberUtil.parseInt("   ");
-		Assert.assertEquals(0, number);
+		Assertions.assertEquals(0, number);
 
 		number = NumberUtil.parseInt("10F");
-		Assert.assertEquals(10, number);
+		Assertions.assertEquals(10, number);
 
 		number = NumberUtil.parseInt("22.4D");
-		Assert.assertEquals(22, number);
+		Assertions.assertEquals(22, number);
 
 		number = NumberUtil.parseInt("22.6D");
-		Assert.assertEquals(22, number);
+		Assertions.assertEquals(22, number);
 
 		number = NumberUtil.parseInt("0");
-		Assert.assertEquals(0, number);
+		Assertions.assertEquals(0, number);
 
 		number = NumberUtil.parseInt(".123");
-		Assert.assertEquals(0, number);
+		Assertions.assertEquals(0, number);
 	}
 
 	@Test
@@ -278,7 +284,7 @@ public class NumberUtilTest {
 		// from 5.4.8 issue#I23ORQ@Gitee
 		// 千位分隔符去掉
 		int v1 = NumberUtil.parseInt("1,482.00");
-		Assert.assertEquals(1482, v1);
+		Assertions.assertEquals(1482, v1);
 	}
 
 	@Test
@@ -286,150 +292,150 @@ public class NumberUtilTest {
 		// from 5.4.8 issue#I23ORQ@Gitee
 		// 千位分隔符去掉
 		int v1 = NumberUtil.parseNumber("1,482.00").intValue();
-		Assert.assertEquals(1482, v1);
+		Assertions.assertEquals(1482, v1);
 
 		Number v2 = NumberUtil.parseNumber("1,482.00D");
-		Assert.assertEquals(1482L, v2.longValue());
+		Assertions.assertEquals(1482L, v2.longValue());
 	}
 
 	@Test
 	public void parseLongTest() {
 		long number = NumberUtil.parseLong("0xFF");
-		Assert.assertEquals(255, number);
+		Assertions.assertEquals(255, number);
 
 		// 0开头
 		number = NumberUtil.parseLong("010");
-		Assert.assertEquals(10, number);
+		Assertions.assertEquals(10, number);
 
 		number = NumberUtil.parseLong("10");
-		Assert.assertEquals(10, number);
+		Assertions.assertEquals(10, number);
 
 		number = NumberUtil.parseLong("   ");
-		Assert.assertEquals(0, number);
+		Assertions.assertEquals(0, number);
 
 		number = NumberUtil.parseLong("10F");
-		Assert.assertEquals(10, number);
+		Assertions.assertEquals(10, number);
 
 		number = NumberUtil.parseLong("22.4D");
-		Assert.assertEquals(22, number);
+		Assertions.assertEquals(22, number);
 
 		number = NumberUtil.parseLong("22.6D");
-		Assert.assertEquals(22, number);
+		Assertions.assertEquals(22, number);
 
 		number = NumberUtil.parseLong("0");
-		Assert.assertEquals(0, number);
+		Assertions.assertEquals(0, number);
 
 		number = NumberUtil.parseLong(".123");
-		Assert.assertEquals(0, number);
+		Assertions.assertEquals(0, number);
 	}
 
 	@Test
 	public void factorialTest(){
 		long factorial = NumberUtil.factorial(0);
-		Assert.assertEquals(1, factorial);
+		Assertions.assertEquals(1, factorial);
 
-		Assert.assertEquals(1L, NumberUtil.factorial(1));
-		Assert.assertEquals(1307674368000L, NumberUtil.factorial(15));
-		Assert.assertEquals(2432902008176640000L, NumberUtil.factorial(20));
+		Assertions.assertEquals(1L, NumberUtil.factorial(1));
+		Assertions.assertEquals(1307674368000L, NumberUtil.factorial(15));
+		Assertions.assertEquals(2432902008176640000L, NumberUtil.factorial(20));
 
 		factorial = NumberUtil.factorial(5, 0);
-		Assert.assertEquals(120, factorial);
+		Assertions.assertEquals(120, factorial);
 		factorial = NumberUtil.factorial(5, 1);
-		Assert.assertEquals(120, factorial);
+		Assertions.assertEquals(120, factorial);
 
-		Assert.assertEquals(5, NumberUtil.factorial(5, 4));
-		Assert.assertEquals(2432902008176640000L, NumberUtil.factorial(20, 0));
+		Assertions.assertEquals(5, NumberUtil.factorial(5, 4));
+		Assertions.assertEquals(2432902008176640000L, NumberUtil.factorial(20, 0));
 	}
 
 	@Test
 	public void factorialTest2(){
 		long factorial = NumberUtil.factorial(new BigInteger("0")).longValue();
-		Assert.assertEquals(1, factorial);
+		Assertions.assertEquals(1, factorial);
 
-		Assert.assertEquals(1L, NumberUtil.factorial(new BigInteger("1")).longValue());
-		Assert.assertEquals(1307674368000L, NumberUtil.factorial(new BigInteger("15")).longValue());
-		Assert.assertEquals(2432902008176640000L, NumberUtil.factorial(20));
+		Assertions.assertEquals(1L, NumberUtil.factorial(new BigInteger("1")).longValue());
+		Assertions.assertEquals(1307674368000L, NumberUtil.factorial(new BigInteger("15")).longValue());
+		Assertions.assertEquals(2432902008176640000L, NumberUtil.factorial(20));
 
 		factorial = NumberUtil.factorial(new BigInteger("5"), new BigInteger("0")).longValue();
-		Assert.assertEquals(120, factorial);
+		Assertions.assertEquals(120, factorial);
 		factorial = NumberUtil.factorial(new BigInteger("5"), BigInteger.ONE).longValue();
-		Assert.assertEquals(120, factorial);
+		Assertions.assertEquals(120, factorial);
 
-		Assert.assertEquals(5, NumberUtil.factorial(new BigInteger("5"), new BigInteger("4")).longValue());
-		Assert.assertEquals(2432902008176640000L, NumberUtil.factorial(new BigInteger("20"), BigInteger.ZERO).longValue());
+		Assertions.assertEquals(5, NumberUtil.factorial(new BigInteger("5"), new BigInteger("4")).longValue());
+		Assertions.assertEquals(2432902008176640000L, NumberUtil.factorial(new BigInteger("20"), BigInteger.ZERO).longValue());
 	}
 
 	@Test
 	public void mulTest(){
 		final BigDecimal mul = NumberUtil.mul(new BigDecimal("10"), null);
-		Assert.assertEquals(BigDecimal.ZERO, mul);
+		Assertions.assertEquals(BigDecimal.ZERO, mul);
 	}
 
 
 	@Test
 	public void isPowerOfTwoTest() {
-		Assert.assertFalse(NumberUtil.isPowerOfTwo(-1));
-		Assert.assertTrue(NumberUtil.isPowerOfTwo(16));
-		Assert.assertTrue(NumberUtil.isPowerOfTwo(65536));
-		Assert.assertTrue(NumberUtil.isPowerOfTwo(1));
-		Assert.assertFalse(NumberUtil.isPowerOfTwo(17));
+		Assertions.assertFalse(NumberUtil.isPowerOfTwo(-1));
+		Assertions.assertTrue(NumberUtil.isPowerOfTwo(16));
+		Assertions.assertTrue(NumberUtil.isPowerOfTwo(65536));
+		Assertions.assertTrue(NumberUtil.isPowerOfTwo(1));
+		Assertions.assertFalse(NumberUtil.isPowerOfTwo(17));
 	}
 
 	@Test
 	public void generateRandomNumberTest(){
 		final int[] ints = NumberUtil.generateRandomNumber(10, 20, 5);
-		Assert.assertEquals(5, ints.length);
+		Assertions.assertEquals(5, ints.length);
 		final Set<?> set = Convert.convert(Set.class, ints);
-		Assert.assertEquals(5, set.size());
+		Assertions.assertEquals(5, set.size());
 	}
 
 	@Test
 	public void toStrTest(){
-		Assert.assertEquals("1", NumberUtil.toStr(new BigDecimal("1.0000000000")));
-		Assert.assertEquals("0", NumberUtil.toStr(NumberUtil.sub(new BigDecimal("9600.00000"), new BigDecimal("9600.00000"))));
-		Assert.assertEquals("0", NumberUtil.toStr(NumberUtil.sub(new BigDecimal("9600.0000000000"), new BigDecimal("9600.000000"))));
-		Assert.assertEquals("0", NumberUtil.toStr(new BigDecimal("9600.00000").subtract(new BigDecimal("9600.000000000"))));
+		Assertions.assertEquals("1", NumberUtil.toStr(new BigDecimal("1.0000000000")));
+		Assertions.assertEquals("0", NumberUtil.toStr(NumberUtil.sub(new BigDecimal("9600.00000"), new BigDecimal("9600.00000"))));
+		Assertions.assertEquals("0", NumberUtil.toStr(NumberUtil.sub(new BigDecimal("9600.0000000000"), new BigDecimal("9600.000000"))));
+		Assertions.assertEquals("0", NumberUtil.toStr(new BigDecimal("9600.00000").subtract(new BigDecimal("9600.000000000"))));
 	}
 
 	@Test
 	public void generateRandomNumberTest2(){
 		// 检查边界
 		final int[] ints = NumberUtil.generateRandomNumber(1, 8, 7);
-		Assert.assertEquals(7, ints.length);
+		Assertions.assertEquals(7, ints.length);
 		final Set<?> set = Convert.convert(Set.class, ints);
-		Assert.assertEquals(7, set.size());
+		Assertions.assertEquals(7, set.size());
 	}
 
 	@Test
 	public void toPlainNumberTest(){
 		String num = "5344.34234e3";
 		final String s = new BigDecimal(num).toPlainString();
-		Assert.assertEquals("5344342.34", s);
+		Assertions.assertEquals("5344342.34", s);
 	}
 
 	@Test
 	public void generateBySetTest(){
 		final Integer[] integers = NumberUtil.generateBySet(10, 100, 5);
-		Assert.assertEquals(5, integers.length);
+		Assertions.assertEquals(5, integers.length);
 	}
 
 	@Test
 	public void isOddOrEvenTest(){
 		int[] a = { 0, 32, -32, 123, -123 };
-		Assert.assertFalse(NumberUtil.isOdd(a[0]));
-		Assert.assertTrue(NumberUtil.isEven(a[0]));
+		Assertions.assertFalse(NumberUtil.isOdd(a[0]));
+		Assertions.assertTrue(NumberUtil.isEven(a[0]));
 
-		Assert.assertFalse(NumberUtil.isOdd(a[1]));
-		Assert.assertTrue(NumberUtil.isEven(a[1]));
+		Assertions.assertFalse(NumberUtil.isOdd(a[1]));
+		Assertions.assertTrue(NumberUtil.isEven(a[1]));
 
-		Assert.assertFalse(NumberUtil.isOdd(a[2]));
-		Assert.assertTrue(NumberUtil.isEven(a[2]));
+		Assertions.assertFalse(NumberUtil.isOdd(a[2]));
+		Assertions.assertTrue(NumberUtil.isEven(a[2]));
 
-		Assert.assertTrue(NumberUtil.isOdd(a[3]));
-		Assert.assertFalse(NumberUtil.isEven(a[3]));
+		Assertions.assertTrue(NumberUtil.isOdd(a[3]));
+		Assertions.assertFalse(NumberUtil.isEven(a[3]));
 
-		Assert.assertTrue(NumberUtil.isOdd(a[4]));
-		Assert.assertFalse(NumberUtil.isEven(a[4]));
+		Assertions.assertTrue(NumberUtil.isOdd(a[4]));
+		Assertions.assertFalse(NumberUtil.isEven(a[4]));
 	}
 
 

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -2,14 +2,12 @@ package cn.hutool.core.util;
 
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.lang.Console;
-import cn.hutool.core.lang.id.NanoId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.security.SecureRandom;
 import java.util.Set;
 
 /**

--- a/hutool-core/src/test/java/cn/hutool/core/util/ObjectUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ObjectUtilTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.clone.CloneSupport;
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.date.DatePattern;
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -18,21 +18,21 @@ public class ObjectUtilTest {
 	public void equalsTest(){
 		Object a = null;
 		Object b = null;
-		Assert.assertTrue(ObjectUtil.equals(a, b));
+		Assertions.assertTrue(ObjectUtil.equals(a, b));
 	}
 
 	@Test
 	public void lengthTest(){
 		int[] array = new int[]{1,2,3,4,5};
 		int length = ObjectUtil.length(array);
-		Assert.assertEquals(5, length);
+		Assertions.assertEquals(5, length);
 
 		Map<String, String> map = new HashMap<>();
 		map.put("a", "a1");
 		map.put("b", "b1");
 		map.put("c", "c1");
 		length = ObjectUtil.length(map);
-		Assert.assertEquals(3, length);
+		Assertions.assertEquals(3, length);
 	}
 
 	@Test
@@ -40,14 +40,14 @@ public class ObjectUtilTest {
 		int[] array = new int[]{1,2,3,4,5};
 
 		final boolean contains = ObjectUtil.contains(array, 1);
-		Assert.assertTrue(contains);
+		Assertions.assertTrue(contains);
 	}
 
 	@Test
 	public void cloneTest() {
 		Obj obj = new Obj();
 		Obj obj2 = ObjectUtil.clone(obj);
-		Assert.assertEquals("OK", obj2.doSomeThing());
+		Assertions.assertEquals("OK", obj2.doSomeThing());
 	}
 
 	static class Obj extends CloneSupport<Obj> {
@@ -60,7 +60,7 @@ public class ObjectUtilTest {
 	public void toStringTest() {
 		ArrayList<String> strings = CollUtil.newArrayList("1", "2");
 		String result = ObjectUtil.toString(strings);
-		Assert.assertEquals("[1, 2]", result);
+		Assertions.assertEquals("[1, 2]", result);
 	}
 
 	@Test
@@ -69,10 +69,10 @@ public class ObjectUtilTest {
 		final String dateStr = "2020-10-23 15:12:30";
 		Instant result1 = ObjectUtil.defaultIfNull(dateStr,
 				() -> DateUtil.parse(dateStr, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
-		Assert.assertNotNull(result1);
+		Assertions.assertNotNull(result1);
 		Instant result2 = ObjectUtil.defaultIfNull(nullValue,
 				() -> DateUtil.parse(nullValue, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
-		Assert.assertNotNull(result2);
+		Assertions.assertNotNull(result2);
 	}
 
 	@Test
@@ -81,16 +81,16 @@ public class ObjectUtilTest {
 		final String dateStr = "2020-10-23 15:12:30";
 		Instant result1 = ObjectUtil.defaultIfEmpty(emptyValue,
 				() -> DateUtil.parse(emptyValue, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
-		Assert.assertNotNull(result1);
+		Assertions.assertNotNull(result1);
 		Instant result2 = ObjectUtil.defaultIfEmpty(dateStr,
 				() -> DateUtil.parse(dateStr, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
-		Assert.assertNotNull(result2);
+		Assertions.assertNotNull(result2);
 	}
 
 	@Test
 	public void isBasicTypeTest(){
 		int a = 1;
 		final boolean basicType = ObjectUtil.isBasicType(a);
-		Assert.assertTrue(basicType);
+		Assertions.assertTrue(basicType);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/PageUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/PageUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 分页单元测试
@@ -9,28 +9,28 @@ import org.junit.Test;
  *
  */
 public class PageUtilTest {
-	
+
 	@Test
 	public void transToStartEndTest(){
 		PageUtil.setFirstPageNo(0);
 		int[] startEnd1 = PageUtil.transToStartEnd(0, 10);
-		Assert.assertEquals(0, startEnd1[0]);
-		Assert.assertEquals(10, startEnd1[1]);
-		
+		Assertions.assertEquals(0, startEnd1[0]);
+		Assertions.assertEquals(10, startEnd1[1]);
+
 		int[] startEnd2 = PageUtil.transToStartEnd(1, 10);
-		Assert.assertEquals(10, startEnd2[0]);
-		Assert.assertEquals(20, startEnd2[1]);
+		Assertions.assertEquals(10, startEnd2[0]);
+		Assertions.assertEquals(20, startEnd2[1]);
 	}
-	
+
 	@Test
 	public void totalPage(){
 		int totalPage = PageUtil.totalPage(20, 3);
-		Assert.assertEquals(7, totalPage);
+		Assertions.assertEquals(7, totalPage);
 	}
-	
+
 	@Test
 	public void rainbowTest() {
 		int[] rainbow = PageUtil.rainbow(5, 20, 6);
-		Assert.assertArrayEquals(new int[] {3, 4, 5, 6, 7, 8}, rainbow);
+		Assertions.assertArrayEquals(new int[] {3, 4, 5, 6, 7, 8}, rainbow);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/PhoneUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/PhoneUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
@@ -19,15 +19,15 @@ public class PhoneUtilTest {
 		String errMobile = "136123456781";
 		String errTel = "010-889931081";
 
-		Assert.assertTrue(PhoneUtil.isMobile(mobile));
-		Assert.assertTrue(PhoneUtil.isTel(tel));
-		Assert.assertTrue(PhoneUtil.isPhone(mobile));
-		Assert.assertTrue(PhoneUtil.isPhone(tel));
+		Assertions.assertTrue(PhoneUtil.isMobile(mobile));
+		Assertions.assertTrue(PhoneUtil.isTel(tel));
+		Assertions.assertTrue(PhoneUtil.isPhone(mobile));
+		Assertions.assertTrue(PhoneUtil.isPhone(tel));
 
-		Assert.assertFalse(PhoneUtil.isMobile(errMobile));
-		Assert.assertFalse(PhoneUtil.isTel(errTel));
-		Assert.assertFalse(PhoneUtil.isPhone(errMobile));
-		Assert.assertFalse(PhoneUtil.isPhone(errTel));
+		Assertions.assertFalse(PhoneUtil.isMobile(errMobile));
+		Assertions.assertFalse(PhoneUtil.isTel(errTel));
+		Assertions.assertFalse(PhoneUtil.isPhone(errMobile));
+		Assertions.assertFalse(PhoneUtil.isPhone(errTel));
 	}
 
 	@Test
@@ -42,10 +42,10 @@ public class PhoneUtilTest {
 		errTels.add("0755-7654.321");
 		errTels.add("13619887123");
 		for (String s : tels) {
-			Assert.assertTrue(PhoneUtil.isTel(s));
+			Assertions.assertTrue(PhoneUtil.isTel(s));
 		}
 		for (String s : errTels) {
-			Assert.assertFalse(PhoneUtil.isTel(s));
+			Assertions.assertFalse(PhoneUtil.isTel(s));
 		}
 	}
 
@@ -53,17 +53,17 @@ public class PhoneUtilTest {
 	public void testHide() {
 		String mobile = "13612345678";
 
-		Assert.assertEquals("*******5678", PhoneUtil.hideBefore(mobile));
-		Assert.assertEquals("136****5678", PhoneUtil.hideBetween(mobile));
-		Assert.assertEquals("1361234****", PhoneUtil.hideAfter(mobile));
+		Assertions.assertEquals("*******5678", PhoneUtil.hideBefore(mobile));
+		Assertions.assertEquals("136****5678", PhoneUtil.hideBetween(mobile));
+		Assertions.assertEquals("1361234****", PhoneUtil.hideAfter(mobile));
 	}
 
 	@Test
 	public void testSubString() {
 		String mobile = "13612345678";
-		Assert.assertEquals("136", PhoneUtil.subBefore(mobile));
-		Assert.assertEquals("1234", PhoneUtil.subBetween(mobile));
-		Assert.assertEquals("5678", PhoneUtil.subAfter(mobile));
+		Assertions.assertEquals("136", PhoneUtil.subBefore(mobile));
+		Assertions.assertEquals("1234", PhoneUtil.subBetween(mobile));
+		Assertions.assertEquals("5678", PhoneUtil.subAfter(mobile));
 	}
 
 	@Test
@@ -81,19 +81,19 @@ public class PhoneUtilTest {
 		errTels.add("0755-7654.321");
 		errTels.add("13619887123");
 		for (String s : tels) {
-			Assert.assertTrue(PhoneUtil.isTel(s));
+			Assertions.assertTrue(PhoneUtil.isTel(s));
 		}
 		for (String s : errTels) {
-			Assert.assertFalse(PhoneUtil.isTel(s));
+			Assertions.assertFalse(PhoneUtil.isTel(s));
 		}
-		Assert.assertEquals("010", PhoneUtil.subTelBefore("010-12345678"));
-		Assert.assertEquals("010", PhoneUtil.subTelBefore("01012345678"));
-		Assert.assertEquals("12345678", PhoneUtil.subTelAfter("010-12345678"));
-		Assert.assertEquals("12345678", PhoneUtil.subTelAfter("01012345678"));
+		Assertions.assertEquals("010", PhoneUtil.subTelBefore("010-12345678"));
+		Assertions.assertEquals("010", PhoneUtil.subTelBefore("01012345678"));
+		Assertions.assertEquals("12345678", PhoneUtil.subTelAfter("010-12345678"));
+		Assertions.assertEquals("12345678", PhoneUtil.subTelAfter("01012345678"));
 
-		Assert.assertEquals("0755", PhoneUtil.subTelBefore("0755-7654321"));
-		Assert.assertEquals("0755", PhoneUtil.subTelBefore("07557654321"));
-		Assert.assertEquals("7654321", PhoneUtil.subTelAfter("0755-7654321"));
-		Assert.assertEquals("7654321", PhoneUtil.subTelAfter("07557654321"));
+		Assertions.assertEquals("0755", PhoneUtil.subTelBefore("0755-7654321"));
+		Assertions.assertEquals("0755", PhoneUtil.subTelBefore("07557654321"));
+		Assertions.assertEquals("7654321", PhoneUtil.subTelAfter("0755-7654321"));
+		Assertions.assertEquals("7654321", PhoneUtil.subTelAfter("07557654321"));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/RandomUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/RandomUtilTest.java
@@ -2,9 +2,9 @@ package cn.hutool.core.util;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.math.RoundingMode;
 import java.util.List;
@@ -15,23 +15,23 @@ public class RandomUtilTest {
 	@Test
 	public void randomEleSetTest(){
 		Set<Integer> set = RandomUtil.randomEleSet(CollUtil.newArrayList(1, 2, 3, 4, 5, 6), 2);
-		Assert.assertEquals(set.size(), 2);
+		Assertions.assertEquals(set.size(), 2);
 	}
 
 	@Test
 	public void randomElesTest(){
 		List<Integer> result = RandomUtil.randomEles(CollUtil.newArrayList(1, 2, 3, 4, 5, 6), 2);
-		Assert.assertEquals(result.size(), 2);
+		Assertions.assertEquals(result.size(), 2);
 	}
 
 	@Test
 	public void randomDoubleTest() {
 		double randomDouble = RandomUtil.randomDouble(0, 1, 0, RoundingMode.HALF_UP);
-		Assert.assertTrue(randomDouble <= 1);
+		Assertions.assertTrue(randomDouble <= 1);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void randomBooleanTest() {
 		Console.log(RandomUtil.randomBoolean());
 	}
@@ -39,24 +39,24 @@ public class RandomUtilTest {
 	@Test
 	public void randomNumberTest() {
 		final char c = RandomUtil.randomNumber();
-		Assert.assertTrue(c <= '9');
+		Assertions.assertTrue(c <= '9');
 	}
 
 	@Test
 	public void randomIntTest() {
 		final int c = RandomUtil.randomInt(10, 100);
-		Assert.assertTrue(c >= 10 && c < 100);
+		Assertions.assertTrue(c >= 10 && c < 100);
 	}
 
 	@Test
 	public void randomBytesTest() {
 		final byte[] c = RandomUtil.randomBytes(10);
-		Assert.assertNotNull(c);
+		Assertions.assertNotNull(c);
 	}
 
 	@Test
 	public void randomChineseTest(){
 		char c = RandomUtil.randomChinese();
-		Assert.assertTrue(c > 0);
+		Assertions.assertTrue(c > 0);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
@@ -3,8 +3,8 @@ package cn.hutool.core.util;
 import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.lang.PatternPool;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,28 +17,28 @@ public class ReUtilTest {
 	@Test
 	public void getTest() {
 		String resultGet = ReUtil.get("\\w{2}", content, 0);
-		Assert.assertEquals("ZZ", resultGet);
+		Assertions.assertEquals("ZZ", resultGet);
 	}
 
 	@Test
 	public void extractMultiTest() {
 		// 抽取多个分组然后把它们拼接起来
 		String resultExtractMulti = ReUtil.extractMulti("(\\w)aa(\\w)", content, "$1-$2");
-		Assert.assertEquals("Z-a", resultExtractMulti);
+		Assertions.assertEquals("Z-a", resultExtractMulti);
 	}
 
 	@Test
 	public void extractMultiTest2() {
 		// 抽取多个分组然后把它们拼接起来
 		String resultExtractMulti = ReUtil.extractMulti("(\\w)(\\w)(\\w)(\\w)(\\w)(\\w)(\\w)(\\w)(\\w)(\\w)", content, "$1-$2-$3-$4-$5-$6-$7-$8-$9-$10");
-		Assert.assertEquals("Z-Z-Z-a-a-a-b-b-b-c", resultExtractMulti);
+		Assertions.assertEquals("Z-Z-Z-a-a-a-b-b-b-c", resultExtractMulti);
 	}
 
 	@Test
 	public void delFirstTest() {
 		// 删除第一个匹配到的内容
 		String resultDelFirst = ReUtil.delFirst("(\\w)aa(\\w)", content);
-		Assert.assertEquals("ZZbbbccc中文1234", resultDelFirst);
+		Assertions.assertEquals("ZZbbbccc中文1234", resultDelFirst);
 	}
 
 	@Test
@@ -47,25 +47,25 @@ public class ReUtilTest {
 		String word = "180公斤";
 		String sentence = "10.商品KLS100021型号xxl适合身高180体重130斤的用户";
 		//空字符串兼容
-		Assert.assertEquals(blank,ReUtil.delLast("\\d+", blank));
-		Assert.assertEquals(blank,ReUtil.delLast(PatternPool.NUMBERS, blank));
+		Assertions.assertEquals(blank,ReUtil.delLast("\\d+", blank));
+		Assertions.assertEquals(blank,ReUtil.delLast(PatternPool.NUMBERS, blank));
 
 		//去除数字
-		Assert.assertEquals("公斤",ReUtil.delLast("\\d+", word));
-		Assert.assertEquals("公斤",ReUtil.delLast(PatternPool.NUMBERS, word));
+		Assertions.assertEquals("公斤",ReUtil.delLast("\\d+", word));
+		Assertions.assertEquals("公斤",ReUtil.delLast(PatternPool.NUMBERS, word));
 		//去除汉字
-		Assert.assertEquals("180",ReUtil.delLast("[\u4E00-\u9FFF]+", word));
-		Assert.assertEquals("180",ReUtil.delLast(PatternPool.CHINESES, word));
+		Assertions.assertEquals("180",ReUtil.delLast("[\u4E00-\u9FFF]+", word));
+		Assertions.assertEquals("180",ReUtil.delLast(PatternPool.CHINESES, word));
 
 		//多个匹配删除最后一个 判断是否不在包含最后的数字
 		String s = ReUtil.delLast("\\d+", sentence);
-		Assert.assertEquals("10.商品KLS100021型号xxl适合身高180体重斤的用户", s);
+		Assertions.assertEquals("10.商品KLS100021型号xxl适合身高180体重斤的用户", s);
 		s = ReUtil.delLast(PatternPool.NUMBERS, sentence);
-		Assert.assertEquals("10.商品KLS100021型号xxl适合身高180体重斤的用户", s);
+		Assertions.assertEquals("10.商品KLS100021型号xxl适合身高180体重斤的用户", s);
 
 		//多个匹配删除最后一个 判断是否不在包含最后的数字
-		Assert.assertFalse(ReUtil.delLast("[\u4E00-\u9FFF]+", sentence).contains("斤的用户"));
-		Assert.assertFalse(ReUtil.delLast(PatternPool.CHINESES, sentence).contains("斤的用户"));
+		Assertions.assertFalse(ReUtil.delLast("[\u4E00-\u9FFF]+", sentence).contains("斤的用户"));
+		Assertions.assertFalse(ReUtil.delLast(PatternPool.CHINESES, sentence).contains("斤的用户"));
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class ReUtilTest {
 		// 删除所有匹配到的内容
 		String content = "发东方大厦eee![images]http://abc.com/2.gpg]好机会eee![images]http://abc.com/2.gpg]好机会";
 		String resultDelAll = ReUtil.delAll("!\\[images\\][^\\u4e00-\\u9fa5\\\\s]*", content);
-		Assert.assertEquals("发东方大厦eee好机会eee好机会", resultDelAll);
+		Assertions.assertEquals("发东方大厦eee好机会eee好机会", resultDelAll);
 	}
 
 	@Test
@@ -81,21 +81,21 @@ public class ReUtilTest {
 		// 查找所有匹配文本
 		List<String> resultFindAll = ReUtil.findAll("\\w{2}", content, 0, new ArrayList<>());
 		ArrayList<String> expected = CollectionUtil.newArrayList("ZZ", "Za", "aa", "bb", "bc", "cc", "12", "34");
-		Assert.assertEquals(expected, resultFindAll);
+		Assertions.assertEquals(expected, resultFindAll);
 	}
 
 	@Test
 	public void getFirstNumberTest() {
 		// 找到匹配的第一个数字
 		Integer resultGetFirstNumber = ReUtil.getFirstNumber(content);
-		Assert.assertEquals(Integer.valueOf(1234), resultGetFirstNumber);
+		Assertions.assertEquals(Integer.valueOf(1234), resultGetFirstNumber);
 	}
 
 	@Test
 	public void isMatchTest() {
 		// 给定字符串是否匹配给定正则
 		boolean isMatch = ReUtil.isMatch("\\w+[\u4E00-\u9FFF]+\\d+", content);
-		Assert.assertTrue(isMatch);
+		Assertions.assertTrue(isMatch);
 	}
 
 	@Test
@@ -103,43 +103,43 @@ public class ReUtilTest {
 		//通过正则查找到字符串，然后把匹配到的字符串加入到replacementTemplate中，$1表示分组1的字符串
 		//此处把1234替换为 ->1234<-
 		String replaceAll = ReUtil.replaceAll(content, "(\\d+)", "->$1<-");
-		Assert.assertEquals("ZZZaaabbbccc中文->1234<-", replaceAll);
+		Assertions.assertEquals("ZZZaaabbbccc中文->1234<-", replaceAll);
 	}
 
 	@Test
 	public void replaceAllTest2() {
 		//此处把1234替换为 ->1234<-
 		String replaceAll = ReUtil.replaceAll(this.content, "(\\d+)", parameters -> "->" + parameters.group(1) + "<-");
-		Assert.assertEquals("ZZZaaabbbccc中文->1234<-", replaceAll);
+		Assertions.assertEquals("ZZZaaabbbccc中文->1234<-", replaceAll);
 	}
 
 	@Test
 	public void replaceTest() {
 		String str = "AAABBCCCBBDDDBB";
 		String replace = StrUtil.replace(str, 0, "BB", "22", false);
-		Assert.assertEquals("AAA22CCC22DDD22", replace);
+		Assertions.assertEquals("AAA22CCC22DDD22", replace);
 
 		replace = StrUtil.replace(str, 3, "BB", "22", false);
-		Assert.assertEquals("AAA22CCC22DDD22", replace);
+		Assertions.assertEquals("AAA22CCC22DDD22", replace);
 
 		replace = StrUtil.replace(str, 4, "BB", "22", false);
-		Assert.assertEquals("AAABBCCC22DDD22", replace);
+		Assertions.assertEquals("AAABBCCC22DDD22", replace);
 
 		replace = StrUtil.replace(str, 4, "bb", "22", true);
-		Assert.assertEquals("AAABBCCC22DDD22", replace);
+		Assertions.assertEquals("AAABBCCC22DDD22", replace);
 
 		replace = StrUtil.replace(str, 4, "bb", "", true);
-		Assert.assertEquals("AAABBCCCDDD", replace);
+		Assertions.assertEquals("AAABBCCCDDD", replace);
 
 		replace = StrUtil.replace(str, 4, "bb", null, true);
-		Assert.assertEquals("AAABBCCCDDD", replace);
+		Assertions.assertEquals("AAABBCCCDDD", replace);
 	}
 
 	@Test
 	public void escapeTest() {
 		//转义给定字符串，为正则相关的特殊符号转义
 		String escape = ReUtil.escape("我有个$符号{}");
-		Assert.assertEquals("我有个\\$符号\\{\\}", escape);
+		Assertions.assertEquals("我有个\\$符号\\{\\}", escape);
 	}
 
 	@Test
@@ -147,15 +147,15 @@ public class ReUtilTest {
 		//转义给定字符串，为正则相关的特殊符号转义
 		Pattern pattern = Pattern.compile("(\\d+)-(\\d+)-(\\d+)");
 		List<String> allGroups = ReUtil.getAllGroups(pattern, "192-168-1-1");
-		Assert.assertEquals("192-168-1", allGroups.get(0));
-		Assert.assertEquals("192", allGroups.get(1));
-		Assert.assertEquals("168", allGroups.get(2));
-		Assert.assertEquals("1", allGroups.get(3));
+		Assertions.assertEquals("192-168-1", allGroups.get(0));
+		Assertions.assertEquals("192", allGroups.get(1));
+		Assertions.assertEquals("168", allGroups.get(2));
+		Assertions.assertEquals("1", allGroups.get(3));
 
 		allGroups = ReUtil.getAllGroups(pattern, "192-168-1-1", false);
-		Assert.assertEquals("192", allGroups.get(0));
-		Assert.assertEquals("168", allGroups.get(1));
-		Assert.assertEquals("1", allGroups.get(2));
+		Assertions.assertEquals("192", allGroups.get(0));
+		Assertions.assertEquals("168", allGroups.get(1));
+		Assertions.assertEquals("1", allGroups.get(2));
 	}
 
 	@Test
@@ -170,11 +170,11 @@ public class ReUtilTest {
 		String content = "2021-10-11";
 		String regex = "(?<year>\\d+)-(?<month>\\d+)-(?<day>\\d+)";
 		String year = ReUtil.get(regex, content, "year");
-		Assert.assertEquals("2021", year);
+		Assertions.assertEquals("2021", year);
 		String month = ReUtil.get(regex, content, "month");
-		Assert.assertEquals("10", month);
+		Assertions.assertEquals("10", month);
 		String day = ReUtil.get(regex, content, "day");
-		Assert.assertEquals("11", day);
+		Assertions.assertEquals("11", day);
 	}
 
 	@Test
@@ -182,8 +182,8 @@ public class ReUtilTest {
 		String content = "2021-10-11";
 		String regex = "(?<year>\\d+)-(?<month>\\d+)-(?<day>\\d+)";
 		Map<String, String> map = ReUtil.getAllGroupNames(PatternPool.get(regex, Pattern.DOTALL), content);
-		Assert.assertEquals(map.get("year"), "2021");
-		Assert.assertEquals(map.get("month"), "10");
-		Assert.assertEquals(map.get("day"), "11");
+		Assertions.assertEquals(map.get("year"), "2021");
+		Assertions.assertEquals(map.get("month"), "10");
+		Assertions.assertEquals(map.get("day"), "11");
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ReflectUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ReflectUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.core.util;
 
 import cn.hutool.core.lang.test.bean.ExamInfoDict;
 import cn.hutool.core.util.ClassUtilTest.TestSubClass;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -18,82 +18,82 @@ public class ReflectUtilTest {
 	@Test
 	public void getMethodsTest() {
 		Method[] methods = ReflectUtil.getMethods(ExamInfoDict.class);
-		Assert.assertEquals(22, methods.length);
+		Assertions.assertEquals(22, methods.length);
 
 		//过滤器测试
 		methods = ReflectUtil.getMethods(ExamInfoDict.class, t -> Integer.class.equals(t.getReturnType()));
 
-		Assert.assertEquals(4, methods.length);
+		Assertions.assertEquals(4, methods.length);
 		final Method method = methods[0];
-		Assert.assertNotNull(method);
+		Assertions.assertNotNull(method);
 
 		//null过滤器测试
 		methods = ReflectUtil.getMethods(ExamInfoDict.class, null);
 
-		Assert.assertEquals(22, methods.length);
+		Assertions.assertEquals(22, methods.length);
 		final Method method2 = methods[0];
-		Assert.assertNotNull(method2);
+		Assertions.assertNotNull(method2);
 	}
 
 	@Test
 	public void getMethodTest() {
 		Method method = ReflectUtil.getMethod(ExamInfoDict.class, "getId");
-		Assert.assertEquals("getId", method.getName());
-		Assert.assertEquals(0, method.getParameterTypes().length);
+		Assertions.assertEquals("getId", method.getName());
+		Assertions.assertEquals(0, method.getParameterTypes().length);
 
 		method = ReflectUtil.getMethod(ExamInfoDict.class, "getId", Integer.class);
-		Assert.assertEquals("getId", method.getName());
-		Assert.assertEquals(1, method.getParameterTypes().length);
+		Assertions.assertEquals("getId", method.getName());
+		Assertions.assertEquals(1, method.getParameterTypes().length);
 	}
 
 	@Test
 	public void getMethodIgnoreCaseTest() {
 		Method method = ReflectUtil.getMethodIgnoreCase(ExamInfoDict.class, "getId");
-		Assert.assertEquals("getId", method.getName());
-		Assert.assertEquals(0, method.getParameterTypes().length);
+		Assertions.assertEquals("getId", method.getName());
+		Assertions.assertEquals(0, method.getParameterTypes().length);
 
 		method = ReflectUtil.getMethodIgnoreCase(ExamInfoDict.class, "GetId");
-		Assert.assertEquals("getId", method.getName());
-		Assert.assertEquals(0, method.getParameterTypes().length);
+		Assertions.assertEquals("getId", method.getName());
+		Assertions.assertEquals(0, method.getParameterTypes().length);
 
 		method = ReflectUtil.getMethodIgnoreCase(ExamInfoDict.class, "setanswerIs", Integer.class);
-		Assert.assertEquals("setAnswerIs", method.getName());
-		Assert.assertEquals(1, method.getParameterTypes().length);
+		Assertions.assertEquals("setAnswerIs", method.getName());
+		Assertions.assertEquals(1, method.getParameterTypes().length);
 	}
 
 	@Test
 	public void getFieldTest() {
 		// 能够获取到父类字段
 		Field privateField = ReflectUtil.getField(TestSubClass.class, "privateField");
-		Assert.assertNotNull(privateField);
+		Assertions.assertNotNull(privateField);
 	}
 
 	@Test
 	public void getFieldsTest() {
 		// 能够获取到父类字段
 		final Field[] fields = ReflectUtil.getFields(TestSubClass.class);
-		Assert.assertEquals(4, fields.length);
+		Assertions.assertEquals(4, fields.length);
 	}
 
 	@Test
 	public void setFieldTest() {
 		TestClass testClass = new TestClass();
 		ReflectUtil.setFieldValue(testClass, "a", "111");
-		Assert.assertEquals(111, testClass.getA());
+		Assertions.assertEquals(111, testClass.getA());
 	}
 
 	@Test
 	public void invokeTest() {
 		TestClass testClass = new TestClass();
 		ReflectUtil.invoke(testClass, "setA", 10);
-		Assert.assertEquals(10, testClass.getA());
+		Assertions.assertEquals(10, testClass.getA());
 	}
 
 	@Test
 	public void noneStaticInnerClassTest() {
 		final TestAClass testAClass = ReflectUtil.newInstanceIfPossible(TestAClass.class);
-		Assert.assertNotNull(testAClass);
-		Assert.assertEquals(2, testAClass.getA());
+		Assertions.assertNotNull(testAClass);
+		Assertions.assertEquals(2, testAClass.getA());
 	}
 
 	static class TestClass {

--- a/hutool-core/src/test/java/cn/hutool/core/util/RuntimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/RuntimeUtilTest.java
@@ -1,9 +1,9 @@
 package cn.hutool.core.util;
 
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * 命令行单元测试
@@ -13,21 +13,21 @@ import org.junit.Test;
 public class RuntimeUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void execTest() {
 		String str = RuntimeUtil.execForStr("ipconfig");
 		Console.log(str);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void execCmdTest() {
 		String str = RuntimeUtil.execForStr("cmd /c dir");
 		Console.log(str);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void execCmdTest2() {
 		String str = RuntimeUtil.execForStr("cmd /c", "cd \"C:\\Program Files (x86)\"", "chdir");
 		Console.log(str);
@@ -35,6 +35,6 @@ public class RuntimeUtilTest {
 
 	@Test
 	public void getUsableMemoryTest(){
-		Assert.assertTrue(RuntimeUtil.getUsableMemory() > 0);
+		Assertions.assertTrue(RuntimeUtil.getUsableMemory() > 0);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.util;
 
 import cn.hutool.core.lang.Dict;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -16,32 +16,32 @@ public class StrUtilTest {
 	@Test
 	public void isBlankTest() {
 		String blank = "	  　";
-		Assert.assertTrue(StrUtil.isBlank(blank));
+		Assertions.assertTrue(StrUtil.isBlank(blank));
 	}
 
 	@Test
 	public void trimTest() {
 		String blank = "	 哈哈 　";
 		String trim = StrUtil.trim(blank);
-		Assert.assertEquals("哈哈", trim);
+		Assertions.assertEquals("哈哈", trim);
 	}
 
 	@Test
 	public void trimNewLineTest() {
 		String str = "\r\naaa";
-		Assert.assertEquals("aaa", StrUtil.trim(str));
+		Assertions.assertEquals("aaa", StrUtil.trim(str));
 		str = "\raaa";
-		Assert.assertEquals("aaa", StrUtil.trim(str));
+		Assertions.assertEquals("aaa", StrUtil.trim(str));
 		str = "\naaa";
-		Assert.assertEquals("aaa", StrUtil.trim(str));
+		Assertions.assertEquals("aaa", StrUtil.trim(str));
 		str = "\r\n\r\naaa";
-		Assert.assertEquals("aaa", StrUtil.trim(str));
+		Assertions.assertEquals("aaa", StrUtil.trim(str));
 	}
 
 	@Test
 	public void trimTabTest() {
 		String str = "\taaa";
-		Assert.assertEquals("aaa", StrUtil.trim(str));
+		Assertions.assertEquals("aaa", StrUtil.trim(str));
 	}
 
 	@Test
@@ -49,14 +49,14 @@ public class StrUtilTest {
 		// 包含：制表符、英文空格、不间断空白符、全角空格
 		String str = "	 你 好　";
 		String cleanBlank = StrUtil.cleanBlank(str);
-		Assert.assertEquals("你好", cleanBlank);
+		Assertions.assertEquals("你好", cleanBlank);
 	}
 
 	@Test
 	public void cutTest() {
 		String str = "aaabbbcccdddaadfdfsdfsdf0";
 		String[] cut = StrUtil.cut(str, 4);
-		Assert.assertArrayEquals(new String[]{"aaab", "bbcc", "cddd", "aadf", "dfsd", "fsdf", "0"}, cut);
+		Assertions.assertArrayEquals(new String[]{"aaab", "bbcc", "cddd", "aadf", "dfsd", "fsdf", "0"}, cut);
 	}
 
 	@Test
@@ -64,12 +64,12 @@ public class StrUtilTest {
 		String str = "a,b ,c,d,,e";
 		List<String> split = StrUtil.split(str, ',', -1, true, true);
 		// 测试空是否被去掉
-		Assert.assertEquals(5, split.size());
+		Assertions.assertEquals(5, split.size());
 		// 测试去掉两边空白符是否生效
-		Assert.assertEquals("b", split.get(1));
+		Assertions.assertEquals("b", split.get(1));
 
 		final String[] strings = StrUtil.splitToArray("abc/", '/');
-		Assert.assertEquals(2, strings.length);
+		Assertions.assertEquals(2, strings.length);
 	}
 
 	@Test
@@ -77,202 +77,206 @@ public class StrUtilTest {
 		String str = "";
 		List<String> split = StrUtil.split(str, ',', -1, true, true);
 		// 测试空是否被去掉
-		Assert.assertEquals(0, split.size());
+		Assertions.assertEquals(0, split.size());
 	}
 
 	@Test
 	public void splitTest2() {
 		String str = "a.b.";
 		List<String> split = StrUtil.split(str, '.');
-		Assert.assertEquals(3, split.size());
-		Assert.assertEquals("b", split.get(1));
-		Assert.assertEquals("", split.get(2));
+		Assertions.assertEquals(3, split.size());
+		Assertions.assertEquals("b", split.get(1));
+		Assertions.assertEquals("", split.get(2));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void splitNullTest() {
-		StrUtil.split(null, '.');
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			StrUtil.split(null, '.');
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void splitToArrayNullTest() {
-		StrUtil.splitToArray(null, '.');
+		Assertions.assertThrows(IllegalArgumentException.class, () -> {
+			StrUtil.splitToArray(null, '.');
+		});
 	}
 
 	@Test
 	public void splitToLongTest() {
 		String str = "1,2,3,4, 5";
 		long[] longArray = StrUtil.splitToLong(str, ',');
-		Assert.assertArrayEquals(new long[]{1, 2, 3, 4, 5}, longArray);
+		Assertions.assertArrayEquals(new long[]{1, 2, 3, 4, 5}, longArray);
 
 		longArray = StrUtil.splitToLong(str, ",");
-		Assert.assertArrayEquals(new long[]{1, 2, 3, 4, 5}, longArray);
+		Assertions.assertArrayEquals(new long[]{1, 2, 3, 4, 5}, longArray);
 	}
 
 	@Test
 	public void splitToIntTest() {
 		String str = "1,2,3,4, 5";
 		int[] intArray = StrUtil.splitToInt(str, ',');
-		Assert.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, intArray);
+		Assertions.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, intArray);
 
 		intArray = StrUtil.splitToInt(str, ",");
-		Assert.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, intArray);
+		Assertions.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, intArray);
 	}
 
 	@Test
 	public void formatTest() {
 		String template = "你好，我是{name}，我的电话是：{phone}";
 		String result = StrUtil.format(template, Dict.create().set("name", "张三").set("phone", "13888881111"));
-		Assert.assertEquals("你好，我是张三，我的电话是：13888881111", result);
+		Assertions.assertEquals("你好，我是张三，我的电话是：13888881111", result);
 
 		String result2 = StrUtil.format(template, Dict.create().set("name", "张三").set("phone", null));
-		Assert.assertEquals("你好，我是张三，我的电话是：{phone}", result2);
+		Assertions.assertEquals("你好，我是张三，我的电话是：{phone}", result2);
 	}
 
 	@Test
 	public void stripTest() {
 		String str = "abcd123";
 		String strip = StrUtil.strip(str, "ab", "23");
-		Assert.assertEquals("cd1", strip);
+		Assertions.assertEquals("cd1", strip);
 
 		str = "abcd123";
 		strip = StrUtil.strip(str, "ab", "");
-		Assert.assertEquals("cd123", strip);
+		Assertions.assertEquals("cd123", strip);
 
 		str = "abcd123";
 		strip = StrUtil.strip(str, null, "");
-		Assert.assertEquals("abcd123", strip);
+		Assertions.assertEquals("abcd123", strip);
 
 		str = "abcd123";
 		strip = StrUtil.strip(str, null, "567");
-		Assert.assertEquals("abcd123", strip);
+		Assertions.assertEquals("abcd123", strip);
 
-		Assert.assertEquals("", StrUtil.strip("a", "a"));
-		Assert.assertEquals("", StrUtil.strip("a", "a", "b"));
+		Assertions.assertEquals("", StrUtil.strip("a", "a"));
+		Assertions.assertEquals("", StrUtil.strip("a", "a", "b"));
 	}
 
 	@Test
 	public void stripIgnoreCaseTest() {
 		String str = "abcd123";
 		String strip = StrUtil.stripIgnoreCase(str, "Ab", "23");
-		Assert.assertEquals("cd1", strip);
+		Assertions.assertEquals("cd1", strip);
 
 		str = "abcd123";
 		strip = StrUtil.stripIgnoreCase(str, "AB", "");
-		Assert.assertEquals("cd123", strip);
+		Assertions.assertEquals("cd123", strip);
 
 		str = "abcd123";
 		strip = StrUtil.stripIgnoreCase(str, "ab", "");
-		Assert.assertEquals("cd123", strip);
+		Assertions.assertEquals("cd123", strip);
 
 		str = "abcd123";
 		strip = StrUtil.stripIgnoreCase(str, null, "");
-		Assert.assertEquals("abcd123", strip);
+		Assertions.assertEquals("abcd123", strip);
 
 		str = "abcd123";
 		strip = StrUtil.stripIgnoreCase(str, null, "567");
-		Assert.assertEquals("abcd123", strip);
+		Assertions.assertEquals("abcd123", strip);
 	}
 
 	@Test
 	public void indexOfIgnoreCaseTest() {
-		Assert.assertEquals(-1, StrUtil.indexOfIgnoreCase(null, "balabala", 0));
-		Assert.assertEquals(-1, StrUtil.indexOfIgnoreCase("balabala", null, 0));
-		Assert.assertEquals(0, StrUtil.indexOfIgnoreCase("", "", 0));
-		Assert.assertEquals(0, StrUtil.indexOfIgnoreCase("aabaabaa", "A", 0));
-		Assert.assertEquals(2, StrUtil.indexOfIgnoreCase("aabaabaa", "B", 0));
-		Assert.assertEquals(1, StrUtil.indexOfIgnoreCase("aabaabaa", "AB", 0));
-		Assert.assertEquals(5, StrUtil.indexOfIgnoreCase("aabaabaa", "B", 3));
-		Assert.assertEquals(-1, StrUtil.indexOfIgnoreCase("aabaabaa", "B", 9));
-		Assert.assertEquals(2, StrUtil.indexOfIgnoreCase("aabaabaa", "B", -1));
-		Assert.assertEquals(-1, StrUtil.indexOfIgnoreCase("aabaabaa", "", 2));
-		Assert.assertEquals(-1, StrUtil.indexOfIgnoreCase("abc", "", 9));
+		Assertions.assertEquals(-1, StrUtil.indexOfIgnoreCase(null, "balabala", 0));
+		Assertions.assertEquals(-1, StrUtil.indexOfIgnoreCase("balabala", null, 0));
+		Assertions.assertEquals(0, StrUtil.indexOfIgnoreCase("", "", 0));
+		Assertions.assertEquals(0, StrUtil.indexOfIgnoreCase("aabaabaa", "A", 0));
+		Assertions.assertEquals(2, StrUtil.indexOfIgnoreCase("aabaabaa", "B", 0));
+		Assertions.assertEquals(1, StrUtil.indexOfIgnoreCase("aabaabaa", "AB", 0));
+		Assertions.assertEquals(5, StrUtil.indexOfIgnoreCase("aabaabaa", "B", 3));
+		Assertions.assertEquals(-1, StrUtil.indexOfIgnoreCase("aabaabaa", "B", 9));
+		Assertions.assertEquals(2, StrUtil.indexOfIgnoreCase("aabaabaa", "B", -1));
+		Assertions.assertEquals(-1, StrUtil.indexOfIgnoreCase("aabaabaa", "", 2));
+		Assertions.assertEquals(-1, StrUtil.indexOfIgnoreCase("abc", "", 9));
 	}
 
 	@Test
 	public void lastIndexOfTest() {
 		String a = "aabbccddcc";
 		int lastIndexOf = StrUtil.lastIndexOf(a, "c", 0, false);
-		Assert.assertEquals(-1, lastIndexOf);
+		Assertions.assertEquals(-1, lastIndexOf);
 	}
 
 	@Test
 	public void lastIndexOfIgnoreCaseTest() {
-		Assert.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase(null, "balabala", 0));
-		Assert.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("balabala", null));
-		Assert.assertEquals(0, StrUtil.lastIndexOfIgnoreCase("", ""));
-		Assert.assertEquals(7, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "A"));
-		Assert.assertEquals(5, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B"));
-		Assert.assertEquals(4, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "AB"));
-		Assert.assertEquals(2, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B", 3));
-		Assert.assertEquals(5, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B", 9));
-		Assert.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B", -1));
-		Assert.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "", 2));
-		Assert.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("abc", "", 9));
-		Assert.assertEquals(0, StrUtil.lastIndexOfIgnoreCase("AAAcsd", "aaa"));
+		Assertions.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase(null, "balabala", 0));
+		Assertions.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("balabala", null));
+		Assertions.assertEquals(0, StrUtil.lastIndexOfIgnoreCase("", ""));
+		Assertions.assertEquals(7, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "A"));
+		Assertions.assertEquals(5, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B"));
+		Assertions.assertEquals(4, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "AB"));
+		Assertions.assertEquals(2, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B", 3));
+		Assertions.assertEquals(5, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B", 9));
+		Assertions.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "B", -1));
+		Assertions.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("aabaabaa", "", 2));
+		Assertions.assertEquals(-1, StrUtil.lastIndexOfIgnoreCase("abc", "", 9));
+		Assertions.assertEquals(0, StrUtil.lastIndexOfIgnoreCase("AAAcsd", "aaa"));
 	}
 
 	@Test
 	public void replaceTest() {
 		String string = StrUtil.replace("aabbccdd", 2, 6, '*');
-		Assert.assertEquals("aa****dd", string);
+		Assertions.assertEquals("aa****dd", string);
 		string = StrUtil.replace("aabbccdd", 2, 12, '*');
-		Assert.assertEquals("aa******", string);
+		Assertions.assertEquals("aa******", string);
 	}
 
 	@Test
 	public void replaceTest2() {
 		String result = StrUtil.replace("123", "2", "3");
-		Assert.assertEquals("133", result);
+		Assertions.assertEquals("133", result);
 	}
 
 	@Test
 	public void replaceTest3() {
 		String result = StrUtil.replace(",abcdef,", ",", "|");
-		Assert.assertEquals("|abcdef|", result);
+		Assertions.assertEquals("|abcdef|", result);
 	}
 
 	@Test
 	public void replaceTest4() {
 		String a = "1039";
 		String result = StrUtil.padPre(a, 8, "0"); //在字符串1039前补4个0
-		Assert.assertEquals("00001039", result);
+		Assertions.assertEquals("00001039", result);
 
 		String aa = "1039";
 		String result1 = StrUtil.padPre(aa, -1, "0"); //在字符串1039前补4个0
-		Assert.assertEquals("103", result1);
+		Assertions.assertEquals("103", result1);
 	}
 
 	@Test
 	public void replaceTest5() {
 		String a = "\uD853\uDC09秀秀";
 		String result = StrUtil.replace(a, 1, a.length(), '*');
-		Assert.assertEquals("\uD853\uDC09**", result);
+		Assertions.assertEquals("\uD853\uDC09**", result);
 
 		String aa = "规划大师";
 		String result1 = StrUtil.replace(aa, 2, a.length(), '*');
-		Assert.assertEquals("规划**", result1);
+		Assertions.assertEquals("规划**", result1);
 	}
 
 	@Test
 	public void upperFirstTest() {
 		StringBuilder sb = new StringBuilder("KEY");
 		String s = StrUtil.upperFirst(sb);
-		Assert.assertEquals(s, sb.toString());
+		Assertions.assertEquals(s, sb.toString());
 	}
 
 	@Test
 	public void lowerFirstTest() {
 		StringBuilder sb = new StringBuilder("KEY");
 		String s = StrUtil.lowerFirst(sb);
-		Assert.assertEquals("kEY", s);
+		Assertions.assertEquals("kEY", s);
 	}
 
 	@Test
 	public void subTest() {
 		String a = "abcderghigh";
 		String pre = StrUtil.sub(a, -5, a.length());
-		Assert.assertEquals("ghigh", pre);
+		Assertions.assertEquals("ghigh", pre);
 	}
 
 	@Test
@@ -282,133 +286,133 @@ public class StrUtilTest {
 
 		// 不正确的子字符串
 		String wrongAnswer = StrUtil.sub(test, 0, 3);
-		Assert.assertNotEquals("\uD83E\uDD14\uD83D\uDC4D\uD83C\uDF53", wrongAnswer);
+		Assertions.assertNotEquals("\uD83E\uDD14\uD83D\uDC4D\uD83C\uDF53", wrongAnswer);
 
 		// 正确的子字符串
 		String rightAnswer = StrUtil.subByCodePoint(test, 0, 3);
-		Assert.assertEquals("\uD83E\uDD14\uD83D\uDC4D\uD83C\uDF53", rightAnswer);
+		Assertions.assertEquals("\uD83E\uDD14\uD83D\uDC4D\uD83C\uDF53", rightAnswer);
 	}
 
 	@Test
 	public void subBeforeTest() {
 		String a = "abcderghigh";
 		String pre = StrUtil.subBefore(a, "d", false);
-		Assert.assertEquals("abc", pre);
+		Assertions.assertEquals("abc", pre);
 		pre = StrUtil.subBefore(a, 'd', false);
-		Assert.assertEquals("abc", pre);
+		Assertions.assertEquals("abc", pre);
 		pre = StrUtil.subBefore(a, 'a', false);
-		Assert.assertEquals("", pre);
+		Assertions.assertEquals("", pre);
 
 		//找不到返回原串
 		pre = StrUtil.subBefore(a, 'k', false);
-		Assert.assertEquals(a, pre);
+		Assertions.assertEquals(a, pre);
 		pre = StrUtil.subBefore(a, 'k', true);
-		Assert.assertEquals(a, pre);
+		Assertions.assertEquals(a, pre);
 	}
 
 	@Test
 	public void subAfterTest() {
 		String a = "abcderghigh";
 		String pre = StrUtil.subAfter(a, "d", false);
-		Assert.assertEquals("erghigh", pre);
+		Assertions.assertEquals("erghigh", pre);
 		pre = StrUtil.subAfter(a, 'd', false);
-		Assert.assertEquals("erghigh", pre);
+		Assertions.assertEquals("erghigh", pre);
 		pre = StrUtil.subAfter(a, 'h', true);
-		Assert.assertEquals("", pre);
+		Assertions.assertEquals("", pre);
 
 		//找不到字符返回空串
 		pre = StrUtil.subAfter(a, 'k', false);
-		Assert.assertEquals("", pre);
+		Assertions.assertEquals("", pre);
 		pre = StrUtil.subAfter(a, 'k', true);
-		Assert.assertEquals("", pre);
+		Assertions.assertEquals("", pre);
 	}
 
 	@Test
 	public void subSufByLengthTest() {
-		Assert.assertEquals("cde", StrUtil.subSufByLength("abcde", 3));
-		Assert.assertEquals("", StrUtil.subSufByLength("abcde", -1));
-		Assert.assertEquals("", StrUtil.subSufByLength("abcde", 0));
-		Assert.assertEquals("abcde", StrUtil.subSufByLength("abcde", 5));
-		Assert.assertEquals("abcde", StrUtil.subSufByLength("abcde", 10));
+		Assertions.assertEquals("cde", StrUtil.subSufByLength("abcde", 3));
+		Assertions.assertEquals("", StrUtil.subSufByLength("abcde", -1));
+		Assertions.assertEquals("", StrUtil.subSufByLength("abcde", 0));
+		Assertions.assertEquals("abcde", StrUtil.subSufByLength("abcde", 5));
+		Assertions.assertEquals("abcde", StrUtil.subSufByLength("abcde", 10));
 	}
 
 	@Test
 	public void repeatAndJoinTest() {
 		String repeatAndJoin = StrUtil.repeatAndJoin("?", 5, ",");
-		Assert.assertEquals("?,?,?,?,?", repeatAndJoin);
+		Assertions.assertEquals("?,?,?,?,?", repeatAndJoin);
 
 		repeatAndJoin = StrUtil.repeatAndJoin("?", 0, ",");
-		Assert.assertEquals("", repeatAndJoin);
+		Assertions.assertEquals("", repeatAndJoin);
 
 		repeatAndJoin = StrUtil.repeatAndJoin("?", 5, null);
-		Assert.assertEquals("?????", repeatAndJoin);
+		Assertions.assertEquals("?????", repeatAndJoin);
 	}
 
 	@Test
 	public void moveTest() {
 		String str = "aaaaaaa22222bbbbbbb";
 		String result = StrUtil.move(str, 7, 12, -3);
-		Assert.assertEquals("aaaa22222aaabbbbbbb", result);
+		Assertions.assertEquals("aaaa22222aaabbbbbbb", result);
 		result = StrUtil.move(str, 7, 12, -4);
-		Assert.assertEquals("aaa22222aaaabbbbbbb", result);
+		Assertions.assertEquals("aaa22222aaaabbbbbbb", result);
 		result = StrUtil.move(str, 7, 12, -7);
-		Assert.assertEquals("22222aaaaaaabbbbbbb", result);
+		Assertions.assertEquals("22222aaaaaaabbbbbbb", result);
 		result = StrUtil.move(str, 7, 12, -20);
-		Assert.assertEquals("aaaaaa22222abbbbbbb", result);
+		Assertions.assertEquals("aaaaaa22222abbbbbbb", result);
 
 		result = StrUtil.move(str, 7, 12, 3);
-		Assert.assertEquals("aaaaaaabbb22222bbbb", result);
+		Assertions.assertEquals("aaaaaaabbb22222bbbb", result);
 		result = StrUtil.move(str, 7, 12, 7);
-		Assert.assertEquals("aaaaaaabbbbbbb22222", result);
+		Assertions.assertEquals("aaaaaaabbbbbbb22222", result);
 		result = StrUtil.move(str, 7, 12, 20);
-		Assert.assertEquals("aaaaaaab22222bbbbbb", result);
+		Assertions.assertEquals("aaaaaaab22222bbbbbb", result);
 
 		result = StrUtil.move(str, 7, 12, 0);
-		Assert.assertEquals("aaaaaaa22222bbbbbbb", result);
+		Assertions.assertEquals("aaaaaaa22222bbbbbbb", result);
 	}
 
 	@Test
 	public void removePrefixIgnorecaseTest() {
 		String a = "aaabbb";
 		String prefix = "aaa";
-		Assert.assertEquals("bbb", StrUtil.removePrefixIgnoreCase(a, prefix));
+		Assertions.assertEquals("bbb", StrUtil.removePrefixIgnoreCase(a, prefix));
 
 		prefix = "AAA";
-		Assert.assertEquals("bbb", StrUtil.removePrefixIgnoreCase(a, prefix));
+		Assertions.assertEquals("bbb", StrUtil.removePrefixIgnoreCase(a, prefix));
 
 		prefix = "AAABBB";
-		Assert.assertEquals("", StrUtil.removePrefixIgnoreCase(a, prefix));
+		Assertions.assertEquals("", StrUtil.removePrefixIgnoreCase(a, prefix));
 	}
 
 	@Test
 	public void maxLengthTest() {
 		String text = "我是一段正文，很长的正文，需要截取的正文";
 		String str = StrUtil.maxLength(text, 5);
-		Assert.assertEquals("我是一段正...", str);
+		Assertions.assertEquals("我是一段正...", str);
 		str = StrUtil.maxLength(text, 21);
-		Assert.assertEquals(text, str);
+		Assertions.assertEquals(text, str);
 		str = StrUtil.maxLength(text, 50);
-		Assert.assertEquals(text, str);
+		Assertions.assertEquals(text, str);
 	}
 
 	@Test
 	public void toCamelCaseTest() {
 		String str = "Table_Test_Of_day";
 		String result = StrUtil.toCamelCase(str);
-		Assert.assertEquals("tableTestOfDay", result);
+		Assertions.assertEquals("tableTestOfDay", result);
 
 		String str1 = "TableTestOfDay";
 		String result1 = StrUtil.toCamelCase(str1);
-		Assert.assertEquals("TableTestOfDay", result1);
+		Assertions.assertEquals("TableTestOfDay", result1);
 
 		String abc1d = StrUtil.toCamelCase("abc_1d");
-		Assert.assertEquals("abc1d", abc1d);
+		Assertions.assertEquals("abc1d", abc1d);
 
 
 		String str2 = "Table-Test-Of-day";
 		String result2 = StrUtil.toCamelCase(str2, CharUtil.DASHED);
 		System.out.println(result2);
-		Assert.assertEquals("tableTestOfDay", result2);
+		Assertions.assertEquals("tableTestOfDay", result2);
 	}
 
 	@Test
@@ -421,77 +425,77 @@ public class StrUtilTest {
 				.set("HelloWorld_test", "hello_world_test")
 				.set("H2", "H2")
 				.set("H#case", "H#case")
-				.forEach((key, value) -> Assert.assertEquals(value, StrUtil.toUnderlineCase(key)));
+				.forEach((key, value) -> Assertions.assertEquals(value, StrUtil.toUnderlineCase(key)));
 	}
 
 	@Test
 	public void toUnderLineCaseTest2() {
 		Dict.create()
 				.set("PNLabel", "PN_label")
-				.forEach((key, value) -> Assert.assertEquals(value, StrUtil.toUnderlineCase(key)));
+				.forEach((key, value) -> Assertions.assertEquals(value, StrUtil.toUnderlineCase(key)));
 	}
 
 	@Test
 	public void containsAnyTest() {
 		//字符
 		boolean containsAny = StrUtil.containsAny("aaabbbccc", 'a', 'd');
-		Assert.assertTrue(containsAny);
+		Assertions.assertTrue(containsAny);
 		containsAny = StrUtil.containsAny("aaabbbccc", 'e', 'd');
-		Assert.assertFalse(containsAny);
+		Assertions.assertFalse(containsAny);
 		containsAny = StrUtil.containsAny("aaabbbccc", 'd', 'c');
-		Assert.assertTrue(containsAny);
+		Assertions.assertTrue(containsAny);
 
 		//字符串
 		containsAny = StrUtil.containsAny("aaabbbccc", "a", "d");
-		Assert.assertTrue(containsAny);
+		Assertions.assertTrue(containsAny);
 		containsAny = StrUtil.containsAny("aaabbbccc", "e", "d");
-		Assert.assertFalse(containsAny);
+		Assertions.assertFalse(containsAny);
 		containsAny = StrUtil.containsAny("aaabbbccc", "d", "c");
-		Assert.assertTrue(containsAny);
+		Assertions.assertTrue(containsAny);
 	}
 
 	@Test
 	public void centerTest() {
-		Assert.assertNull(StrUtil.center(null, 10));
-		Assert.assertEquals("    ", StrUtil.center("", 4));
-		Assert.assertEquals("ab", StrUtil.center("ab", -1));
-		Assert.assertEquals(" ab ", StrUtil.center("ab", 4));
-		Assert.assertEquals("abcd", StrUtil.center("abcd", 2));
-		Assert.assertEquals(" a  ", StrUtil.center("a", 4));
+		Assertions.assertNull(StrUtil.center(null, 10));
+		Assertions.assertEquals("    ", StrUtil.center("", 4));
+		Assertions.assertEquals("ab", StrUtil.center("ab", -1));
+		Assertions.assertEquals(" ab ", StrUtil.center("ab", 4));
+		Assertions.assertEquals("abcd", StrUtil.center("abcd", 2));
+		Assertions.assertEquals(" a  ", StrUtil.center("a", 4));
 	}
 
 	@Test
 	public void padPreTest() {
-		Assert.assertNull(StrUtil.padPre(null, 10, ' '));
-		Assert.assertEquals("001", StrUtil.padPre("1", 3, '0'));
-		Assert.assertEquals("12", StrUtil.padPre("123", 2, '0'));
+		Assertions.assertNull(StrUtil.padPre(null, 10, ' '));
+		Assertions.assertEquals("001", StrUtil.padPre("1", 3, '0'));
+		Assertions.assertEquals("12", StrUtil.padPre("123", 2, '0'));
 
-		Assert.assertNull(StrUtil.padPre(null, 10, "AA"));
-		Assert.assertEquals("AB1", StrUtil.padPre("1", 3, "ABC"));
-		Assert.assertEquals("12", StrUtil.padPre("123", 2, "ABC"));
+		Assertions.assertNull(StrUtil.padPre(null, 10, "AA"));
+		Assertions.assertEquals("AB1", StrUtil.padPre("1", 3, "ABC"));
+		Assertions.assertEquals("12", StrUtil.padPre("123", 2, "ABC"));
 	}
 
 	@Test
 	public void padAfterTest() {
-		Assert.assertNull(StrUtil.padAfter(null, 10, ' '));
-		Assert.assertEquals("100", StrUtil.padAfter("1", 3, '0'));
-		Assert.assertEquals("23", StrUtil.padAfter("123", 2, '0'));
-		Assert.assertEquals("", StrUtil.padAfter("123", -1, '0'));
+		Assertions.assertNull(StrUtil.padAfter(null, 10, ' '));
+		Assertions.assertEquals("100", StrUtil.padAfter("1", 3, '0'));
+		Assertions.assertEquals("23", StrUtil.padAfter("123", 2, '0'));
+		Assertions.assertEquals("", StrUtil.padAfter("123", -1, '0'));
 
-		Assert.assertNull(StrUtil.padAfter(null, 10, "ABC"));
-		Assert.assertEquals("1AB", StrUtil.padAfter("1", 3, "ABC"));
-		Assert.assertEquals("23", StrUtil.padAfter("123", 2, "ABC"));
+		Assertions.assertNull(StrUtil.padAfter(null, 10, "ABC"));
+		Assertions.assertEquals("1AB", StrUtil.padAfter("1", 3, "ABC"));
+		Assertions.assertEquals("23", StrUtil.padAfter("123", 2, "ABC"));
 	}
 
 	@Test
 	public void subBetweenAllTest() {
-		Assert.assertArrayEquals(new String[]{"yz", "abc"}, StrUtil.subBetweenAll("saho[yz]fdsadp[abc]a", "[", "]"));
-		Assert.assertArrayEquals(new String[]{"abc"}, StrUtil.subBetweenAll("saho[yzfdsadp[abc]a]", "[", "]"));
-		Assert.assertArrayEquals(new String[]{"abc", "abc"}, StrUtil.subBetweenAll("yabczyabcz", "y", "z"));
-		Assert.assertArrayEquals(new String[0], StrUtil.subBetweenAll(null, "y", "z"));
-		Assert.assertArrayEquals(new String[0], StrUtil.subBetweenAll("", "y", "z"));
-		Assert.assertArrayEquals(new String[0], StrUtil.subBetweenAll("abc", null, "z"));
-		Assert.assertArrayEquals(new String[0], StrUtil.subBetweenAll("abc", "y", null));
+		Assertions.assertArrayEquals(new String[]{"yz", "abc"}, StrUtil.subBetweenAll("saho[yz]fdsadp[abc]a", "[", "]"));
+		Assertions.assertArrayEquals(new String[]{"abc"}, StrUtil.subBetweenAll("saho[yzfdsadp[abc]a]", "[", "]"));
+		Assertions.assertArrayEquals(new String[]{"abc", "abc"}, StrUtil.subBetweenAll("yabczyabcz", "y", "z"));
+		Assertions.assertArrayEquals(new String[0], StrUtil.subBetweenAll(null, "y", "z"));
+		Assertions.assertArrayEquals(new String[0], StrUtil.subBetweenAll("", "y", "z"));
+		Assertions.assertArrayEquals(new String[0], StrUtil.subBetweenAll("abc", null, "z"));
+		Assertions.assertArrayEquals(new String[0], StrUtil.subBetweenAll("abc", "y", null));
 	}
 
 	@Test
@@ -501,30 +505,30 @@ public class StrUtilTest {
 		String src2 = "/ * hutool  */  asdas  / * hutool  */";
 
 		String[] results1 = StrUtil.subBetweenAll(src1, "/**", "*/");
-		Assert.assertEquals(0, results1.length);
+		Assertions.assertEquals(0, results1.length);
 
 		String[] results2 = StrUtil.subBetweenAll(src2, "/*", "*/");
-		Assert.assertEquals(0, results2.length);
+		Assertions.assertEquals(0, results2.length);
 	}
 
 	@Test
 	public void subBetweenAllTest3() {
 		String src1 = "'abc'and'123'";
 		String[] strings = StrUtil.subBetweenAll(src1, "'", "'");
-		Assert.assertEquals(2, strings.length);
-		Assert.assertEquals("abc", strings[0]);
-		Assert.assertEquals("123", strings[1]);
+		Assertions.assertEquals(2, strings.length);
+		Assertions.assertEquals("abc", strings[0]);
+		Assertions.assertEquals("123", strings[1]);
 
 		String src2 = "'abc''123'";
 		strings = StrUtil.subBetweenAll(src2, "'", "'");
-		Assert.assertEquals(2, strings.length);
-		Assert.assertEquals("abc", strings[0]);
-		Assert.assertEquals("123", strings[1]);
+		Assertions.assertEquals(2, strings.length);
+		Assertions.assertEquals("abc", strings[0]);
+		Assertions.assertEquals("123", strings[1]);
 
 		String src3 = "'abc'123'";
 		strings = StrUtil.subBetweenAll(src3, "'", "'");
-		Assert.assertEquals(1, strings.length);
-		Assert.assertEquals("abc", strings[0]);
+		Assertions.assertEquals(1, strings.length);
+		Assertions.assertEquals("abc", strings[0]);
 	}
 
 	@Test
@@ -532,7 +536,7 @@ public class StrUtilTest {
 		String str = RandomUtil.randomString(1000);
 		int maxLength = RandomUtil.randomInt(1000);
 		String brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals(brief.length(), maxLength);
+		Assertions.assertEquals(brief.length(), maxLength);
 	}
 
 	@Test
@@ -540,15 +544,15 @@ public class StrUtilTest {
 		String str = "123";
 		int maxLength = 3;
 		String brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals("123", brief);
+		Assertions.assertEquals("123", brief);
 
 		maxLength = 2;
 		brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals("1.", brief);
+		Assertions.assertEquals("1.", brief);
 
 		maxLength = 1;
 		brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals("1", brief);
+		Assertions.assertEquals("1", brief);
 	}
 
 	@Test
@@ -556,32 +560,32 @@ public class StrUtilTest {
 		String str = "123abc";
 		int maxLength = 3;
 		String brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals("1.c", brief);
+		Assertions.assertEquals("1.c", brief);
 
 		maxLength = 2;
 		brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals("1.", brief);
+		Assertions.assertEquals("1.", brief);
 
 		maxLength = 1;
 		brief = StrUtil.brief(str, maxLength);
-		Assert.assertEquals("1", brief);
+		Assertions.assertEquals("1", brief);
 	}
 
 	@Test
 	public void filterTest() {
 		final String filterNumber = StrUtil.filter("hutool678", CharUtil::isNumber);
-		Assert.assertEquals("678", filterNumber);
+		Assertions.assertEquals("678", filterNumber);
 		String cleanBlank = StrUtil.filter("	 你 好　", c -> !CharUtil.isBlankChar(c));
-		Assert.assertEquals("你好", cleanBlank);
+		Assertions.assertEquals("你好", cleanBlank);
 	}
 
 	@Test
 	public void wrapAllTest() {
 		String[] strings = StrUtil.wrapAll("`", "`", StrUtil.splitToArray("1,2,3,4", ','));
-		Assert.assertEquals("[`1`, `2`, `3`, `4`]", StrUtil.utf8Str(strings));
+		Assertions.assertEquals("[`1`, `2`, `3`, `4`]", StrUtil.utf8Str(strings));
 
 		strings = StrUtil.wrapAllWithPair("`", StrUtil.splitToArray("1,2,3,4", ','));
-		Assert.assertEquals("[`1`, `2`, `3`, `4`]", StrUtil.utf8Str(strings));
+		Assertions.assertEquals("[`1`, `2`, `3`, `4`]", StrUtil.utf8Str(strings));
 	}
 
 	@Test
@@ -589,37 +593,37 @@ public class StrUtilTest {
 		String a = "123";
 		String b = "123";
 
-		Assert.assertTrue(StrUtil.startWith(a, b));
-		Assert.assertFalse(StrUtil.startWithIgnoreEquals(a, b));
+		Assertions.assertTrue(StrUtil.startWith(a, b));
+		Assertions.assertFalse(StrUtil.startWithIgnoreEquals(a, b));
 	}
 
 	@Test
 	public void indexedFormatTest() {
 		final String ret = StrUtil.indexedFormat("this is {0} for {1}", "a", 1000);
-		Assert.assertEquals("this is a for 1,000", ret);
+		Assertions.assertEquals("this is a for 1,000", ret);
 	}
 
 	@Test
 	public void hideTest() {
-		Assert.assertNull(StrUtil.hide(null, 1, 1));
-		Assert.assertEquals("", StrUtil.hide("", 1, 1));
-		Assert.assertEquals("****duan@163.com", StrUtil.hide("jackduan@163.com", -1, 4));
-		Assert.assertEquals("ja*kduan@163.com", StrUtil.hide("jackduan@163.com", 2, 3));
-		Assert.assertEquals("jackduan@163.com", StrUtil.hide("jackduan@163.com", 3, 2));
-		Assert.assertEquals("jackduan@163.com", StrUtil.hide("jackduan@163.com", 16, 16));
-		Assert.assertEquals("jackduan@163.com", StrUtil.hide("jackduan@163.com", 16, 17));
+		Assertions.assertNull(StrUtil.hide(null, 1, 1));
+		Assertions.assertEquals("", StrUtil.hide("", 1, 1));
+		Assertions.assertEquals("****duan@163.com", StrUtil.hide("jackduan@163.com", -1, 4));
+		Assertions.assertEquals("ja*kduan@163.com", StrUtil.hide("jackduan@163.com", 2, 3));
+		Assertions.assertEquals("jackduan@163.com", StrUtil.hide("jackduan@163.com", 3, 2));
+		Assertions.assertEquals("jackduan@163.com", StrUtil.hide("jackduan@163.com", 16, 16));
+		Assertions.assertEquals("jackduan@163.com", StrUtil.hide("jackduan@163.com", 16, 17));
 	}
 
 
 	@Test
 	public void isCharEqualsTest() {
 		String a = "aaaaaaaaa";
-		Assert.assertTrue(StrUtil.isCharEquals(a));
+		Assertions.assertTrue(StrUtil.isCharEquals(a));
 	}
 
 	@Test
 	public void isNumericTest() {
 		String a = "2142342422423423";
-		Assert.assertTrue(StrUtil.isNumeric(a));
+		Assertions.assertTrue(StrUtil.isNumeric(a));
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/TypeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/TypeUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.core.util;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -10,32 +10,32 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TypeUtilTest {
-	
+
 	@Test
 	public void getEleTypeTest() {
 		Method method = ReflectUtil.getMethod(TestClass.class, "getList");
 		Type type = TypeUtil.getReturnType(method);
-		Assert.assertEquals("java.util.List<java.lang.String>", type.toString());
-		
+		Assertions.assertEquals("java.util.List<java.lang.String>", type.toString());
+
 		Type type2 = TypeUtil.getTypeArgument(type);
-		Assert.assertEquals(String.class, type2);
+		Assertions.assertEquals(String.class, type2);
 	}
-	
+
 	@Test
 	public void getParamTypeTest() {
 		Method method = ReflectUtil.getMethod(TestClass.class, "intTest", Integer.class);
 		Type type = TypeUtil.getParamType(method, 0);
-		Assert.assertEquals(Integer.class, type);
-		
+		Assertions.assertEquals(Integer.class, type);
+
 		Type returnType = TypeUtil.getReturnType(method);
-		Assert.assertEquals(Integer.class, returnType);
+		Assertions.assertEquals(Integer.class, returnType);
 	}
-	
+
 	public static class TestClass {
 		public List<String> getList(){
 			return new ArrayList<>();
 		}
-		
+
 		public Integer intTest(Integer integer) {
 			return 1;
 		}
@@ -45,7 +45,7 @@ public class TypeUtilTest {
 	public void getTypeArgumentTest(){
 		// 测试不继承父类，而是实现泛型接口时是否可以获取成功。
 		final Type typeArgument = TypeUtil.getTypeArgument(IPService.class);
-		Assert.assertEquals(String.class, typeArgument);
+		Assertions.assertEquals(String.class, typeArgument);
 	}
 
 	public interface OperateService<T> {
@@ -64,7 +64,7 @@ public class TypeUtilTest {
 		Type idType = TypeUtil.getActualType(Level3.class,
 				ReflectUtil.getField(Level3.class, "id"));
 
-		Assert.assertEquals(Long.class, idType);
+		Assertions.assertEquals(Long.class, idType);
 	}
 
 	public static class Level3 extends Level2<Level3>{

--- a/hutool-core/src/test/java/cn/hutool/core/util/URLUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/URLUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.core.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -20,51 +20,51 @@ public class URLUtilTest {
 		// issue#I25MZL，多个/被允许
 		String url = "http://www.hutool.cn//aaa/bbb";
 		String normalize = URLUtil.normalize(url);
-		Assert.assertEquals("http://www.hutool.cn//aaa/bbb", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa/bbb", normalize);
 
 		url = "www.hutool.cn//aaa/bbb";
 		normalize = URLUtil.normalize(url);
-		Assert.assertEquals("http://www.hutool.cn//aaa/bbb", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa/bbb", normalize);
 	}
 
 	@Test
 	public void normalizeTest2() {
 		String url = "http://www.hutool.cn//aaa/\\bbb?a=1&b=2";
 		String normalize = URLUtil.normalize(url);
-		Assert.assertEquals("http://www.hutool.cn//aaa//bbb?a=1&b=2", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa//bbb?a=1&b=2", normalize);
 
 		url = "www.hutool.cn//aaa/bbb?a=1&b=2";
 		normalize = URLUtil.normalize(url);
-		Assert.assertEquals("http://www.hutool.cn//aaa/bbb?a=1&b=2", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa/bbb?a=1&b=2", normalize);
 	}
 
 	@Test
 	public void normalizeTest3() {
 		String url = "http://www.hutool.cn//aaa/\\bbb?a=1&b=2";
 		String normalize = URLUtil.normalize(url, true);
-		Assert.assertEquals("http://www.hutool.cn//aaa//bbb?a=1&b=2", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa//bbb?a=1&b=2", normalize);
 
 		url = "www.hutool.cn//aaa/bbb?a=1&b=2";
 		normalize = URLUtil.normalize(url, true);
-		Assert.assertEquals("http://www.hutool.cn//aaa/bbb?a=1&b=2", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa/bbb?a=1&b=2", normalize);
 
 		url = "\\/www.hutool.cn//aaa/bbb?a=1&b=2";
 		normalize = URLUtil.normalize(url, true);
-		Assert.assertEquals("http://www.hutool.cn//aaa/bbb?a=1&b=2", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa/bbb?a=1&b=2", normalize);
 	}
 
 	@Test
 	public void normalizeIpv6Test() {
 		String url = "http://[fe80::8f8:2022:a603:d180]:9439";
 		String normalize = URLUtil.normalize("http://[fe80::8f8:2022:a603:d180]:9439", true);
-		Assert.assertEquals(url, normalize);
+		Assertions.assertEquals(url, normalize);
 	}
 
 	@Test
 	public void formatTest() {
 		String url = "//www.hutool.cn//aaa/\\bbb?a=1&b=2";
 		String normalize = URLUtil.normalize(url);
-		Assert.assertEquals("http://www.hutool.cn//aaa//bbb?a=1&b=2", normalize);
+		Assertions.assertEquals("http://www.hutool.cn//aaa//bbb?a=1&b=2", normalize);
 	}
 
 	@Test
@@ -72,24 +72,24 @@ public class URLUtilTest {
 		String url = "https://www.hutool.cn//aaa/\\bbb?a=1&b=2";
 		String normalize = URLUtil.normalize(url);
 		URI host = URLUtil.getHost(new URL(normalize));
-		Assert.assertEquals("https://www.hutool.cn", host.toString());
+		Assertions.assertEquals("https://www.hutool.cn", host.toString());
 	}
 
 	@Test
 	public void encodeTest() {
 		String body = "366466 - 副本.jpg";
 		String encode = URLUtil.encode(body);
-		Assert.assertEquals("366466%20-%20%E5%89%AF%E6%9C%AC.jpg", encode);
-		Assert.assertEquals(body, URLUtil.decode(encode));
+		Assertions.assertEquals("366466%20-%20%E5%89%AF%E6%9C%AC.jpg", encode);
+		Assertions.assertEquals(body, URLUtil.decode(encode));
 
 		String encode2 = URLUtil.encodeQuery(body);
-		Assert.assertEquals("366466+-+%E5%89%AF%E6%9C%AC.jpg", encode2);
+		Assertions.assertEquals("366466+-+%E5%89%AF%E6%9C%AC.jpg", encode2);
 	}
 
 	@Test
 	public void getPathTest(){
 		String url = " http://www.aaa.bbb/search?scope=ccc&q=ddd";
 		String path = URLUtil.getPath(url);
-		Assert.assertEquals("/search", path);
+		Assertions.assertEquals("/search", path);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/XmlUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/XmlUtilTest.java
@@ -7,9 +7,9 @@ import cn.hutool.core.lang.Console;
 import cn.hutool.core.map.MapBuilder;
 import cn.hutool.core.map.MapUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -40,11 +40,11 @@ public class XmlUtilTest {
 				+ "</returnsms>";
 		Document docResult = XmlUtil.parseXml(result);
 		String elementText = XmlUtil.elementText(docResult.getDocumentElement(), "returnstatus");
-		Assert.assertEquals("Success", elementText);
+		Assertions.assertEquals("Success", elementText);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		String result = "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"//
 				+ "<returnsms>"//
@@ -70,7 +70,7 @@ public class XmlUtilTest {
 				+ "</returnsms>";
 		Document docResult = XmlUtil.parseXml(result);
 		Object value = XmlUtil.getByXPath("//returnsms/message", docResult, XPathConstants.STRING);
-		Assert.assertEquals("ok", value);
+		Assertions.assertEquals("ok", value);
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class XmlUtilTest {
 		String result = ResourceUtil.readUtf8Str("test.xml");
 		Document docResult = XmlUtil.parseXml(result);
 		Object value = XmlUtil.getByXPath("//returnsms/message", docResult, XPathConstants.STRING);
-		Assert.assertEquals("ok", value);
+		Assertions.assertEquals("ok", value);
 	}
 
 	@Test
@@ -94,13 +94,13 @@ public class XmlUtilTest {
 				+ "</returnsms>";
 		Map<String, Object> map = XmlUtil.xmlToMap(xml);
 
-		Assert.assertEquals(6, map.size());
-		Assert.assertEquals("Success", map.get("returnstatus"));
-		Assert.assertEquals("ok", map.get("message"));
-		Assert.assertEquals("1490", map.get("remainpoint"));
-		Assert.assertEquals("885", map.get("taskID"));
-		Assert.assertEquals("1", map.get("successCounts"));
-		Assert.assertEquals("subText", ((Map<?, ?>) map.get("newNode")).get("sub"));
+		Assertions.assertEquals(6, map.size());
+		Assertions.assertEquals("Success", map.get("returnstatus"));
+		Assertions.assertEquals("ok", map.get("message"));
+		Assertions.assertEquals("1490", map.get("remainpoint"));
+		Assertions.assertEquals("885", map.get("taskID"));
+		Assertions.assertEquals("1", map.get("successCounts"));
+		Assertions.assertEquals("subText", ((Map<?, ?>) map.get("newNode")).get("sub"));
 	}
 
 	@Test
@@ -108,8 +108,8 @@ public class XmlUtilTest {
 		String xml = "<root><name>张三</name><name>李四</name></root>";
 		Map<String, Object> map = XmlUtil.xmlToMap(xml);
 
-		Assert.assertEquals(1, map.size());
-		Assert.assertEquals(CollUtil.newArrayList("张三", "李四"), map.get("name"));
+		Assertions.assertEquals(1, map.size());
+		Assertions.assertEquals(CollUtil.newArrayList("张三", "李四"), map.get("name"));
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class XmlUtilTest {
 				.build();
 		Document doc = XmlUtil.mapToXml(map, "user");
 		// Console.log(XmlUtil.toStr(doc, false));
-		Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"//
+		Assertions.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"//
 						+ "<user>"//
 						+ "<name>张三</name>"//
 						+ "<age>12</age>"//
@@ -141,7 +141,7 @@ public class XmlUtilTest {
 				.build();
 
 		Document doc = XmlUtil.mapToXml(map, "City");
-		Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
+		Assertions.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>" +
 						"<City>" +
 						"<Town>town1</Town>" +
 						"<Town>town2</Town>" +
@@ -152,7 +152,7 @@ public class XmlUtilTest {
 	@Test
 	public void readTest() {
 		Document doc = XmlUtil.readXML("test.xml");
-		Assert.assertNotNull(doc);
+		Assertions.assertNotNull(doc);
 	}
 
 	@Test
@@ -162,7 +162,7 @@ public class XmlUtilTest {
 		XmlUtil.readBySax(ResourceUtil.getStream("test.xml"), new DefaultHandler(){
 			@Override
 			public void startElement(String uri, String localName, String qName, Attributes attributes) {
-				Assert.assertTrue(eles.contains(localName));
+				Assertions.assertTrue(eles.contains(localName));
 			}
 		});
 	}
@@ -174,7 +174,7 @@ public class XmlUtilTest {
 				.put("name", "ddatsh")
 				.build();
 		String xml = XmlUtil.mapToXmlStr(map, true);
-		Assert.assertEquals("<xml><name>ddatsh</name></xml>", xml);
+		Assertions.assertEquals("<xml><name>ddatsh</name></xml>", xml);
 	}
 
 	@Test
@@ -192,7 +192,7 @@ public class XmlUtilTest {
 		Object value = XmlUtil.getByXPath(
 				"//soap:Envelope/soap:Body/ns2:testResponse/return",
 				document, XPathConstants.STRING);//
-		Assert.assertEquals("2020/04/15 21:01:21", value);
+		Assertions.assertEquals("2020/04/15 21:01:21", value);
 	}
 
 	@Test
@@ -215,11 +215,11 @@ public class XmlUtilTest {
 
 		// 不忽略空字段情况下保留自闭标签
 		Document doc = XmlUtil.beanToXml(testBean, null, false);
-		Assert.assertNotNull(XmlUtil.getElement(doc.getDocumentElement(), "ProjectCode"));
+		Assertions.assertNotNull(XmlUtil.getElement(doc.getDocumentElement(), "ProjectCode"));
 
 		// 忽略空字段情况下无自闭标签
 		doc = XmlUtil.beanToXml(testBean, null, true);
-		Assert.assertNull(XmlUtil.getElement(doc.getDocumentElement(), "ProjectCode"));
+		Assertions.assertNull(XmlUtil.getElement(doc.getDocumentElement(), "ProjectCode"));
 	}
 
 	@Test
@@ -241,14 +241,14 @@ public class XmlUtilTest {
 		testBean.setBankCode("00001");
 
 		final Document doc = XmlUtil.beanToXml(testBean);
-		Assert.assertEquals(TestBean.class.getSimpleName(), doc.getDocumentElement().getTagName());
+		Assertions.assertEquals(TestBean.class.getSimpleName(), doc.getDocumentElement().getTagName());
 
 		final TestBean testBean2 = XmlUtil.xmlToBean(doc, TestBean.class);
-		Assert.assertEquals(testBean.getReqCode(), testBean2.getReqCode());
-		Assert.assertEquals(testBean.getAccountName(), testBean2.getAccountName());
-		Assert.assertEquals(testBean.getOperator(), testBean2.getOperator());
-		Assert.assertEquals(testBean.getProjectCode(), testBean2.getProjectCode());
-		Assert.assertEquals(testBean.getBankCode(), testBean2.getBankCode());
+		Assertions.assertEquals(testBean.getReqCode(), testBean2.getReqCode());
+		Assertions.assertEquals(testBean.getAccountName(), testBean2.getAccountName());
+		Assertions.assertEquals(testBean.getOperator(), testBean2.getOperator());
+		Assertions.assertEquals(testBean.getProjectCode(), testBean2.getProjectCode());
+		Assertions.assertEquals(testBean.getBankCode(), testBean2.getBankCode());
 	}
 
 	@Test
@@ -271,18 +271,18 @@ public class XmlUtilTest {
 		// toBean方式
 		SmsRes res1 = XmlUtil.xmlToBean(doc.getFirstChild(), SmsRes.class);
 
-		Assert.assertEquals(res.toString(), res1.toString());
+		Assertions.assertEquals(res.toString(), res1.toString());
 	}
 
 	@Test
 	public void cleanCommentTest() {
 		final String xmlContent = "<info><title>hutool</title><!-- 这是注释 --><lang>java</lang></info>";
 		final String ret = XmlUtil.cleanComment(xmlContent);
-		Assert.assertEquals("<info><title>hutool</title><lang>java</lang></info>", ret);
+		Assertions.assertEquals("<info><title>hutool</title><lang>java</lang></info>", ret);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void formatTest(){
 		// https://github.com/looly/hutool/pull/1234
 		Document xml = XmlUtil.createXml("NODES");
@@ -329,6 +329,6 @@ public class XmlUtilTest {
 
 		final Document doc = XmlUtil.parseXml(xml);
 		final String name = doc.getDocumentElement().getAttribute("name");
-		Assert.assertEquals("aaaa", name);
+		Assertions.assertEquals("aaaa", name);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ZipUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ZipUtilTest.java
@@ -4,9 +4,9 @@ import cn.hutool.core.compress.ZipReader;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IORuntimeException;
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -40,9 +40,9 @@ public class ZipUtilTest {
 		List<String> afterNames = zipEntryNames(tempZipFile);
 
 		// 确认增加了文件
-		Assert.assertEquals(beforeNames.size() + 1, afterNames.size());
-		Assert.assertTrue(afterNames.containsAll(beforeNames));
-		Assert.assertTrue(afterNames.contains(appendFile.getName()));
+		Assertions.assertEquals(beforeNames.size() + 1, afterNames.size());
+		Assertions.assertTrue(afterNames.containsAll(beforeNames));
+		Assertions.assertTrue(afterNames.contains(appendFile.getName()));
 
 		// test dir add
 		beforeNames = zipEntryNames(tempZipFile);
@@ -51,12 +51,12 @@ public class ZipUtilTest {
 		afterNames = zipEntryNames(tempZipFile);
 
 		// 确认增加了文件和目录，增加目录和目录下一个文件，故此处+2
-		Assert.assertEquals(beforeNames.size() + 2, afterNames.size());
-		Assert.assertTrue(afterNames.containsAll(beforeNames));
-		Assert.assertTrue(afterNames.contains(appendFile.getName()));
+		Assertions.assertEquals(beforeNames.size() + 2, afterNames.size());
+		Assertions.assertTrue(afterNames.containsAll(beforeNames));
+		Assertions.assertTrue(afterNames.contains(appendFile.getName()));
 
 		// rollback
-		Assert.assertTrue(String.format("delete temp file %s failed", tempZipFile.getCanonicalPath()), tempZipFile.delete());
+		Assertions.assertTrue(tempZipFile.delete(), String.format("delete temp file %s failed", tempZipFile.getCanonicalPath()));
 	}
 
 	/**
@@ -74,43 +74,43 @@ public class ZipUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipDirTest() {
 		ZipUtil.zip(new File("d:/test"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void unzipTest() {
 		File unzip = ZipUtil.unzip("f:/test/apache-maven-3.6.2.zip", "f:\\test");
 		Console.log(unzip);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void unzipTest2() {
 		File unzip = ZipUtil.unzip("f:/test/各种资源.zip", "f:/test/各种资源", CharsetUtil.CHARSET_GBK);
 		Console.log(unzip);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void unzipFromStreamTest() {
 		File unzip = ZipUtil.unzip(FileUtil.getInputStream("e:/test/hutool-core-5.1.0.jar"), FileUtil.file("e:/test/"), CharsetUtil.CHARSET_UTF_8);
 		Console.log(unzip);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void unzipChineseTest() {
 		ZipUtil.unzip("d:/测试.zip");
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void unzipFileBytesTest() {
 		byte[] fileBytes = ZipUtil.unzipFileBytes(FileUtil.file("e:/02 电力相关设备及服务2-241-.zip"), CharsetUtil.CHARSET_GBK, "images/CE-EP-HY-MH01-ES-0001.jpg");
-		Assert.assertNotNull(fileBytes);
+		Assertions.assertNotNull(fileBytes);
 	}
 
 	@Test
@@ -120,11 +120,11 @@ public class ZipUtilTest {
 		byte[] gzip = ZipUtil.gzip(bytes);
 
 		//保证gzip长度正常
-		Assert.assertEquals(68, gzip.length);
+		Assertions.assertEquals(68, gzip.length);
 
 		byte[] unGzip = ZipUtil.unGzip(gzip);
 		//保证正常还原
-		Assert.assertEquals(data, StrUtil.utf8Str(unGzip));
+		Assertions.assertEquals(data, StrUtil.utf8Str(unGzip));
 	}
 
 	@Test
@@ -134,21 +134,21 @@ public class ZipUtilTest {
 		byte[] gzip = ZipUtil.zlib(bytes, 0);
 
 		//保证zlib长度正常
-		Assert.assertEquals(62, gzip.length);
+		Assertions.assertEquals(62, gzip.length);
 		byte[] unGzip = ZipUtil.unZlib(gzip);
 		//保证正常还原
-		Assert.assertEquals(data, StrUtil.utf8Str(unGzip));
+		Assertions.assertEquals(data, StrUtil.utf8Str(unGzip));
 
 		gzip = ZipUtil.zlib(bytes, 9);
 		//保证zlib长度正常
-		Assert.assertEquals(56, gzip.length);
+		Assertions.assertEquals(56, gzip.length);
 		byte[] unGzip2 = ZipUtil.unZlib(gzip);
 		//保证正常还原
-		Assert.assertEquals(data, StrUtil.utf8Str(unGzip2));
+		Assertions.assertEquals(data, StrUtil.utf8Str(unGzip2));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipStreamTest(){
 		//https://github.com/looly/hutool/issues/944
 		String dir = "d:/test";
@@ -162,7 +162,7 @@ public class ZipUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipStreamTest2(){
 		// https://github.com/dromara/hutool/issues/944
 		String file1 = "d:/test/a.txt";
@@ -179,7 +179,7 @@ public class ZipUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipToStreamTest(){
 		String zip = "d:/test/testToStream.zip";
 		OutputStream out = FileUtil.getOutputStream(zip);

--- a/hutool-core/src/test/resources/LICENSE-junit.txt
+++ b/hutool-core/src/test/resources/LICENSE-junit.txt
@@ -1,0 +1,1 @@
+用于 ClassPathResourceTest

--- a/hutool-cron/src/test/java/cn/hutool/cron/TaskTableTest.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/TaskTableTest.java
@@ -3,13 +3,13 @@ package cn.hutool.cron;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.IdUtil;
 import cn.hutool.cron.pattern.CronPattern;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TaskTableTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void toStringTest(){
 		final TaskTable taskTable = new TaskTable();
 		taskTable.add(IdUtil.fastUUID(), new CronPattern("*/10 * * * * *"), ()-> Console.log("Task 1"));

--- a/hutool-cron/src/test/java/cn/hutool/cron/demo/CronTest.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/demo/CronTest.java
@@ -6,8 +6,8 @@ import cn.hutool.cron.CronUtil;
 import cn.hutool.cron.TaskExecutor;
 import cn.hutool.cron.listener.TaskListener;
 import cn.hutool.cron.task.Task;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * 定时任务样例
@@ -15,7 +15,7 @@ import org.junit.Test;
 public class CronTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void customCronTest() {
 		CronUtil.schedule("*/2 * * * * *", (Task) () -> Console.log("Task excuted."));
 
@@ -28,7 +28,7 @@ public class CronTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void cronTest() {
 		// 支持秒级别定时任务
 		CronUtil.setMatchSecond(true);
@@ -40,7 +40,7 @@ public class CronTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void cronWithListenerTest() {
 		CronUtil.getScheduler().addListener(new TaskListener() {
 			@Override
@@ -68,7 +68,7 @@ public class CronTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void addAndRemoveTest() {
 		String id = CronUtil.schedule("*/2 * * * * *", (Runnable) () -> Console.log("task running : 2s"));
 

--- a/hutool-cron/src/test/java/cn/hutool/cron/pattern/CronPatternTest.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/pattern/CronPatternTest.java
@@ -3,8 +3,8 @@ package cn.hutool.cron.pattern;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.cron.CronException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 定时任务单元测试类
@@ -20,8 +20,8 @@ public class CronPatternTest {
 		// 任何时间匹配
 		pattern = new CronPattern("* * * * * *");
 		ThreadUtil.sleep(600);
-		Assert.assertTrue(pattern.match(DateUtil.current(), true));
-		Assert.assertTrue(pattern.match(DateUtil.current(), false));
+		Assertions.assertTrue(pattern.match(DateUtil.current(), true));
+		Assertions.assertTrue(pattern.match(DateUtil.current(), false));
 	}
 
 	@Test
@@ -32,7 +32,7 @@ public class CronPatternTest {
 		// 任何时间匹配
 		pattern = new CronPattern("* * * * *");
 		for(int i = 0; i < 1; i++) {
-			Assert.assertTrue(pattern.match(DateUtil.current(), false));
+			Assertions.assertTrue(pattern.match(DateUtil.current(), false));
 		}
 	}
 
@@ -95,11 +95,11 @@ public class CronPatternTest {
 	@Test
 	public void CronPatternTest2() {
 		CronPattern pattern = new CronPattern("0/30 * * * *");
-		Assert.assertTrue(pattern.match(DateUtil.parse("2018-10-09 12:00:00").getTime(), false));
-		Assert.assertTrue(pattern.match(DateUtil.parse("2018-10-09 12:30:00").getTime(), false));
+		Assertions.assertTrue(pattern.match(DateUtil.parse("2018-10-09 12:00:00").getTime(), false));
+		Assertions.assertTrue(pattern.match(DateUtil.parse("2018-10-09 12:30:00").getTime(), false));
 
 		pattern = new CronPattern("32 * * * *");
-		Assert.assertTrue(pattern.match(DateUtil.parse("2018-10-09 12:32:00").getTime(), false));
+		Assertions.assertTrue(pattern.match(DateUtil.parse("2018-10-09 12:32:00").getTime(), false));
 	}
 
 	@Test
@@ -143,10 +143,12 @@ public class CronPatternTest {
 		assertMatch(pattern, "2017-12-02 23:59:59");
 	}
 
-	@Test(expected = CronException.class)
+	@Test
 	public void rangeYearTest() {
-		// year的范围是1970~2099年，超出报错
-		new CronPattern("0/1 * * * 1/1 ? 2020-2120");
+		Assertions.assertThrows(CronException.class, () -> {
+			// year的范围是1970~2099年，超出报错
+			new CronPattern("0/1 * * * 1/1 ? 2020-2120");
+		});
 	}
 
 	/**
@@ -157,7 +159,7 @@ public class CronPatternTest {
 	 */
 	@SuppressWarnings("ConstantConditions")
 	private void assertMatch(CronPattern pattern, String date) {
-		Assert.assertTrue(pattern.match(DateUtil.parse(date).getTime(), false));
-		Assert.assertTrue(pattern.match(DateUtil.parse(date).getTime(), true));
+		Assertions.assertTrue(pattern.match(DateUtil.parse(date).getTime(), false));
+		Assertions.assertTrue(pattern.match(DateUtil.parse(date).getTime(), true));
 	}
 }

--- a/hutool-cron/src/test/java/cn/hutool/cron/pattern/CronPatternUtilTest.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/pattern/CronPatternUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.cron.pattern;
 
 import cn.hutool.core.date.DateUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
@@ -13,35 +13,35 @@ public class CronPatternUtilTest {
 	public void matchedDatesTest() {
 		//测试每30秒执行
 		List<Date> matchedDates = CronPatternUtil.matchedDates("0/30 * 8-18 * * ?", DateUtil.parse("2018-10-15 14:33:22"), 5, true);
-		Assert.assertEquals(5, matchedDates.size());
-		Assert.assertEquals("2018-10-15 14:33:30", matchedDates.get(0).toString());
-		Assert.assertEquals("2018-10-15 14:34:00", matchedDates.get(1).toString());
-		Assert.assertEquals("2018-10-15 14:34:30", matchedDates.get(2).toString());
-		Assert.assertEquals("2018-10-15 14:35:00", matchedDates.get(3).toString());
-		Assert.assertEquals("2018-10-15 14:35:30", matchedDates.get(4).toString());
+		Assertions.assertEquals(5, matchedDates.size());
+		Assertions.assertEquals("2018-10-15 14:33:30", matchedDates.get(0).toString());
+		Assertions.assertEquals("2018-10-15 14:34:00", matchedDates.get(1).toString());
+		Assertions.assertEquals("2018-10-15 14:34:30", matchedDates.get(2).toString());
+		Assertions.assertEquals("2018-10-15 14:35:00", matchedDates.get(3).toString());
+		Assertions.assertEquals("2018-10-15 14:35:30", matchedDates.get(4).toString());
 	}
 
 	@Test
 	public void matchedDatesTest2() {
 		//测试每小时执行
 		List<Date> matchedDates = CronPatternUtil.matchedDates("0 0 */1 * * *", DateUtil.parse("2018-10-15 14:33:22"), 5, true);
-		Assert.assertEquals(5, matchedDates.size());
-		Assert.assertEquals("2018-10-15 15:00:00", matchedDates.get(0).toString());
-		Assert.assertEquals("2018-10-15 16:00:00", matchedDates.get(1).toString());
-		Assert.assertEquals("2018-10-15 17:00:00", matchedDates.get(2).toString());
-		Assert.assertEquals("2018-10-15 18:00:00", matchedDates.get(3).toString());
-		Assert.assertEquals("2018-10-15 19:00:00", matchedDates.get(4).toString());
+		Assertions.assertEquals(5, matchedDates.size());
+		Assertions.assertEquals("2018-10-15 15:00:00", matchedDates.get(0).toString());
+		Assertions.assertEquals("2018-10-15 16:00:00", matchedDates.get(1).toString());
+		Assertions.assertEquals("2018-10-15 17:00:00", matchedDates.get(2).toString());
+		Assertions.assertEquals("2018-10-15 18:00:00", matchedDates.get(3).toString());
+		Assertions.assertEquals("2018-10-15 19:00:00", matchedDates.get(4).toString());
 	}
 
 	@Test
 	public void matchedDatesTest3() {
 		//测试最后一天
 		List<Date> matchedDates = CronPatternUtil.matchedDates("0 0 */1 L * *", DateUtil.parse("2018-10-30 23:33:22"), 5, true);
-		Assert.assertEquals(5, matchedDates.size());
-		Assert.assertEquals("2018-10-31 00:00:00", matchedDates.get(0).toString());
-		Assert.assertEquals("2018-10-31 01:00:00", matchedDates.get(1).toString());
-		Assert.assertEquals("2018-10-31 02:00:00", matchedDates.get(2).toString());
-		Assert.assertEquals("2018-10-31 03:00:00", matchedDates.get(3).toString());
-		Assert.assertEquals("2018-10-31 04:00:00", matchedDates.get(4).toString());
+		Assertions.assertEquals(5, matchedDates.size());
+		Assertions.assertEquals("2018-10-31 00:00:00", matchedDates.get(0).toString());
+		Assertions.assertEquals("2018-10-31 01:00:00", matchedDates.get(1).toString());
+		Assertions.assertEquals("2018-10-31 02:00:00", matchedDates.get(2).toString());
+		Assertions.assertEquals("2018-10-31 03:00:00", matchedDates.get(3).toString());
+		Assertions.assertEquals("2018-10-31 04:00:00", matchedDates.get(4).toString());
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/BCUtilTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/BCUtilTest.java
@@ -1,10 +1,10 @@
 package cn.hutool.crypto.test;
 
-import cn.hutool.core.lang.Assert;
 import cn.hutool.crypto.BCUtil;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BCUtilTest {
 
@@ -17,7 +17,7 @@ public class BCUtilTest {
 		String y = "F7E938B02EED7280277493B8556E5B01CB436E018A562DFDC53342BF41FDF728";
 
 		final ECPublicKeyParameters keyParameters = BCUtil.toSm2Params(x, y);
-		Assert.notNull(keyParameters);
+		Assertions.assertNotNull(keyParameters);
 	}
 
 	@Test
@@ -25,6 +25,6 @@ public class BCUtilTest {
 		String privateKeyHex = "5F6CA5BB044C40ED2355F0372BF72A5B3AE6943712F9FDB7C1FFBAECC06F3829";
 
 		final ECPrivateKeyParameters keyParameters = BCUtil.toSm2Params(privateKeyHex);
-		Assert.notNull(keyParameters);
+		Assertions.assertNotNull(keyParameters);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/KeyUtilTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/KeyUtilTest.java
@@ -3,9 +3,9 @@ package cn.hutool.crypto.test;
 import cn.hutool.crypto.CryptoException;
 import cn.hutool.crypto.GlobalBouncyCastleProvider;
 import cn.hutool.crypto.KeyUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -16,12 +16,14 @@ public class KeyUtilTest {
 	/**
 	 * 测试关闭BouncyCastle支持时是否会正常抛出异常，即关闭是否有效
 	 */
-	@Test(expected = CryptoException.class)
-	@Ignore
+	@Test
+	@Disabled
 	public void generateKeyPairTest() {
-		GlobalBouncyCastleProvider.setUseBouncyCastle(false);
-		KeyPair pair = KeyUtil.generateKeyPair("SM2");
-		Assert.assertNotNull(pair);
+		Assertions.assertThrows(CryptoException.class, () -> {
+			GlobalBouncyCastleProvider.setUseBouncyCastle(false);
+			KeyPair pair = KeyUtil.generateKeyPair("SM2");
+			Assertions.assertNotNull(pair);
+		});
 	}
 
 	@Test
@@ -29,7 +31,7 @@ public class KeyUtilTest {
 		final KeyPair keyPair = KeyUtil.generateKeyPair("RSA");
 		final PrivateKey aPrivate = keyPair.getPrivate();
 		final PublicKey rsaPublicKey = KeyUtil.getRSAPublicKey(aPrivate);
-		Assert.assertEquals(rsaPublicKey, keyPair.getPublic());
+		Assertions.assertEquals(rsaPublicKey, keyPair.getPublic());
 	}
 
 	/**
@@ -38,24 +40,24 @@ public class KeyUtilTest {
 	@Test
 	public void generateECIESKeyTest(){
 		final KeyPair ecies = KeyUtil.generateKeyPair("ECIES");
-		Assert.assertNotNull(ecies.getPrivate());
-		Assert.assertNotNull(ecies.getPublic());
+		Assertions.assertNotNull(ecies.getPrivate());
+		Assertions.assertNotNull(ecies.getPublic());
 
 		byte[] privateKeyBytes = ecies.getPrivate().getEncoded();
 
 		final PrivateKey privateKey = KeyUtil.generatePrivateKey("EC", privateKeyBytes);
-		Assert.assertEquals(ecies.getPrivate(), privateKey);
+		Assertions.assertEquals(ecies.getPrivate(), privateKey);
 	}
 
 	@Test
 	public void generateDHTest(){
 		final KeyPair dh = KeyUtil.generateKeyPair("DH");
-		Assert.assertNotNull(dh.getPrivate());
-		Assert.assertNotNull(dh.getPublic());
+		Assertions.assertNotNull(dh.getPrivate());
+		Assertions.assertNotNull(dh.getPublic());
 
 		byte[] privateKeyBytes = dh.getPrivate().getEncoded();
 
 		final PrivateKey privateKey = KeyUtil.generatePrivateKey("DH", privateKeyBytes);
-		Assert.assertEquals(dh.getPrivate(), privateKey);
+		Assertions.assertEquals(dh.getPrivate(), privateKey);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/PemUtilTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/PemUtilTest.java
@@ -7,9 +7,9 @@ import cn.hutool.crypto.PemUtil;
 import cn.hutool.crypto.asymmetric.KeyType;
 import cn.hutool.crypto.asymmetric.RSA;
 import cn.hutool.crypto.asymmetric.SM2;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
@@ -20,19 +20,19 @@ public class PemUtilTest {
 	@Test
 	public void readPrivateKeyTest() {
 		PrivateKey privateKey = PemUtil.readPemPrivateKey(ResourceUtil.getStream("test_private_key.pem"));
-		Assert.assertNotNull(privateKey);
+		Assertions.assertNotNull(privateKey);
 	}
 
 	@Test
 	public void readPublicKeyTest() {
 		PublicKey publicKey = PemUtil.readPemPublicKey(ResourceUtil.getStream("test_public_key.csr"));
-		Assert.assertNotNull(publicKey);
+		Assertions.assertNotNull(publicKey);
 	}
 
 	@Test
 	public void readPemKeyTest() {
 		PublicKey publicKey = (PublicKey) PemUtil.readPemKey(ResourceUtil.getStream("test_public_key.csr"));
-		Assert.assertNotNull(publicKey);
+		Assertions.assertNotNull(publicKey);
 	}
 
 	@Test
@@ -45,7 +45,7 @@ public class PemUtilTest {
 
 		String encryptStr = rsa.encryptBase64(str, KeyType.PublicKey);
 		String decryptStr = rsa.decryptStr(encryptStr, KeyType.PrivateKey);
-		Assert.assertEquals(str, decryptStr);
+		Assertions.assertEquals(str, decryptStr);
 	}
 
 	@Test
@@ -59,11 +59,11 @@ public class PemUtilTest {
 
 		byte[] sign = sm2.sign(dataBytes, null);
 		// 64位签名
-		Assert.assertEquals(64, sign.length);
+		Assertions.assertEquals(64, sign.length);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readECPrivateKeyTest2() {
 		// https://gitee.com/loolly/hutool/issues/I37Z75
 		byte[] d = PemUtil.readPem(FileUtil.getInputStream("d:/test/keys/priv.key"));
@@ -75,6 +75,6 @@ public class PemUtilTest {
 		String content = "我是Hanley.";
 		byte[] sign = sm2.sign(StrUtil.utf8Bytes(content));
 		boolean verify = sm2.verify(StrUtil.utf8Bytes(content), sign);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/SmTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/SmTest.java
@@ -7,8 +7,8 @@ import cn.hutool.crypto.Padding;
 import cn.hutool.crypto.SmUtil;
 import cn.hutool.crypto.digest.HMac;
 import cn.hutool.crypto.symmetric.SM4;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.SecretKey;
 
@@ -23,7 +23,7 @@ public class SmTest {
 	@Test
 	public void sm3Test() {
 		String digestHex = SmUtil.sm3("aaaaa");
-		Assert.assertEquals("136ce3c86e4ed909b76082055a61586af20b4dab674732ebd4b599eef080c9be", digestHex);
+		Assertions.assertEquals("136ce3c86e4ed909b76082055a61586af20b4dab674732ebd4b599eef080c9be", digestHex);
 	}
 
 	@Test
@@ -34,7 +34,7 @@ public class SmTest {
 		String encryptHex = sm4.encryptHex(content);
 		String decryptStr = sm4.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -46,18 +46,18 @@ public class SmTest {
 		String encryptHex = sm4.encryptHex(content);
 		String decryptStr = sm4.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
 	public void sm4ECBPKCS5PaddingTest2() {
 		String content = "test中文";
 		SM4 sm4 = new SM4(Mode.ECB, Padding.PKCS5Padding);
-		Assert.assertEquals("SM4/ECB/PKCS5Padding", sm4.getCipher().getAlgorithm());
+		Assertions.assertEquals("SM4/ECB/PKCS5Padding", sm4.getCipher().getAlgorithm());
 
 		String encryptHex = sm4.encryptHex(content);
 		String decryptStr = sm4.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -67,11 +67,11 @@ public class SmTest {
 		SecretKey key = KeyUtil.generateKey(SM4.ALGORITHM_NAME);
 
 		SM4 sm4 = new SM4(Mode.ECB, Padding.PKCS5Padding, key);
-		Assert.assertEquals("SM4/ECB/PKCS5Padding", sm4.getCipher().getAlgorithm());
+		Assertions.assertEquals("SM4/ECB/PKCS5Padding", sm4.getCipher().getAlgorithm());
 
 		String encryptHex = sm4.encryptHex(content);
 		String decryptStr = sm4.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class SmTest {
 		String content = "test中文";
 		HMac hMac = SmUtil.hmacSm3("password".getBytes());
 		String digest = hMac.digestHex(content);
-		Assert.assertEquals("493e3f9a1896b43075fbe54658076727960d69632ac6b6ed932195857a6840c6", digest);
+		Assertions.assertEquals("493e3f9a1896b43075fbe54658076727960d69632ac6b6ed932195857a6840c6", digest);
 	}
 
 

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/ECIESTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/ECIESTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.asymmetric.AsymmetricCrypto;
 import cn.hutool.crypto.asymmetric.ECIES;
 import cn.hutool.crypto.asymmetric.KeyType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ECIESTest {
 
@@ -42,6 +42,6 @@ public class ECIESTest {
 		String encryptStr = cryptoForEncrypt.encryptBase64(text.toString(), KeyType.PublicKey);
 
 		String decryptStr = StrUtil.utf8Str(cryptoForDecrypt.decrypt(encryptStr, KeyType.PrivateKey));
-		Assert.assertEquals(text.toString(), decryptStr);
+		Assertions.assertEquals(text.toString(), decryptStr);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/RSATest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/RSATest.java
@@ -14,8 +14,8 @@ import cn.hutool.crypto.asymmetric.KeyType;
 import cn.hutool.crypto.asymmetric.RSA;
 import cn.hutool.crypto.asymmetric.Sign;
 import cn.hutool.crypto.asymmetric.SignAlgorithm;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.Cipher;
 import java.math.BigInteger;
@@ -32,8 +32,8 @@ public class RSATest {
 	@Test
 	public void generateKeyPairTest() {
 		KeyPair pair = KeyUtil.generateKeyPair("RSA");
-		Assert.assertNotNull(pair.getPrivate());
-		Assert.assertNotNull(pair.getPublic());
+		Assertions.assertNotNull(pair.getPrivate());
+		Assertions.assertNotNull(pair.getPublic());
 	}
 
 	@Test
@@ -47,12 +47,12 @@ public class RSATest {
 		// 公钥加密，私钥解密
 		byte[] encrypt = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 		byte[] decrypt = rsa.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 
 		// 私钥加密，公钥解密
 		byte[] encrypt2 = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PrivateKey);
 		byte[] decrypt2 = rsa.decrypt(encrypt2, KeyType.PublicKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -60,21 +60,21 @@ public class RSATest {
 		final RSA rsa = new RSA();
 
 		// 获取私钥和公钥
-		Assert.assertNotNull(rsa.getPrivateKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
-		Assert.assertNotNull(rsa.getPublicKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPrivateKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPublicKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
 
 		// 公钥加密，私钥解密
 		byte[] encrypt = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 
 		byte[] decrypt = rsa.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 
 		// 私钥加密，公钥解密
 		byte[] encrypt2 = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PrivateKey);
 		byte[] decrypt2 = rsa.decrypt(encrypt2, KeyType.PublicKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -82,21 +82,21 @@ public class RSATest {
 		final RSA rsa = new RSA(AsymmetricAlgorithm.RSA_ECB.getValue());
 
 		// 获取私钥和公钥
-		Assert.assertNotNull(rsa.getPrivateKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
-		Assert.assertNotNull(rsa.getPublicKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPrivateKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPublicKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
 
 		// 公钥加密，私钥解密
 		byte[] encrypt = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 
 		byte[] decrypt = rsa.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 
 		// 私钥加密，公钥解密
 		byte[] encrypt2 = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PrivateKey);
 		byte[] decrypt2 = rsa.decrypt(encrypt2, KeyType.PublicKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -104,21 +104,21 @@ public class RSATest {
 		final RSA rsa = new RSA(AsymmetricAlgorithm.RSA_None.getValue());
 
 		// 获取私钥和公钥
-		Assert.assertNotNull(rsa.getPrivateKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
-		Assert.assertNotNull(rsa.getPublicKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPrivateKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPublicKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
 
 		// 公钥加密，私钥解密
 		byte[] encrypt = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 
 		byte[] decrypt = rsa.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 
 		// 私钥加密，公钥解密
 		byte[] encrypt2 = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PrivateKey);
 		byte[] decrypt2 = rsa.decrypt(encrypt2, KeyType.PublicKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -127,20 +127,20 @@ public class RSATest {
 		rsa.setEncryptBlockSize(3);
 
 		// 获取私钥和公钥
-		Assert.assertNotNull(rsa.getPrivateKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
-		Assert.assertNotNull(rsa.getPublicKey());
-		Assert.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPrivateKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
+		Assertions.assertNotNull(rsa.getPublicKey());
+		Assertions.assertNotNull(rsa.getPrivateKeyBase64());
 
 		// 公钥加密，私钥解密
 		byte[] encrypt = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 		byte[] decrypt = rsa.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 
 		// 私钥加密，公钥解密
 		byte[] encrypt2 = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PrivateKey);
 		byte[] decrypt2 = rsa.decrypt(encrypt2, KeyType.PublicKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -152,12 +152,12 @@ public class RSATest {
 		// 公钥加密，私钥解密
 		String encryptStr = rsa.encryptBcd(text, KeyType.PublicKey);
 		String decryptStr = StrUtil.utf8Str(rsa.decryptFromBcd(encryptStr, KeyType.PrivateKey));
-		Assert.assertEquals(text, decryptStr);
+		Assertions.assertEquals(text, decryptStr);
 
 		// 私钥加密，公钥解密
 		String encrypt2 = rsa.encryptBcd(text, KeyType.PrivateKey);
 		String decrypt2 = StrUtil.utf8Str(rsa.decryptFromBcd(encrypt2, KeyType.PublicKey));
-		Assert.assertEquals(text, decrypt2);
+		Assertions.assertEquals(text, decrypt2);
 	}
 
 	@Test
@@ -173,12 +173,12 @@ public class RSATest {
 		// 公钥加密，私钥解密
 		String encryptStr = rsa.encryptBase64(text.toString(), KeyType.PublicKey);
 		String decryptStr = StrUtil.utf8Str(rsa.decrypt(encryptStr, KeyType.PrivateKey));
-		Assert.assertEquals(text.toString(), decryptStr);
+		Assertions.assertEquals(text.toString(), decryptStr);
 
 		// 私钥加密，公钥解密
 		String encrypt2 = rsa.encryptBase64(text.toString(), KeyType.PrivateKey);
 		String decrypt2 = StrUtil.utf8Str(rsa.decrypt(encrypt2, KeyType.PublicKey));
-		Assert.assertEquals(text.toString(), decrypt2);
+		Assertions.assertEquals(text.toString(), decrypt2);
 	}
 
 	@Test
@@ -203,7 +203,7 @@ public class RSATest {
 		byte[] aByte = HexUtil.decodeHex(a);
 		byte[] decrypt = rsa.decrypt(aByte, KeyType.PrivateKey);
 
-		Assert.assertEquals("虎头闯杭州,多抬头看天,切勿只管种地", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("虎头闯杭州,多抬头看天,切勿只管种地", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -229,7 +229,7 @@ public class RSATest {
 		rsa.setEncryptBlockSize(128);
 		String result2 = rsa.encryptHex(finalData, KeyType.PublicKey);
 
-		Assert.assertEquals(result1, result2);
+		Assertions.assertEquals(result1, result2);
 	}
 
 	@Test
@@ -242,6 +242,6 @@ public class RSATest {
 		RSA rsa = new RSA(new BigInteger(modulus, 16), null, new BigInteger(publicExponent));
 
 		final String encryptBase64 = rsa.encryptBase64("测试内容", KeyType.PublicKey);
-		Assert.assertNotNull(encryptBase64);
+		Assertions.assertNotNull(encryptBase64);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/SM2Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/SM2Test.java
@@ -13,8 +13,8 @@ import cn.hutool.crypto.asymmetric.SM2;
 import org.bouncycastle.crypto.engines.SM2Engine;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.jcajce.spec.OpenSSHPrivateKeySpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
@@ -31,8 +31,8 @@ public class SM2Test {
 	@Test
 	public void generateKeyPairTest() {
 		KeyPair pair = SecureUtil.generateKeyPair("SM2");
-		Assert.assertNotNull(pair.getPrivate());
-		Assert.assertNotNull(pair.getPublic());
+		Assertions.assertNotNull(pair.getPrivate());
+		Assertions.assertNotNull(pair.getPublic());
 	}
 
 	@Test
@@ -40,8 +40,8 @@ public class SM2Test {
 		// OBJECT IDENTIFIER 1.2.156.10197.1.301
 		String OID = "06082A811CCF5501822D";
 		KeyPair pair = SecureUtil.generateKeyPair("SM2");
-		Assert.assertTrue(HexUtil.encodeHexStr(pair.getPrivate().getEncoded()).toUpperCase().contains(OID));
-		Assert.assertTrue(HexUtil.encodeHexStr(pair.getPublic().getEncoded()).toUpperCase().contains(OID));
+		Assertions.assertTrue(HexUtil.encodeHexStr(pair.getPrivate().getEncoded()).toUpperCase().contains(OID));
+		Assertions.assertTrue(HexUtil.encodeHexStr(pair.getPublic().getEncoded()).toUpperCase().contains(OID));
 	}
 
 	@Test
@@ -56,7 +56,7 @@ public class SM2Test {
 		// 公钥加密，私钥解密
 		byte[] encrypt = sm2.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 		byte[] decrypt = sm2.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -64,15 +64,15 @@ public class SM2Test {
 		final SM2 sm2 = SmUtil.sm2();
 
 		// 获取私钥和公钥
-		Assert.assertNotNull(sm2.getPrivateKey());
-		Assert.assertNotNull(sm2.getPrivateKeyBase64());
-		Assert.assertNotNull(sm2.getPublicKey());
-		Assert.assertNotNull(sm2.getPrivateKeyBase64());
+		Assertions.assertNotNull(sm2.getPrivateKey());
+		Assertions.assertNotNull(sm2.getPrivateKeyBase64());
+		Assertions.assertNotNull(sm2.getPublicKey());
+		Assertions.assertNotNull(sm2.getPrivateKeyBase64());
 
 		// 公钥加密，私钥解密
 		byte[] encrypt = sm2.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
 		byte[] decrypt = sm2.decrypt(encrypt, KeyType.PrivateKey);
-		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 	}
 
 	@Test
@@ -84,7 +84,7 @@ public class SM2Test {
 		// 公钥加密，私钥解密
 		String encryptStr = sm2.encryptBcd(text, KeyType.PublicKey);
 		String decryptStr = StrUtil.utf8Str(sm2.decryptFromBcd(encryptStr, KeyType.PrivateKey));
-		Assert.assertEquals(text, decryptStr);
+		Assertions.assertEquals(text, decryptStr);
 	}
 
 	@Test
@@ -100,7 +100,7 @@ public class SM2Test {
 		// 公钥加密，私钥解密
 		String encryptStr = sm2.encryptBase64(text.toString(), KeyType.PublicKey);
 		String decryptStr = StrUtil.utf8Str(sm2.decrypt(encryptStr, KeyType.PrivateKey));
-		Assert.assertEquals(text.toString(), decryptStr);
+		Assertions.assertEquals(text.toString(), decryptStr);
 
 		// 测试自定义密钥后是否生效
 		PrivateKey privateKey = sm2.getPrivateKey();
@@ -110,7 +110,7 @@ public class SM2Test {
 		sm2.setPrivateKey(privateKey);
 		sm2.setPublicKey(publicKey);
 		String decryptStr2 = StrUtil.utf8Str(sm2.decrypt(encryptStr, KeyType.PrivateKey));
-		Assert.assertEquals(text.toString(), decryptStr2);
+		Assertions.assertEquals(text.toString(), decryptStr2);
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class SM2Test {
 		sm2.usePlainEncoding();
 		byte[] sign = sm2.sign(dataBytes, null);
 		// 64位签名
-		Assert.assertEquals(64, sign.length);
+		Assertions.assertEquals(64, sign.length);
 	}
 
 	@Test
@@ -140,7 +140,7 @@ public class SM2Test {
 		sm2.usePlainEncoding();
 
 		boolean verify = sm2.verify(dataBytes, HexUtil.decodeHex(signHex));
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -151,7 +151,7 @@ public class SM2Test {
 
 		byte[] sign = sm2.sign(StrUtil.utf8Bytes(content));
 		boolean verify = sm2.verify(StrUtil.utf8Bytes(content), sign);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -162,7 +162,7 @@ public class SM2Test {
 
 		String sign = sm2.signHex(HexUtil.encodeHexStr(content));
 		boolean verify = sm2.verifyHex(HexUtil.encodeHexStr(content), sign);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -175,7 +175,7 @@ public class SM2Test {
 
 		byte[] sign = sm2.sign(content.getBytes(StandardCharsets.UTF_8));
 		boolean verify = sm2.verify(content.getBytes(StandardCharsets.UTF_8), sign);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -191,7 +191,7 @@ public class SM2Test {
 
 		byte[] sign = sm2.sign(content.getBytes(StandardCharsets.UTF_8));
 		boolean verify = sm2.verify(content.getBytes(StandardCharsets.UTF_8), sign);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -203,8 +203,8 @@ public class SM2Test {
 		String encodeB64 = Base64.encode(data);
 		PublicKey Hexdecode = KeyUtil.decodeECPoint(encodeHex, KeyUtil.SM2_DEFAULT_CURVE);
 		PublicKey B64decode = KeyUtil.decodeECPoint(encodeB64, KeyUtil.SM2_DEFAULT_CURVE);
-		Assert.assertEquals(HexUtil.encodeHexStr(publicKey.getEncoded()), HexUtil.encodeHexStr(Hexdecode.getEncoded()));
-		Assert.assertEquals(HexUtil.encodeHexStr(publicKey.getEncoded()), HexUtil.encodeHexStr(B64decode.getEncoded()));
+		Assertions.assertEquals(HexUtil.encodeHexStr(publicKey.getEncoded()), HexUtil.encodeHexStr(Hexdecode.getEncoded()));
+		Assertions.assertEquals(HexUtil.encodeHexStr(publicKey.getEncoded()), HexUtil.encodeHexStr(B64decode.getEncoded()));
 	}
 
 	@Test
@@ -218,7 +218,7 @@ public class SM2Test {
 
 		final SM2 sm2 = new SM2(d, x, y);
 		final String sign = sm2.signHex(data, id);
-		Assert.assertTrue(sm2.verifyHex(data, sign));
+		Assertions.assertTrue(sm2.verifyHex(data, sign));
 	}
 
 	@Test
@@ -238,10 +238,10 @@ public class SM2Test {
 
 
 		String sign = "DCA0E80A7F46C93714B51C3EFC55A922BCEF7ECF0FE9E62B53BA6A7438B543A76C145A452CA9036F3CB70D7E6C67D4D9D7FE114E5367A2F6F5A4D39F2B10F3D6";
-		Assert.assertTrue(sm2.verifyHex(data, sign));
+		Assertions.assertTrue(sm2.verifyHex(data, sign));
 
 		String sign2 = sm2.signHex(data, id);
-		Assert.assertTrue(sm2.verifyHex(data, sign2));
+		Assertions.assertTrue(sm2.verifyHex(data, sign2));
 	}
 
 	@Test
@@ -256,7 +256,7 @@ public class SM2Test {
 		final String encryptHex = sm2.encryptHex(data, KeyType.PublicKey);
 		final String decryptStr = sm2.decryptStr(encryptHex, KeyType.PrivateKey);
 
-		Assert.assertEquals(data, decryptStr);
+		Assertions.assertEquals(data, decryptStr);
 	}
 
 	@Test
@@ -267,10 +267,10 @@ public class SM2Test {
 		byte[] data = sm2.encrypt(src, KeyType.PublicKey);
 		byte[] sign =  sm2.sign(src.getBytes(StandardCharsets.UTF_8));
 
-		Assert.assertTrue(sm2.verify( src.getBytes(StandardCharsets.UTF_8), sign));
+		Assertions.assertTrue(sm2.verify( src.getBytes(StandardCharsets.UTF_8), sign));
 
 		byte[] dec =  sm2.decrypt(data, KeyType.PrivateKey);
-		Assert.assertArrayEquals(dec, src.getBytes(StandardCharsets.UTF_8));
+		Assertions.assertArrayEquals(dec, src.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test
@@ -288,10 +288,10 @@ public class SM2Test {
 		byte[] data = sm2.encrypt(src, KeyType.PublicKey);
 		byte[] sign =  sm2.sign(src.getBytes(StandardCharsets.UTF_8));
 
-		Assert.assertTrue(sm2.verify( src.getBytes(StandardCharsets.UTF_8), sign));
+		Assertions.assertTrue(sm2.verify( src.getBytes(StandardCharsets.UTF_8), sign));
 
 		byte[] dec =  sm2.decrypt(data, KeyType.PrivateKey);
-		Assert.assertArrayEquals(dec, src.getBytes(StandardCharsets.UTF_8));
+		Assertions.assertArrayEquals(dec, src.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test
@@ -306,19 +306,19 @@ public class SM2Test {
 		byte[] data = sm2.encrypt(src, KeyType.PublicKey);
 		byte[] sign =  sm2.sign(src.getBytes(StandardCharsets.UTF_8));
 
-		Assert.assertTrue(sm2.verify( src.getBytes(StandardCharsets.UTF_8), sign));
+		Assertions.assertTrue(sm2.verify( src.getBytes(StandardCharsets.UTF_8), sign));
 
 		byte[] dec =  sm2.decrypt(data, KeyType.PrivateKey);
-		Assert.assertArrayEquals(dec, src.getBytes(StandardCharsets.UTF_8));
+		Assertions.assertArrayEquals(dec, src.getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test
 	public void dLengthTest(){
 		final SM2 sm2 = SmUtil.sm2();
-		Assert.assertEquals(64, sm2.getDHex().length());
-		Assert.assertEquals(32, sm2.getD().length);
+		Assertions.assertEquals(64, sm2.getDHex().length());
+		Assertions.assertEquals(32, sm2.getD().length);
 
 		// 04占位一个字节
-		Assert.assertEquals(65, sm2.getQ(false).length);
+		Assertions.assertEquals(65, sm2.getQ(false).length);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/SignTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/asymmetric/SignTest.java
@@ -5,8 +5,8 @@ import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.SecureUtil;
 import cn.hutool.crypto.asymmetric.Sign;
 import cn.hutool.crypto.asymmetric.SignAlgorithm;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -25,7 +25,7 @@ public class SignTest {
 
 		String privateKey = "MIICdQIBADANBgkqhkiG9w0BAQEFAASCAl8wggJbAgEAAoGBAJ4fG8vJ0tzu7tjXMSJhyNjlE5B7GkTKMKEQlR6LY3IhIhMFVjuA6W+DqH1VMxl9h3GIM4yCKG2VRZEYEPazgVxa5/ifO8W0pfmrzWCPrddUq4t0Slz5u2lLKymLpPjCzboHoDb8VlF+1HOxjKQckAXq9q7U7dV5VxOzJDuZXlz3AgMBAAECgYABo2LfVqT3owYYewpIR+kTzjPIsG3SPqIIWSqiWWFbYlp/BfQhw7EndZ6+Ra602ecYVwfpscOHdx90ZGJwm+WAMkKT4HiWYwyb0ZqQzRBGYDHFjPpfCBxrzSIJ3QL+B8c8YHq4HaLKRKmq7VUF1gtyWaek87rETWAmQoGjt8DyAQJBAOG4OxsT901zjfxrgKwCv6fV8wGXrNfDSViP1t9r3u6tRPsE6Gli0dfMyzxwENDTI75sOEAfyu6xBlemQGmNsfcCQQCzVWQkl9YUoVDWEitvI5MpkvVKYsFLRXKvLfyxLcY3LxpLKBcEeJ/n5wLxjH0GorhJMmM2Rw3hkjUTJCoqqe0BAkATt8FKC0N2O5ryqv1xiUfuxGzW/cX2jzOwDdiqacTuuqok93fKBPzpyhUS8YM2iss7jj6Xs29JzKMOMxK7ZcpfAkAf21lwzrAu9gEgJhYlJhKsXfjJAAYKUwnuaKLs7o65mtp242ZDWxI85eK1+hjzptBJ4HOTXsfufESFY/VBovIBAkAltO886qQRoNSc0OsVlCi4X1DGo6x2RqQ9EsWPrxWEZGYuyEdODrc54b8L+zaUJLfMJdsCIHEUbM7WXxvFVXNv";
 		Sign sign = SecureUtil.sign(SignAlgorithm.SHA1withRSA, privateKey, null);
-		Assert.assertNull(sign.getPublicKeyBase64());
+		Assertions.assertNull(sign.getPublicKeyBase64());
 		// 签名
 		byte[] signed = sign.sign(content.getBytes());
 
@@ -33,7 +33,7 @@ public class SignTest {
 		sign = SecureUtil.sign(SignAlgorithm.SHA1withRSA, null, publicKey);
 		// 验证签名
 		boolean verify = sign.verify(content.getBytes(), signed);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -72,7 +72,7 @@ public class SignTest {
 
 		// 验证签名
 		boolean verify = sign.verify(data, signed);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class SignTest {
 
 		// 验证签名
 		boolean verify = sign.verify(data, signed);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 
 	@Test
@@ -99,11 +99,11 @@ public class SignTest {
 				.put("key2", "value2").build();
 
 		String sign1 = SecureUtil.signParamsSha1(build);
-		Assert.assertEquals("9ed30bfe2efbc7038a824b6c55c24a11bfc0dce5", sign1);
+		Assertions.assertEquals("9ed30bfe2efbc7038a824b6c55c24a11bfc0dce5", sign1);
 		String sign2 = SecureUtil.signParamsSha1(build, "12345678");
-		Assert.assertEquals("944b68d94c952ec178c4caf16b9416b6661f7720", sign2);
+		Assertions.assertEquals("944b68d94c952ec178c4caf16b9416b6661f7720", sign2);
 		String sign3 = SecureUtil.signParamsSha1(build, "12345678", "abc");
-		Assert.assertEquals("edee1b477af1b96ebd20fdf08d818f352928d25d", sign3);
+		Assertions.assertEquals("edee1b477af1b96ebd20fdf08d818f352928d25d", sign3);
 	}
 
 	/**
@@ -120,6 +120,6 @@ public class SignTest {
 
 		// 验证签名
 		boolean verify = sign.verify(data, signed);
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/BCryptTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/BCryptTest.java
@@ -1,14 +1,14 @@
 package cn.hutool.crypto.test.digest;
 
 import cn.hutool.crypto.digest.BCrypt;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BCryptTest {
 
 	@Test
 	public void checkpwTest(){
-		Assert.assertFalse(BCrypt.checkpw("xxx",
+		Assertions.assertFalse(BCrypt.checkpw("xxx",
 				"$2a$2a$10$e4lBTlZ019KhuAFyqAlgB.Jxc6cM66GwkSR/5/xXNQuHUItPLyhzy"));
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/DigestTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/DigestTest.java
@@ -1,6 +1,6 @@
 package cn.hutool.crypto.test.digest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.util.CharsetUtil;
@@ -14,63 +14,63 @@ import cn.hutool.crypto.digest.Digester;
  *
  */
 public class DigestTest {
-	
+
 	@Test
 	public void digesterTest(){
 		String testStr = "test中文";
-		
+
 		Digester md5 = new Digester(DigestAlgorithm.MD5);
 		String digestHex = md5.digestHex(testStr);
-		Assert.assertEquals("5393554e94bf0eb6436f240a4fd71282", digestHex);
+		Assertions.assertEquals("5393554e94bf0eb6436f240a4fd71282", digestHex);
 	}
-	
+
 	@Test
 	public void md5Test(){
 		String testStr = "test中文";
-		
+
 		String md5Hex1 = DigestUtil.md5Hex(testStr);
-		Assert.assertEquals("5393554e94bf0eb6436f240a4fd71282", md5Hex1);
-		
+		Assertions.assertEquals("5393554e94bf0eb6436f240a4fd71282", md5Hex1);
+
 		String md5Hex2 = DigestUtil.md5Hex(IoUtil.toStream(testStr, CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals("5393554e94bf0eb6436f240a4fd71282", md5Hex2);
+		Assertions.assertEquals("5393554e94bf0eb6436f240a4fd71282", md5Hex2);
 	}
-	
+
 	@Test
 	public void md5WithSaltTest(){
 		String testStr = "test中文";
-		
+
 		Digester md5 = new Digester(DigestAlgorithm.MD5);
-		
+
 		//加盐
 		md5.setSalt("saltTest".getBytes());
 		String md5Hex1 = md5.digestHex(testStr);
-		Assert.assertEquals("762f7335200299dfa09bebbb601a5bc6", md5Hex1);
+		Assertions.assertEquals("762f7335200299dfa09bebbb601a5bc6", md5Hex1);
 		String md5Hex2 = md5.digestHex(IoUtil.toUtf8Stream(testStr));
-		Assert.assertEquals("762f7335200299dfa09bebbb601a5bc6", md5Hex2);
-		
+		Assertions.assertEquals("762f7335200299dfa09bebbb601a5bc6", md5Hex2);
+
 		//重复2次
 		md5.setDigestCount(2);
 		String md5Hex3 = md5.digestHex(testStr);
-		Assert.assertEquals("2b0616296f6755d25efc07f90afe9684", md5Hex3);
+		Assertions.assertEquals("2b0616296f6755d25efc07f90afe9684", md5Hex3);
 		String md5Hex4 = md5.digestHex(IoUtil.toUtf8Stream(testStr));
-		Assert.assertEquals("2b0616296f6755d25efc07f90afe9684", md5Hex4);
+		Assertions.assertEquals("2b0616296f6755d25efc07f90afe9684", md5Hex4);
 	}
-	
+
 	@Test
 	public void sha1Test(){
 		String testStr = "test中文";
-		
+
 		String sha1Hex1 = DigestUtil.sha1Hex(testStr);
-		Assert.assertEquals("ecabf586cef0d3b11c56549433ad50b81110a836", sha1Hex1);
-		
+		Assertions.assertEquals("ecabf586cef0d3b11c56549433ad50b81110a836", sha1Hex1);
+
 		String sha1Hex2 = DigestUtil.sha1Hex(IoUtil.toStream(testStr, CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals("ecabf586cef0d3b11c56549433ad50b81110a836", sha1Hex2);
+		Assertions.assertEquals("ecabf586cef0d3b11c56549433ad50b81110a836", sha1Hex2);
 	}
-	
+
 	@Test
 	public void hash256Test() {
 		String testStr = "Test中文";
 		String hex = DigestUtil.sha256Hex(testStr);
-		Assert.assertEquals(64, hex.length());
+		Assertions.assertEquals(64, hex.length());
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/HmacTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/HmacTest.java
@@ -7,8 +7,8 @@ import cn.hutool.crypto.SecureUtil;
 import cn.hutool.crypto.digest.HMac;
 import cn.hutool.crypto.digest.HmacAlgorithm;
 import cn.hutool.crypto.symmetric.ZUC;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.spec.IvParameterSpec;
 
@@ -27,10 +27,10 @@ public class HmacTest {
 		HMac mac = new HMac(HmacAlgorithm.HmacMD5, key);
 
 		String macHex1 = mac.digestHex(testStr);
-		Assert.assertEquals("b977f4b13f93f549e06140971bded384", macHex1);
+		Assertions.assertEquals("b977f4b13f93f549e06140971bded384", macHex1);
 
 		String macHex2 = mac.digestHex(IoUtil.toStream(testStr, CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals("b977f4b13f93f549e06140971bded384", macHex2);
+		Assertions.assertEquals("b977f4b13f93f549e06140971bded384", macHex2);
 	}
 
 	@Test
@@ -40,10 +40,10 @@ public class HmacTest {
 		HMac mac = SecureUtil.hmacMd5("password");
 
 		String macHex1 = mac.digestHex(testStr);
-		Assert.assertEquals("b977f4b13f93f549e06140971bded384", macHex1);
+		Assertions.assertEquals("b977f4b13f93f549e06140971bded384", macHex1);
 
 		String macHex2 = mac.digestHex(IoUtil.toStream(testStr, CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals("b977f4b13f93f549e06140971bded384", macHex2);
+		Assertions.assertEquals("b977f4b13f93f549e06140971bded384", macHex2);
 	}
 
 	@Test
@@ -52,10 +52,10 @@ public class HmacTest {
 
 		String testStr = "test中文";
 		String macHex1 = mac.digestHex(testStr);
-		Assert.assertEquals("1dd68d2f119d5640f0d416e99d3f42408b88d511", macHex1);
+		Assertions.assertEquals("1dd68d2f119d5640f0d416e99d3f42408b88d511", macHex1);
 
 		String macHex2 = mac.digestHex(IoUtil.toStream(testStr, CharsetUtil.CHARSET_UTF_8));
-		Assert.assertEquals("1dd68d2f119d5640f0d416e99d3f42408b88d511", macHex2);
+		Assertions.assertEquals("1dd68d2f119d5640f0d416e99d3f42408b88d511", macHex2);
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class HmacTest {
 
 		String testStr = "test中文";
 		String macHex1 = mac.digestHex(testStr);
-		Assert.assertEquals("1e0b9455", macHex1);
+		Assertions.assertEquals("1e0b9455", macHex1);
 	}
 
 	@Test
@@ -81,6 +81,6 @@ public class HmacTest {
 
 		String testStr = "test中文";
 		String macHex1 = mac.digestHex(testStr);
-		Assert.assertEquals("d9ad618357c1bfb1d9d1200a763d5eaa", macHex1);
+		Assertions.assertEquals("d9ad618357c1bfb1d9d1200a763d5eaa", macHex1);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/Md5Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/Md5Test.java
@@ -1,13 +1,13 @@
 package cn.hutool.crypto.test.digest;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.crypto.digest.MD5;
 
 /**
  * MD5 单元测试
- * 
+ *
  * @author Looly
  *
  */
@@ -16,7 +16,7 @@ public class Md5Test {
 	@Test
 	public void md5To16Test() {
 		String hex16 = new MD5().digestHex16("中国");
-		Assert.assertEquals(16, hex16.length());
-		Assert.assertEquals("cb143acd6c929826", hex16);
+		Assertions.assertEquals(16, hex16.length());
+		Assertions.assertEquals("cb143acd6c929826", hex16);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/OTPTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/digest/OTPTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.codec.Base32;
 import cn.hutool.crypto.digest.HmacAlgorithm;
 import cn.hutool.crypto.digest.otp.HOTP;
 import cn.hutool.crypto.digest.otp.TOTP;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -19,49 +19,49 @@ public class OTPTest {
 	@Test
 	public void genKeyTest() {
 		String key = TOTP.generateSecretKey(8);
-		Assert.assertEquals(8, Base32.decode(key).length);
+		Assertions.assertEquals(8, Base32.decode(key).length);
 	}
 
 	@Test
 	public void validTest() {
 		String key = "VYCFSW2QZ3WZO";
 		// 2021/7/1下午6:29:54 显示code为 106659
-		//Assert.assertEquals(new TOTP(Base32.decode(key)).generate(Instant.ofEpochSecond(1625135394L)),106659);
+		//Assertions.assertEquals(new TOTP(Base32.decode(key)).generate(Instant.ofEpochSecond(1625135394L)),106659);
 		TOTP totp = new TOTP(Base32.decode(key));
 		Instant instant = Instant.ofEpochSecond(1625135394L);
-		Assert.assertTrue(totp.validate(instant, 0, 106659));
-		Assert.assertTrue(totp.validate(instant.plusSeconds(30), 1, 106659));
-		Assert.assertTrue(totp.validate(instant.plusSeconds(60), 2, 106659));
+		Assertions.assertTrue(totp.validate(instant, 0, 106659));
+		Assertions.assertTrue(totp.validate(instant.plusSeconds(30), 1, 106659));
+		Assertions.assertTrue(totp.validate(instant.plusSeconds(60), 2, 106659));
 
-		Assert.assertFalse(totp.validate(instant.plusSeconds(60), 1, 106659));
-		Assert.assertFalse(totp.validate(instant.plusSeconds(90), 2, 106659));
+		Assertions.assertFalse(totp.validate(instant.plusSeconds(60), 1, 106659));
+		Assertions.assertFalse(totp.validate(instant.plusSeconds(90), 2, 106659));
 	}
 
 	@Test
 	public void googleAuthTest() {
 		String str = TOTP.generateGoogleSecretKey("xl7@qq.com", 10);
-		Assert.assertTrue(str.startsWith("otpauth://totp/xl7@qq.com?secret="));
+		Assertions.assertTrue(str.startsWith("otpauth://totp/xl7@qq.com?secret="));
 	}
 
 	@Test
 	public void longPasswordLengthTest() {
-		Assert.assertThrows(IllegalArgumentException.class, () -> new HOTP(9, "123".getBytes()));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> new HOTP(9, "123".getBytes()));
 	}
 
 	@Test
 	public void generateHOPTTest(){
 		byte[] key = "12345678901234567890".getBytes();
 		final HOTP hotp = new HOTP(key);
-		Assert.assertEquals(755224, hotp.generate(0));
-		Assert.assertEquals(287082, hotp.generate(1));
-		Assert.assertEquals(359152, hotp.generate(2));
-		Assert.assertEquals(969429, hotp.generate(3));
-		Assert.assertEquals(338314, hotp.generate(4));
-		Assert.assertEquals(254676, hotp.generate(5));
-		Assert.assertEquals(287922, hotp.generate(6));
-		Assert.assertEquals(162583, hotp.generate(7));
-		Assert.assertEquals(399871, hotp.generate(8));
-		Assert.assertEquals(520489, hotp.generate(9));
+		Assertions.assertEquals(755224, hotp.generate(0));
+		Assertions.assertEquals(287082, hotp.generate(1));
+		Assertions.assertEquals(359152, hotp.generate(2));
+		Assertions.assertEquals(969429, hotp.generate(3));
+		Assertions.assertEquals(338314, hotp.generate(4));
+		Assertions.assertEquals(254676, hotp.generate(5));
+		Assertions.assertEquals(287922, hotp.generate(6));
+		Assertions.assertEquals(162583, hotp.generate(7));
+		Assertions.assertEquals(399871, hotp.generate(8));
+		Assertions.assertEquals(520489, hotp.generate(9));
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class OTPTest {
 
 		final TOTP totp = new TOTP(timeStep, "123".getBytes());
 
-		Assert.assertEquals(timeStep, totp.getTimeStep());
+		Assertions.assertEquals(timeStep, totp.getTimeStep());
 	}
 
 	@Test
@@ -80,17 +80,17 @@ public class OTPTest {
 		TOTP totp = new TOTP(Duration.ofSeconds(30), 8, algorithm, key);
 
 		int generate = totp.generate(Instant.ofEpochSecond(59L));
-		Assert.assertEquals(94287082, generate);
+		Assertions.assertEquals(94287082, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1111111109L));
-		Assert.assertEquals(7081804, generate);
+		Assertions.assertEquals(7081804, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1111111111L));
-		Assert.assertEquals(14050471, generate);
+		Assertions.assertEquals(14050471, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1234567890L));
-		Assert.assertEquals(89005924, generate);
+		Assertions.assertEquals(89005924, generate);
 		generate = totp.generate(Instant.ofEpochSecond(2000000000L));
-		Assert.assertEquals(69279037, generate);
+		Assertions.assertEquals(69279037, generate);
 		generate = totp.generate(Instant.ofEpochSecond(20000000000L));
-		Assert.assertEquals(65353130, generate);
+		Assertions.assertEquals(65353130, generate);
 	}
 
 	@Test
@@ -100,17 +100,17 @@ public class OTPTest {
 		TOTP totp = new TOTP(Duration.ofSeconds(30), 8, algorithm, key);
 
 		int generate = totp.generate(Instant.ofEpochSecond(59L));
-		Assert.assertEquals(46119246, generate);
+		Assertions.assertEquals(46119246, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1111111109L));
-		Assert.assertEquals(68084774, generate);
+		Assertions.assertEquals(68084774, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1111111111L));
-		Assert.assertEquals(67062674, generate);
+		Assertions.assertEquals(67062674, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1234567890L));
-		Assert.assertEquals(91819424, generate);
+		Assertions.assertEquals(91819424, generate);
 		generate = totp.generate(Instant.ofEpochSecond(2000000000L));
-		Assert.assertEquals(90698825, generate);
+		Assertions.assertEquals(90698825, generate);
 		generate = totp.generate(Instant.ofEpochSecond(20000000000L));
-		Assert.assertEquals(77737706, generate);
+		Assertions.assertEquals(77737706, generate);
 	}
 
 	@Test
@@ -120,16 +120,16 @@ public class OTPTest {
 		TOTP totp = new TOTP(Duration.ofSeconds(30), 8, algorithm, key);
 
 		int generate = totp.generate(Instant.ofEpochSecond(59L));
-		Assert.assertEquals(90693936, generate);
+		Assertions.assertEquals(90693936, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1111111109L));
-		Assert.assertEquals(25091201, generate);
+		Assertions.assertEquals(25091201, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1111111111L));
-		Assert.assertEquals(99943326, generate);
+		Assertions.assertEquals(99943326, generate);
 		generate = totp.generate(Instant.ofEpochSecond(1234567890L));
-		Assert.assertEquals(93441116, generate);
+		Assertions.assertEquals(93441116, generate);
 		generate = totp.generate(Instant.ofEpochSecond(2000000000L));
-		Assert.assertEquals(38618901, generate);
+		Assertions.assertEquals(38618901, generate);
 		generate = totp.generate(Instant.ofEpochSecond(20000000000L));
-		Assert.assertEquals(47863826, generate);
+		Assertions.assertEquals(47863826, generate);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/AESTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/AESTest.java
@@ -7,8 +7,8 @@ import cn.hutool.crypto.KeyUtil;
 import cn.hutool.crypto.Mode;
 import cn.hutool.crypto.Padding;
 import cn.hutool.crypto.symmetric.AES;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
@@ -22,7 +22,7 @@ public class AESTest {
 		AES aes = new AES(Mode.CBC, Padding.PKCS5Padding,
 				"1234567890123456".getBytes(), "1234567890123456".getBytes());
 		String encryptHex = aes.encryptHex("123456");
-		Assert.assertEquals("d637735ae9e21ba50cb686b74fab8d2c", encryptHex);
+		Assertions.assertEquals("d637735ae9e21ba50cb686b74fab8d2c", encryptHex);
 	}
 
 	@Test
@@ -31,7 +31,7 @@ public class AESTest {
 		AES aes = new AES(Mode.CTS, Padding.PKCS5Padding,
 				"0CoJUm6Qyw8W8jue".getBytes(), "0102030405060708".getBytes());
 		final String encryptHex = aes.encryptHex(content);
-		Assert.assertEquals("8dc9de7f050e86ca2c8261dde56dfec9", encryptHex);
+		Assertions.assertEquals("8dc9de7f050e86ca2c8261dde56dfec9", encryptHex);
 	}
 
 	@Test
@@ -40,7 +40,7 @@ public class AESTest {
 		AES aes = new AES(Mode.CBC.name(), "pkcs7padding",
 				"1234567890123456".getBytes(), "1234567890123456".getBytes());
 		String encryptHex = aes.encryptHex("123456");
-		Assert.assertEquals("d637735ae9e21ba50cb686b74fab8d2c", encryptHex);
+		Assertions.assertEquals("d637735ae9e21ba50cb686b74fab8d2c", encryptHex);
 	}
 
 	/**
@@ -72,32 +72,32 @@ public class AESTest {
 		// 加密数据为16进制字符串
 		String encryptHex = aes.encryptHex(HexUtil.decodeHex("16c5"));
 		// 加密后的Hex
-		Assert.assertEquals("25869eb3ff227d9e34b3512d3c3c92ed", encryptHex);
+		Assertions.assertEquals("25869eb3ff227d9e34b3512d3c3c92ed", encryptHex);
 
 		// 加密数据为16进制字符串
 		String encryptHex2 = aes.encryptBase64(HexUtil.decodeHex("16c5"));
 		// 加密后的Base64
-		Assert.assertEquals("JYaes/8ifZ40s1EtPDyS7Q==", encryptHex2);
+		Assertions.assertEquals("JYaes/8ifZ40s1EtPDyS7Q==", encryptHex2);
 
 		// 解密
-		Assert.assertEquals("16c5", HexUtil.encodeHexStr(aes.decrypt("25869eb3ff227d9e34b3512d3c3c92ed")));
-		Assert.assertEquals("16c5", HexUtil.encodeHexStr(aes.decrypt(HexUtil.encodeHexStr(Base64.decode("JYaes/8ifZ40s1EtPDyS7Q==")))));
+		Assertions.assertEquals("16c5", HexUtil.encodeHexStr(aes.decrypt("25869eb3ff227d9e34b3512d3c3c92ed")));
+		Assertions.assertEquals("16c5", HexUtil.encodeHexStr(aes.decrypt(HexUtil.encodeHexStr(Base64.decode("JYaes/8ifZ40s1EtPDyS7Q==")))));
 		// ------------------------------------------------------------------------
 
 		// ------------------------------------------------------------------------
 		// 加密数据为字符串(UTF-8)
 		String encryptStr = aes.encryptHex("16c5");
 		// 加密后的Hex
-		Assert.assertEquals("79c210d3e304932cf9ea6a9c887c6d7c", encryptStr);
+		Assertions.assertEquals("79c210d3e304932cf9ea6a9c887c6d7c", encryptStr);
 
 		// 加密数据为字符串(UTF-8)
 		String encryptStr2 = aes.encryptBase64("16c5");
 		// 加密后的Base64
-		Assert.assertEquals("ecIQ0+MEkyz56mqciHxtfA==", encryptStr2);
+		Assertions.assertEquals("ecIQ0+MEkyz56mqciHxtfA==", encryptStr2);
 
 		// 解密
-		Assert.assertEquals("16c5", aes.decryptStr("79c210d3e304932cf9ea6a9c887c6d7c"));
-		Assert.assertEquals("16c5", aes.decryptStr(Base64.decode("ecIQ0+MEkyz56mqciHxtfA==")));
+		Assertions.assertEquals("16c5", aes.decryptStr("79c210d3e304932cf9ea6a9c887c6d7c"));
+		Assertions.assertEquals("16c5", aes.decryptStr(Base64.decode("ecIQ0+MEkyz56mqciHxtfA==")));
 		// ------------------------------------------------------------------------
 	}
 
@@ -111,7 +111,7 @@ public class AESTest {
 		final String result1 = aes.encryptBase64(content);
 
 		final String decryptStr = aes.decryptStr(result1);
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	/**
@@ -131,6 +131,6 @@ public class AESTest {
 		// 加密
 		byte[] encrypt = aes.encrypt(phone);
 		final String decryptStr = aes.decryptStr(encrypt);
-		Assert.assertEquals(phone, decryptStr);
+		Assertions.assertEquals(phone, decryptStr);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/ChaCha20Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/ChaCha20Test.java
@@ -3,8 +3,8 @@ package cn.hutool.crypto.test.symmetric;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.RandomUtil;
 import cn.hutool.crypto.symmetric.ChaCha20;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 见：https://stackoverflow.com/questions/32672241/using-bouncycastles-chacha-for-file-encryption
@@ -26,6 +26,6 @@ public class ChaCha20Test {
 		// 解密为字符串
 		String decryptStr = chacha.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/DesTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/DesTest.java
@@ -5,8 +5,8 @@ import cn.hutool.crypto.Mode;
 import cn.hutool.crypto.Padding;
 import cn.hutool.crypto.SecureUtil;
 import cn.hutool.crypto.symmetric.DES;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * DES加密解密单元测试
@@ -21,7 +21,7 @@ public class DesTest {
 		final String encryptHex = des.encryptHex(content);
 		final String result = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, result);
+		Assertions.assertEquals(content, result);
 	}
 
 	@Test
@@ -37,6 +37,6 @@ public class DesTest {
 		final String encryptHex = des.encryptHex(content);
 		final String result = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, result);
+		Assertions.assertEquals(content, result);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/PBKDF2Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/PBKDF2Test.java
@@ -2,14 +2,14 @@ package cn.hutool.crypto.test.symmetric;
 
 import cn.hutool.core.util.RandomUtil;
 import cn.hutool.crypto.SecureUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PBKDF2Test {
 
 	@Test
 	public void encryptTest(){
 		final String s = SecureUtil.pbkdf2("123456".toCharArray(), RandomUtil.randomBytes(16));
-		Assert.assertEquals(128, s.length());
+		Assertions.assertEquals(128, s.length());
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/RC4Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/RC4Test.java
@@ -1,13 +1,13 @@
 package cn.hutool.crypto.test.symmetric;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.crypto.symmetric.RC4;
 
 public class RC4Test {
-	
+
 	@Test
 	public void testCryptMessage() {
 		String key = "This is pretty long key";
@@ -15,12 +15,12 @@ public class RC4Test {
 		String message = "Hello, World!";
 		byte[] crypt = rc4.encrypt(message);
 		String msg = rc4.decrypt(crypt);
-		Assert.assertEquals(message, msg);
-		
+		Assertions.assertEquals(message, msg);
+
 		String message2 = "Hello, World， this is megssage 2";
 		byte[] crypt2 = rc4.encrypt(message2);
 		String msg2 = rc4.decrypt(crypt2);
-		Assert.assertEquals(message2, msg2);
+		Assertions.assertEquals(message2, msg2);
 	}
 
 	@Test
@@ -30,12 +30,12 @@ public class RC4Test {
 		RC4 rc4 = new RC4(key);
 		byte[] crypt = rc4.encrypt(message);
 		String msg = rc4.decrypt(crypt);
-		Assert.assertEquals(message, msg);
-		
+		Assertions.assertEquals(message, msg);
+
 		String message2 = "这是第二个中文消息！";
 		byte[] crypt2 = rc4.encrypt(message2);
 		String msg2 = rc4.decrypt(crypt2);
-		Assert.assertEquals(message2, msg2);
+		Assertions.assertEquals(message2, msg2);
 	}
 
 	@Test
@@ -45,12 +45,12 @@ public class RC4Test {
 		RC4 rc4 = new RC4(key);
 		String encryptHex = rc4.encryptHex(message, CharsetUtil.CHARSET_UTF_8);
 		String msg = rc4.decrypt(encryptHex);
-		Assert.assertEquals(message, msg);
+		Assertions.assertEquals(message, msg);
 
 		String message2 = "这是第二个用来测试密文为十六进制字符串的消息！";
 		String encryptHex2 = rc4.encryptHex(message2);
 		String msg2 = rc4.decrypt(encryptHex2);
-		Assert.assertEquals(message2, msg2);
+		Assertions.assertEquals(message2, msg2);
 	}
 
 
@@ -61,11 +61,11 @@ public class RC4Test {
 		RC4 rc4 = new RC4(key);
 		String encryptHex = rc4.encryptBase64(message, CharsetUtil.CHARSET_UTF_8);
 		String msg = rc4.decrypt(encryptHex);
-		Assert.assertEquals(message, msg);
+		Assertions.assertEquals(message, msg);
 
 		String message2 = "这是第一个用来测试密文为Base64编码的消息！";
 		String encryptHex2 = rc4.encryptBase64(message2);
 		String msg2 = rc4.decrypt(encryptHex2);
-		Assert.assertEquals(message2, msg2);
+		Assertions.assertEquals(message2, msg2);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/Sm4StreamTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/Sm4StreamTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.crypto.test.symmetric;
 
 import cn.hutool.crypto.symmetric.SM4;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -20,7 +20,7 @@ public class Sm4StreamTest {
 	private static final boolean IS_CLOSE = false;
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sm4Test(){
 		String source = "d:/test/sm4_1.txt";
 		String target = "d:/test/sm4_2.data";

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/SymmetricTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/SymmetricTest.java
@@ -15,8 +15,8 @@ import cn.hutool.crypto.symmetric.DESede;
 import cn.hutool.crypto.symmetric.SymmetricAlgorithm;
 import cn.hutool.crypto.symmetric.SymmetricCrypto;
 import cn.hutool.crypto.symmetric.Vigenere;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -43,14 +43,14 @@ public class SymmetricTest {
 		// 解密
 		byte[] decrypt = aes.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+		Assertions.assertEquals(content, StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
 
 		// 加密为16进制表示
 		String encryptHex = aes.encryptHex(content);
 		// 解密为字符串
 		String decryptStr = aes.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -68,14 +68,14 @@ public class SymmetricTest {
 		// 解密
 		byte[] decrypt = aes.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		// 加密为16进制表示
 		String encryptHex = aes.encryptHex(content);
 		// 解密为字符串
 		String decryptStr = aes.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -89,14 +89,14 @@ public class SymmetricTest {
 		// 解密
 		byte[] decrypt = aes.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		// 加密为16进制表示
 		String encryptHex = aes.encryptHex(content);
 		// 解密为字符串
 		String decryptStr = aes.decryptStr(encryptHex, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class SymmetricTest {
 		// 加密为16进制表示
 		String encryptHex = aes.encryptHex(content);
 
-		Assert.assertEquals("cd0e3a249eaf0ed80c330338508898c4bddcfd665a1b414622164a273ca5daf7b4ebd2c00aaa66b84dd0a237708dac8e", encryptHex);
+		Assertions.assertEquals("cd0e3a249eaf0ed80c330338508898c4bddcfd665a1b414622164a273ca5daf7b4ebd2c00aaa66b84dd0a237708dac8e", encryptHex);
 	}
 
 	@Test
@@ -120,7 +120,7 @@ public class SymmetricTest {
 		String encryptHex = crypto.encryptHex(content);
 		final String data = crypto.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, data);
+		Assertions.assertEquals(content, data);
 	}
 
 	@Test
@@ -133,8 +133,8 @@ public class SymmetricTest {
 		String randomData = aes.updateHex(content.getBytes(StandardCharsets.UTF_8));
 		aes.setMode(CipherMode.encrypt);
 		String randomData2 = aes.updateHex(content.getBytes(StandardCharsets.UTF_8));
-		Assert.assertEquals(randomData2, randomData);
-		Assert.assertEquals(randomData, "cd0e3a249eaf0ed80c330338508898c4");
+		Assertions.assertEquals(randomData2, randomData);
+		Assertions.assertEquals(randomData, "cd0e3a249eaf0ed80c330338508898c4");
 	}
 
 
@@ -147,7 +147,7 @@ public class SymmetricTest {
 		String encryptHex = aes.encryptHex(content);
 		// 解密
 		String decryptStr = aes.decryptStr(encryptHex);
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -161,7 +161,7 @@ public class SymmetricTest {
 		final ByteArrayOutputStream contentStream = new ByteArrayOutputStream();
 		aes.decrypt(IoUtil.toStream(encryptStream), contentStream, true);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(contentStream.toByteArray()));
+		Assertions.assertEquals(content, StrUtil.utf8Str(contentStream.toByteArray()));
 	}
 
 	@Test
@@ -175,7 +175,7 @@ public class SymmetricTest {
 		String encryptHex = aes.encryptHex(content);
 		// 解密
 		String decryptStr = aes.decryptStr(encryptHex);
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -188,12 +188,12 @@ public class SymmetricTest {
 		byte[] encrypt = des.encrypt(content);
 		byte[] decrypt = des.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		String encryptHex = des.encryptHex(content);
 		String decryptStr = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -206,12 +206,12 @@ public class SymmetricTest {
 		byte[] encrypt = des.encrypt(content);
 		byte[] decrypt = des.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		String encryptHex = des.encryptHex(content);
 		String decryptStr = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -223,12 +223,12 @@ public class SymmetricTest {
 		byte[] encrypt = des.encrypt(content);
 		byte[] decrypt = des.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		String encryptHex = des.encryptHex(content);
 		String decryptStr = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -242,12 +242,12 @@ public class SymmetricTest {
 		byte[] encrypt = des.encrypt(content);
 		byte[] decrypt = des.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		String encryptHex = des.encryptHex(content);
 		String decryptStr = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -261,12 +261,12 @@ public class SymmetricTest {
 		byte[] encrypt = des.encrypt(content);
 		byte[] decrypt = des.decrypt(encrypt);
 
-		Assert.assertEquals(content, StrUtil.utf8Str(decrypt));
+		Assertions.assertEquals(content, StrUtil.utf8Str(decrypt));
 
 		String encryptHex = des.encryptHex(content);
 		String decryptStr = des.decryptStr(encryptHex);
 
-		Assert.assertEquals(content, decryptStr);
+		Assertions.assertEquals(content, decryptStr);
 	}
 
 	@Test
@@ -275,8 +275,8 @@ public class SymmetricTest {
 		String key = "CompleteVictory";
 
 		String encrypt = Vigenere.encrypt(content, key);
-		Assert.assertEquals("zXScRZ]KIOMhQjc0\\bYRXZOJK[Vi", encrypt);
+		Assertions.assertEquals("zXScRZ]KIOMhQjc0\\bYRXZOJK[Vi", encrypt);
 		String decrypt = Vigenere.decrypt(encrypt, key);
-		Assert.assertEquals(content, decrypt);
+		Assertions.assertEquals(content, decrypt);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/ZucTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/ZucTest.java
@@ -3,8 +3,8 @@ package cn.hutool.crypto.test.symmetric;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.RandomUtil;
 import cn.hutool.crypto.symmetric.ZUC;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ZucTest {
 
@@ -17,7 +17,7 @@ public class ZucTest {
 		String msg = RandomUtil.randomString(500);
 		byte[] crypt2 = zuc.encrypt(msg);
 		String msg2 = zuc.decryptStr(crypt2, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(msg, msg2);
+		Assertions.assertEquals(msg, msg2);
 	}
 
 	@Test
@@ -29,6 +29,6 @@ public class ZucTest {
 		String msg = RandomUtil.randomString(500);
 		byte[] crypt2 = zuc.encrypt(msg);
 		String msg2 = zuc.decryptStr(crypt2, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(msg, msg2);
+		Assertions.assertEquals(msg, msg2);
 	}
 }

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/fpe/FPETest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/test/symmetric/fpe/FPETest.java
@@ -3,8 +3,8 @@ package cn.hutool.crypto.test.symmetric.fpe;
 import cn.hutool.core.util.RandomUtil;
 import cn.hutool.crypto.symmetric.fpe.FPE;
 import org.bouncycastle.crypto.util.BasicAlphabetMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class FPETest {
 
@@ -21,10 +21,10 @@ public class FPETest {
 		String phone = RandomUtil.randomString("A0123456789", 13);
 		final String encrypt = fpe.encrypt(phone);
 		// 加密后与原密文长度一致
-		Assert.assertEquals(phone.length(), encrypt.length());
+		Assertions.assertEquals(phone.length(), encrypt.length());
 
 		final String decrypt = fpe.decrypt(encrypt);
-		Assert.assertEquals(phone, decrypt);
+		Assertions.assertEquals(phone, decrypt);
 	}
 
 	@Test
@@ -40,9 +40,9 @@ public class FPETest {
 		String phone = RandomUtil.randomString("A0123456789", 13);
 		final String encrypt = fpe.encrypt(phone);
 		// 加密后与原密文长度一致
-		Assert.assertEquals(phone.length(), encrypt.length());
+		Assertions.assertEquals(phone.length(), encrypt.length());
 
 		final String decrypt = fpe.decrypt(encrypt);
-		Assert.assertEquals(phone, decrypt);
+		Assertions.assertEquals(phone, decrypt);
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/CRUDTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/CRUDTest.java
@@ -7,9 +7,9 @@ import cn.hutool.db.handler.EntityListHandler;
 import cn.hutool.db.pojo.User;
 import cn.hutool.db.sql.Condition;
 import cn.hutool.db.sql.Condition.LikeType;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -28,96 +28,96 @@ public class CRUDTest {
 	@Test
 	public void findIsNullTest() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("age", "is null"));
-		Assert.assertEquals(0, results.size());
+		Assertions.assertEquals(0, results.size());
 	}
 
 	@Test
 	public void findIsNullTest2() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("age", "= null"));
-		Assert.assertEquals(0, results.size());
+		Assertions.assertEquals(0, results.size());
 	}
 
 	@Test
 	public void findIsNullTest3() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("age", null));
-		Assert.assertEquals(0, results.size());
+		Assertions.assertEquals(0, results.size());
 	}
 
 	@Test
 	public void findBetweenTest() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("age", "between '18' and '40'"));
-		Assert.assertEquals(1, results.size());
+		Assertions.assertEquals(1, results.size());
 	}
 
 	@Test
 	public void findByBigIntegerTest() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("age", new BigInteger("12")));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findByBigDecimalTest() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("age", new BigDecimal("12")));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findLikeTest() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("name", "like \"%三%\""));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findLikeTest2() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("name", new Condition("name", "三", LikeType.Contains)));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findLikeTest3() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("name", new Condition("name", null, LikeType.Contains)));
-		Assert.assertEquals(0, results.size());
+		Assertions.assertEquals(0, results.size());
 	}
 
 	@Test
 	public void findInTest() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user").set("id", "in 1,2,3"));
 		Console.log(results);
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findInTest2() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user")
 				.set("id", new Condition("id", new long[]{1, 2, 3})));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findInTest3() throws SQLException {
 		List<Entity> results = db.findAll(Entity.create("user")
 				.set("id", new long[]{1, 2, 3}));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 
 	@Test
 	public void findAllTest() throws SQLException {
 		List<Entity> results = db.findAll("user");
-		Assert.assertEquals(4, results.size());
+		Assertions.assertEquals(4, results.size());
 	}
 
 	@Test
 	public void findTest() throws SQLException {
 		List<Entity> find = db.find(CollUtil.newArrayList("name AS name2"), Entity.create("user"), new EntityListHandler());
-		Assert.assertFalse(find.isEmpty());
+		Assertions.assertFalse(find.isEmpty());
 	}
 
 	@Test
 	public void findActiveTest() {
 		ActiveEntity entity = new ActiveEntity(db, "user");
 		entity.setFieldNames("name AS name2").load();
-		Assert.assertEquals("user", entity.getTableName());
-		Assert.assertFalse(entity.isEmpty());
+		Assertions.assertEquals("user", entity.getTableName());
+		Assertions.assertFalse(entity.isEmpty());
 	}
 
 	/**
@@ -126,30 +126,30 @@ public class CRUDTest {
 	 * @throws SQLException SQL异常
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void crudTest() throws SQLException {
 
 		// 增
 		Long id = db.insertForGeneratedKey(Entity.create("user").set("name", "unitTestUser").set("age", 66));
-		Assert.assertTrue(id > 0);
+		Assertions.assertTrue(id > 0);
 		Entity result = db.get("user", "name", "unitTestUser");
-		Assert.assertSame(66, result.getInt("age"));
+		Assertions.assertSame(66, result.getInt("age"));
 
 		// 改
 		int update = db.update(Entity.create().set("age", 88), Entity.create("user").set("name", "unitTestUser"));
-		Assert.assertTrue(update > 0);
+		Assertions.assertTrue(update > 0);
 		Entity result2 = db.get("user", "name", "unitTestUser");
-		Assert.assertSame(88, result2.getInt("age"));
+		Assertions.assertSame(88, result2.getInt("age"));
 
 		// 删
 		int del = db.del("user", "name", "unitTestUser");
-		Assert.assertTrue(del > 0);
+		Assertions.assertTrue(del > 0);
 		Entity result3 = db.get("user", "name", "unitTestUser");
-		Assert.assertNull(result3);
+		Assertions.assertNull(result3);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void insertBatchTest() throws SQLException {
 		User user1 = new User();
 		user1.setName("张三");
@@ -175,7 +175,7 @@ public class CRUDTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void insertBatchOneTest() throws SQLException {
 		User user1 = new User();
 		user1.setName("张三");
@@ -195,6 +195,6 @@ public class CRUDTest {
 	public void selectInTest() throws SQLException {
 		final List<Entity> results = db.query("select * from user where id in (:ids)",
 				MapUtil.of("ids", new int[]{1, 2, 3}));
-		Assert.assertEquals(2, results.size());
+		Assertions.assertEquals(2, results.size());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/ConcurentTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/ConcurentTest.java
@@ -4,29 +4,29 @@ import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.db.handler.EntityListHandler;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * SqlRunner线程安全测试
- * 
+ *
  * @author looly
  *
  */
-@Ignore
+@Disabled
 public class ConcurentTest {
-	
+
 	private Db db;
-	
-	@Before
+
+	@BeforeEach
 	public void init() {
 		db = Db.use("test");
 	}
-	
+
 	@Test
 	public void findTest() {
 		for(int i = 0; i < 10000; i++) {
@@ -40,7 +40,7 @@ public class ConcurentTest {
 				Console.log(find);
 			});
 		}
-		
+
 		//主线程关闭会导致连接池销毁，sleep避免此情况引起的问题
 		ThreadUtil.sleep(5000);
 	}

--- a/hutool-db/src/test/java/cn/hutool/db/ConcurentTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/ConcurentTest.java
@@ -4,7 +4,7 @@ import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.db.handler.EntityListHandler;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -20,10 +20,10 @@ import java.util.List;
 @Disabled
 public class ConcurentTest {
 
-	private Db db;
+	static Db db;
 
-	@BeforeEach
-	public void init() {
+	@BeforeAll
+	public static void init() {
 		db = Db.use("test");
 	}
 

--- a/hutool-db/src/test/java/cn/hutool/db/DbTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/DbTest.java
@@ -3,9 +3,9 @@ package cn.hutool.db;
 import cn.hutool.db.handler.EntityListHandler;
 import cn.hutool.db.sql.Condition;
 import cn.hutool.log.StaticLog;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -22,22 +22,22 @@ public class DbTest {
 	@Test
 	public void queryTest() throws SQLException {
 		List<Entity> find = Db.use().query("select * from user where age = ?", 18);
-		Assert.assertEquals("王五", find.get(0).get("name"));
+		Assertions.assertEquals("王五", find.get(0).get("name"));
 	}
 
 	@Test
 	public void findTest() throws SQLException {
 		List<Entity> find = Db.use().find(Entity.create("user").set("age", 18));
-		Assert.assertEquals("王五", find.get(0).get("name"));
+		Assertions.assertEquals("王五", find.get(0).get("name"));
 	}
 
 	@Test
 	public void pageTest() throws SQLException {
 		// 测试数据库中一共4条数据，第0页有3条，第1页有1条
 		List<Entity> page0 = Db.use().page(Entity.create("user"), 0, 3);
-		Assert.assertEquals(3, page0.size());
+		Assertions.assertEquals(3, page0.size());
 		List<Entity> page1 = Db.use().page(Entity.create("user"), 1, 3);
-		Assert.assertEquals(1, page1.size());
+		Assertions.assertEquals(1, page1.size());
 	}
 
 	@Test
@@ -46,11 +46,11 @@ public class DbTest {
 		// 测试数据库中一共4条数据，第0页有3条，第1页有1条
 		List<Entity> page0 = Db.use().page(
 				sql, Page.of(0, 3));
-		Assert.assertEquals(3, page0.size());
+		Assertions.assertEquals(3, page0.size());
 
 		List<Entity> page1 = Db.use().page(
 				sql, Page.of(1, 3));
-		Assert.assertEquals(1, page1.size());
+		Assertions.assertEquals(1, page1.size());
 	}
 
 	@Test
@@ -59,36 +59,36 @@ public class DbTest {
 		PageResult<Entity> result = Db.use().page(
 				sql, Page.of(0, 3), "张三");
 
-		Assert.assertEquals(2, result.getTotal());
-		Assert.assertEquals(1, result.getTotalPage());
-		Assert.assertEquals(2, result.size());
+		Assertions.assertEquals(2, result.getTotal());
+		Assertions.assertEquals(1, result.getTotalPage());
+		Assertions.assertEquals(2, result.size());
 	}
 
 	@Test
 	public void countTest() throws SQLException {
 		final long count = Db.use().count("select * from user");
-		Assert.assertEquals(4, count);
+		Assertions.assertEquals(4, count);
 	}
 
 	@Test
 	public void countTest2() throws SQLException {
 		final long count = Db.use().count("select * from user order by name DESC");
-		Assert.assertEquals(4, count);
+		Assertions.assertEquals(4, count);
 	}
 
 	@Test
 	public void findLikeTest() throws SQLException {
 		// 方式1
 		List<Entity> find = Db.use().find(Entity.create("user").set("name", "like 王%"));
-		Assert.assertEquals("王五", find.get(0).get("name"));
+		Assertions.assertEquals("王五", find.get(0).get("name"));
 
 		// 方式2
 		find = Db.use().findLike("user", "name", "王", Condition.LikeType.StartWith);
-		Assert.assertEquals("王五", find.get(0).get("name"));
+		Assertions.assertEquals("王五", find.get(0).get("name"));
 
 		// 方式3
 		find = Db.use().query("select * from user where name like ?", "王%");
-		Assert.assertEquals("王五", find.get(0).get("name"));
+		Assertions.assertEquals("王五", find.get(0).get("name"));
 	}
 
 	@Test
@@ -100,11 +100,11 @@ public class DbTest {
 		for (Entity entity : find) {
 			StaticLog.debug("{}", entity);
 		}
-		Assert.assertEquals("unitTestUser", find.get(0).get("name"));
+		Assertions.assertEquals("unitTestUser", find.get(0).get("name"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void txTest() throws SQLException {
 		Db.use().tx(db -> {
 			db.insert(Entity.create("user").set("name", "unitTestUser2"));
@@ -114,7 +114,7 @@ public class DbTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void queryFetchTest() throws SQLException {
 		// https://gitee.com/dromara/hutool/issues/I4JXWN
 		Db.use().query((conn->{

--- a/hutool-db/src/test/java/cn/hutool/db/DerbyTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/DerbyTest.java
@@ -1,24 +1,24 @@
 package cn.hutool.db;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * Derby数据库单元测试
- * 
+ *
  * @author looly
  *
  */
 public class DerbyTest {
-	
+
 	private static final String DS_GROUP_NAME = "derby";
-	
-	@BeforeClass
+
+	@BeforeAll
 	public static void init() throws SQLException {
 		Db db = Db.use(DS_GROUP_NAME);
 		try{
@@ -33,18 +33,18 @@ public class DerbyTest {
 		db.insert(Entity.create("test").set("a", 3).set("b", 31));
 		db.insert(Entity.create("test").set("a", 4).set("b", 41));
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void queryTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).query("select * from test");
-		Assert.assertEquals(4, query.size());
+		Assertions.assertEquals(4, query.size());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void findTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).find(Entity.create("test"));
-		Assert.assertEquals(4, query.size());
+		Assertions.assertEquals(4, query.size());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/DerbyTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/DerbyTest.java
@@ -14,6 +14,7 @@ import java.util.List;
  * @author looly
  *
  */
+@Disabled
 public class DerbyTest {
 
 	private static final String DS_GROUP_NAME = "derby";
@@ -35,14 +36,12 @@ public class DerbyTest {
 	}
 
 	@Test
-	@Disabled
 	public void queryTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).query("select * from test");
 		Assertions.assertEquals(4, query.size());
 	}
 
 	@Test
-	@Disabled
 	public void findTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).find(Entity.create("test"));
 		Assertions.assertEquals(4, query.size());

--- a/hutool-db/src/test/java/cn/hutool/db/DsTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/DsTest.java
@@ -9,8 +9,8 @@ import cn.hutool.db.ds.druid.DruidDSFactory;
 import cn.hutool.db.ds.hikari.HikariDSFactory;
 import cn.hutool.db.ds.pooled.PooledDSFactory;
 import cn.hutool.db.ds.tomcat.TomcatDSFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -29,7 +29,7 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -38,7 +38,7 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -48,7 +48,7 @@ public class DsTest {
 
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -66,7 +66,7 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -84,7 +84,7 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 
 	@Test
@@ -93,6 +93,6 @@ public class DsTest {
 		DataSource ds = DSFactory.get("test");
 		Db db = Db.use(ds);
 		List<Entity> all = db.findAll("user");
-		Assert.assertTrue(CollUtil.isNotEmpty(all));
+		Assertions.assertTrue(CollUtil.isNotEmpty(all));
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/EntityTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/EntityTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.db;
 
 import cn.hutool.db.pojo.User;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Entity测试
@@ -19,8 +19,8 @@ public class EntityTest {
 		user.setName("test");
 
 		Entity entity = Entity.create("testTable").parseBean(user);
-		Assert.assertEquals(Integer.valueOf(1), entity.getInt("id"));
-		Assert.assertEquals("test", entity.getStr("name"));
+		Assertions.assertEquals(Integer.valueOf(1), entity.getInt("id"));
+		Assertions.assertEquals("test", entity.getStr("name"));
 	}
 
 	@Test
@@ -30,9 +30,9 @@ public class EntityTest {
 		user.setName("test");
 
 		Entity entity = Entity.create().parseBean(user);
-		Assert.assertEquals(Integer.valueOf(1), entity.getInt("id"));
-		Assert.assertEquals("test", entity.getStr("name"));
-		Assert.assertEquals("user", entity.getTableName());
+		Assertions.assertEquals(Integer.valueOf(1), entity.getInt("id"));
+		Assertions.assertEquals("test", entity.getStr("name"));
+		Assertions.assertEquals("user", entity.getTableName());
 	}
 
 	@Test
@@ -42,9 +42,9 @@ public class EntityTest {
 
 		Entity entity = Entity.create().parseBean(user, false, true);
 
-		Assert.assertFalse(entity.containsKey("id"));
-		Assert.assertEquals("test", entity.getStr("name"));
-		Assert.assertEquals("user", entity.getTableName());
+		Assertions.assertFalse(entity.containsKey("id"));
+		Assertions.assertEquals("test", entity.getStr("name"));
+		Assertions.assertEquals("user", entity.getTableName());
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class EntityTest {
 		Entity entity = Entity.create().set("ID", 2).set("NAME", "testName");
 		User user = entity.toBeanIgnoreCase(User.class);
 
-		Assert.assertEquals(Integer.valueOf(2), user.getId());
-		Assert.assertEquals("testName", user.getName());
+		Assertions.assertEquals(Integer.valueOf(2), user.getId());
+		Assertions.assertEquals("testName", user.getName());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/FindBeanTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/FindBeanTest.java
@@ -1,16 +1,16 @@
 package cn.hutool.db;
 
 import cn.hutool.db.pojo.User;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * Entity测试
- * 
+ *
  * @author looly
  *
  */
@@ -18,7 +18,7 @@ public class FindBeanTest {
 
 	Db db;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		db = Db.use("test");
 	}
@@ -26,43 +26,43 @@ public class FindBeanTest {
 	@Test
 	public void findAllBeanTest() throws SQLException {
 		List<User> results = db.findAll(Entity.create("user"), User.class);
-		
-		Assert.assertEquals(4, results.size());
-		Assert.assertEquals(Integer.valueOf(1), results.get(0).getId());
-		Assert.assertEquals("张三", results.get(0).getName());
+
+		Assertions.assertEquals(4, results.size());
+		Assertions.assertEquals(Integer.valueOf(1), results.get(0).getId());
+		Assertions.assertEquals("张三", results.get(0).getName());
 	}
-	
+
 	@Test
 	@SuppressWarnings("rawtypes")
 	public void findAllListTest() throws SQLException {
 		List<List> results = db.findAll(Entity.create("user"), List.class);
-		
-		Assert.assertEquals(4, results.size());
-		Assert.assertEquals(1, results.get(0).get(0));
-		Assert.assertEquals("张三", results.get(0).get(1));
+
+		Assertions.assertEquals(4, results.size());
+		Assertions.assertEquals(1, results.get(0).get(0));
+		Assertions.assertEquals("张三", results.get(0).get(1));
 	}
-	
+
 	@Test
 	public void findAllArrayTest() throws SQLException {
 		List<Object[]> results = db.findAll(Entity.create("user"), Object[].class);
-		
-		Assert.assertEquals(4, results.size());
-		Assert.assertEquals(1, results.get(0)[0]);
-		Assert.assertEquals("张三", results.get(0)[1]);
+
+		Assertions.assertEquals(4, results.size());
+		Assertions.assertEquals(1, results.get(0)[0]);
+		Assertions.assertEquals("张三", results.get(0)[1]);
 	}
-	
+
 	@Test
 	public void findAllStringTest() throws SQLException {
 		List<String> results = db.findAll(Entity.create("user"), String.class);
-		Assert.assertEquals(4, results.size());
+		Assertions.assertEquals(4, results.size());
 	}
-	
+
 	@Test
 	public void findAllStringArrayTest() throws SQLException {
 		List<String[]> results = db.findAll(Entity.create("user"), String[].class);
-		
-		Assert.assertEquals(4, results.size());
-		Assert.assertEquals("1", results.get(0)[0]);
-		Assert.assertEquals("张三", results.get(0)[1]);
+
+		Assertions.assertEquals(4, results.size());
+		Assertions.assertEquals("1", results.get(0)[0]);
+		Assertions.assertEquals("张三", results.get(0)[1]);
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/FindBeanTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/FindBeanTest.java
@@ -2,7 +2,7 @@ package cn.hutool.db;
 
 import cn.hutool.db.pojo.User;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
@@ -16,10 +16,10 @@ import java.util.List;
  */
 public class FindBeanTest {
 
-	Db db;
+	static Db db;
 
-	@BeforeEach
-	public void init() {
+	@BeforeAll
+	public static void init() {
 		db = Db.use("test");
 	}
 

--- a/hutool-db/src/test/java/cn/hutool/db/H2Test.java
+++ b/hutool-db/src/test/java/cn/hutool/db/H2Test.java
@@ -1,23 +1,23 @@
 package cn.hutool.db;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * H2数据库单元测试
- * 
+ *
  * @author looly
  *
  */
 public class H2Test {
-	
+
 	private static final String DS_GROUP_NAME = "h2";
-	
-	@BeforeClass
+
+	@BeforeAll
 	public static void init() throws SQLException {
 		Db db = Db.use(DS_GROUP_NAME);
 		db.execute("CREATE TABLE test(a INTEGER, b BIGINT)");
@@ -27,16 +27,16 @@ public class H2Test {
 		db.insert(Entity.create("test").set("a", 3).set("b", 31));
 		db.insert(Entity.create("test").set("a", 4).set("b", 41));
 	}
-	
+
 	@Test
 	public void queryTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).query("select * from test");
-		Assert.assertEquals(4, query.size());
+		Assertions.assertEquals(4, query.size());
 	}
 
 	@Test
 	public void findTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).find(Entity.create("test"));
-		Assert.assertEquals(4, query.size());
+		Assertions.assertEquals(4, query.size());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/HsqldbTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/HsqldbTest.java
@@ -1,23 +1,23 @@
 package cn.hutool.db;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * HSQLDB数据库单元测试
- * 
+ *
  * @author looly
  *
  */
 public class HsqldbTest {
-	
+
 	private static final String DS_GROUP_NAME = "hsqldb";
-	
-	@BeforeClass
+
+	@BeforeAll
 	public static void init() throws SQLException {
 		Db db = Db.use(DS_GROUP_NAME);
 		db.execute("CREATE TABLE test(a INTEGER, b BIGINT)");
@@ -26,16 +26,16 @@ public class HsqldbTest {
 		db.insert(Entity.create("test").set("a", 3).set("b", 31));
 		db.insert(Entity.create("test").set("a", 4).set("b", 41));
 	}
-	
+
 	@Test
 	public void connTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).query("select * from test");
-		Assert.assertEquals(4, query.size());
+		Assertions.assertEquals(4, query.size());
 	}
 
 	@Test
 	public void findTest() throws SQLException {
 		List<Entity> query = Db.use(DS_GROUP_NAME).find(Entity.create("test"));
-		Assert.assertEquals(4, query.size());
+		Assertions.assertEquals(4, query.size());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/MySQLTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/MySQLTest.java
@@ -1,22 +1,23 @@
 package cn.hutool.db;
 
 import cn.hutool.core.lang.Console;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.List;
 
 /**
  * MySQL操作单元测试
- * 
+ *
  * @author looly
  *
  */
 public class MySQLTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void insertTest() throws SQLException {
 		for (int id = 100; id < 200; id++) {
 			Db.use("mysql").insert(Entity.create("user")//
@@ -34,22 +35,24 @@ public class MySQLTest {
 	 *
 	 * @throws SQLException SQL异常
 	 */
-	@Test(expected=SQLException.class)
-	@Ignore
+	@Test
+	@Disabled
 	public void txTest() throws SQLException {
-		Db.use("mysql").tx(db -> {
-			int update = db.update(Entity.create("user").set("text", "描述100"), Entity.create().set("id", 100));
-			db.update(Entity.create("user").set("text", "描述101"), Entity.create().set("id", 101));
-			if(1 == update) {
-				// 手动指定异常，然后测试回滚触发
-				throw new RuntimeException("Error");
-			}
-			db.update(Entity.create("user").set("text", "描述102"), Entity.create().set("id", 102));
+		Assertions.assertThrows(SQLException.class, () -> {
+			Db.use("mysql").tx(db -> {
+				int update = db.update(Entity.create("user").set("text", "描述100"), Entity.create().set("id", 100));
+				db.update(Entity.create("user").set("text", "描述101"), Entity.create().set("id", 101));
+				if(1 == update) {
+					// 手动指定异常，然后测试回滚触发
+					throw new RuntimeException("Error");
+				}
+				db.update(Entity.create("user").set("text", "描述102"), Entity.create().set("id", 102));
+			});
 		});
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pageTest() throws SQLException {
 		PageResult<Entity> result = Db.use("mysql").page(Entity.create("user"), new Page(2, 10));
 		for (Entity entity : result) {
@@ -58,7 +61,7 @@ public class MySQLTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getTimeStampTest() throws SQLException {
 		final List<Entity> all = Db.use("mysql").findAll("test");
 		Console.log(all);

--- a/hutool-db/src/test/java/cn/hutool/db/MySQLTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/MySQLTest.java
@@ -14,10 +14,10 @@ import java.util.List;
  * @author looly
  *
  */
+@Disabled
 public class MySQLTest {
 
 	@Test
-	@Disabled
 	public void insertTest() throws SQLException {
 		for (int id = 100; id < 200; id++) {
 			Db.use("mysql").insert(Entity.create("user")//
@@ -36,7 +36,6 @@ public class MySQLTest {
 	 * @throws SQLException SQL异常
 	 */
 	@Test
-	@Disabled
 	public void txTest() throws SQLException {
 		Assertions.assertThrows(SQLException.class, () -> {
 			Db.use("mysql").tx(db -> {
@@ -52,7 +51,6 @@ public class MySQLTest {
 	}
 
 	@Test
-	@Disabled
 	public void pageTest() throws SQLException {
 		PageResult<Entity> result = Db.use("mysql").page(Entity.create("user"), new Page(2, 10));
 		for (Entity entity : result) {
@@ -61,7 +59,6 @@ public class MySQLTest {
 	}
 
 	@Test
-	@Disabled
 	public void getTimeStampTest() throws SQLException {
 		final List<Entity> all = Db.use("mysql").findAll("test");
 		Console.log(all);

--- a/hutool-db/src/test/java/cn/hutool/db/NamedSqlTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/NamedSqlTest.java
@@ -2,8 +2,8 @@ package cn.hutool.db;
 
 import cn.hutool.core.map.MapUtil;
 import cn.hutool.db.sql.NamedSql;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.HashMap;
@@ -24,9 +24,9 @@ public class NamedSqlTest {
 
 		NamedSql namedSql = new NamedSql(sql, paramMap);
 		//未指定参数原样输出
-		Assert.assertEquals("select * from table where id=@id and name = ? and nickName = ?", namedSql.getSql());
-		Assert.assertEquals("张三", namedSql.getParams()[0]);
-		Assert.assertEquals("小豆豆", namedSql.getParams()[1]);
+		Assertions.assertEquals("select * from table where id=@id and name = ? and nickName = ?", namedSql.getSql());
+		Assertions.assertEquals("张三", namedSql.getParams()[0]);
+		Assertions.assertEquals("小豆豆", namedSql.getParams()[1]);
 	}
 
 	@Test
@@ -41,11 +41,11 @@ public class NamedSqlTest {
 				.build();
 
 		NamedSql namedSql = new NamedSql(sql, paramMap);
-		Assert.assertEquals("select * from table where id=? and name = ? and nickName = ?", namedSql.getSql());
+		Assertions.assertEquals("select * from table where id=? and name = ? and nickName = ?", namedSql.getSql());
 		//指定了null参数的依旧替换，参数值为null
-		Assert.assertNull(namedSql.getParams()[0]);
-		Assert.assertEquals("张三", namedSql.getParams()[1]);
-		Assert.assertEquals("小豆豆", namedSql.getParams()[2]);
+		Assertions.assertNull(namedSql.getParams()[0]);
+		Assertions.assertEquals("张三", namedSql.getParams()[1]);
+		Assertions.assertEquals("小豆豆", namedSql.getParams()[2]);
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class NamedSqlTest {
 				.build();
 
 		NamedSql namedSql = new NamedSql(sql, paramMap);
-		Assert.assertEquals(sql, namedSql.getSql());
+		Assertions.assertEquals(sql, namedSql.getSql());
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class NamedSqlTest {
 				.build();
 
 		NamedSql namedSql = new NamedSql(sql, paramMap);
-		Assert.assertEquals(sql, namedSql.getSql());
+		Assertions.assertEquals(sql, namedSql.getSql());
 	}
 
 	@Test
@@ -80,10 +80,10 @@ public class NamedSqlTest {
 		final HashMap<String, Object> paramMap = MapUtil.of("ids", new int[]{1, 2, 3});
 
 		NamedSql namedSql = new NamedSql(sql, paramMap);
-		Assert.assertEquals("select * from user where id in (?,?,?)", namedSql.getSql());
-		Assert.assertEquals(1, namedSql.getParams()[0]);
-		Assert.assertEquals(2, namedSql.getParams()[1]);
-		Assert.assertEquals(3, namedSql.getParams()[2]);
+		Assertions.assertEquals("select * from user where id in (?,?,?)", namedSql.getSql());
+		Assertions.assertEquals(1, namedSql.getParams()[0]);
+		Assertions.assertEquals(2, namedSql.getParams()[1]);
+		Assertions.assertEquals(3, namedSql.getParams()[2]);
 	}
 
 	@Test
@@ -94,10 +94,10 @@ public class NamedSqlTest {
 		String sql = "select * from user where name = @name1 and age = @age1";
 
 		List<Entity> query = Db.use().query(sql, paramMap);
-		Assert.assertEquals(1, query.size());
+		Assertions.assertEquals(1, query.size());
 
 		// 采用传统方式查询是否能识别Map类型参数
 		query = Db.use().query(sql, new Object[]{paramMap});
-		Assert.assertEquals(1, query.size());
+		Assertions.assertEquals(1, query.size());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/OracleTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/OracleTest.java
@@ -4,15 +4,15 @@ import cn.hutool.core.lang.Console;
 import cn.hutool.db.sql.Query;
 import cn.hutool.db.sql.SqlBuilder;
 import cn.hutool.db.sql.SqlUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
 /**
  * Oracle操作单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -36,11 +36,11 @@ public class OracleTest {
 		String ok = "SELECT * FROM "//
 				+ "( SELECT row_.*, rownum rownum_ from ( SELECT * FROM PMCPERFORMANCEINFO WHERE yearPI = ? ) row_ "//
 				+ "where rownum <= 10) table_alias where table_alias.rownum_ >= 0";//
-		Assert.assertEquals(ok, builder.toString());
+		Assertions.assertEquals(ok, builder.toString());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void insertTest() throws SQLException {
 		for (int id = 100; id < 200; id++) {
 			Db.use("orcl").insert(Entity.create("T_USER")//
@@ -53,7 +53,7 @@ public class OracleTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pageTest() throws SQLException {
 		PageResult<Entity> result = Db.use("orcl").page(Entity.create("T_USER"), new Page(2, 10));
 		for (Entity entity : result) {

--- a/hutool-db/src/test/java/cn/hutool/db/PageResultTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/PageResultTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.db;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PageResultTest {
 
@@ -9,6 +9,6 @@ public class PageResultTest {
 	public void isLastTest(){
 		// 每页2条，共10条，总共5页，第一页是0，最后一页应该是4
 		final PageResult<String> result = new PageResult<>(4, 2, 10);
-		Assert.assertTrue(result.isLast());
+		Assertions.assertTrue(result.isLast());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/PageTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/PageTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.db;
 
 import cn.hutool.db.sql.Order;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PageTest {
 
@@ -10,8 +10,8 @@ public class PageTest {
 	public void addOrderTest() {
 		Page page = new Page();
 		page.addOrder(new Order("aaa"));
-		Assert.assertEquals(page.getOrders().length, 1);
+		Assertions.assertEquals(page.getOrders().length, 1);
 		page.addOrder(new Order("aaa"));
-		Assert.assertEquals(page.getOrders().length, 2);
+		Assertions.assertEquals(page.getOrders().length, 2);
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/PicTransferTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/PicTransferTest.java
@@ -3,8 +3,8 @@ package cn.hutool.db;
 import cn.hutool.core.collection.ListUtil;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.StrUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 public class PicTransferTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void findTest() throws SQLException {
 		Db.use().find(
 				ListUtil.of("NAME", "TYPE", "GROUP", "PIC"),

--- a/hutool-db/src/test/java/cn/hutool/db/PostgreTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/PostgreTest.java
@@ -2,21 +2,21 @@ package cn.hutool.db;
 
 import java.sql.SQLException;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.Console;
 
 /**
  * PostgreSQL 单元测试
- * 
+ *
  * @author looly
  *
  */
 public class PostgreTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void insertTest() throws SQLException {
 		for (int id = 100; id < 200; id++) {
 			Db.use("postgre").insert(Entity.create("user")//
@@ -27,7 +27,7 @@ public class PostgreTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pageTest() throws SQLException {
 		PageResult<Entity> result = Db.use("postgre").page(Entity.create("user"), new Page(2, 10));
 		for (Entity entity : result) {

--- a/hutool-db/src/test/java/cn/hutool/db/SessionTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/SessionTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.db;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
@@ -11,9 +11,9 @@ import java.sql.SQLException;
  *
  */
 public class SessionTest {
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void transTest() {
 		Session session = Session.create("test");
 		try {
@@ -24,9 +24,9 @@ public class SessionTest {
 			session.quietRollback();
 		}
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void txTest() throws SQLException {
 		Session.create("test").tx(session -> session.update(Entity.create().set("age", 78), Entity.create("user").set("name", "unitTestUser")));
 	}

--- a/hutool-db/src/test/java/cn/hutool/db/SqlServerTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/SqlServerTest.java
@@ -2,27 +2,27 @@ package cn.hutool.db;
 
 import java.sql.SQLException;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.Console;
 
 /**
  * SQL Server操作单元测试
- * 
+ *
  * @author looly
  *
  */
 public class SqlServerTest {
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void createTableTest() throws SQLException {
 		Db.use("sqlserver").execute("create table T_USER(ID bigint, name varchar(255))");
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void insertTest() throws SQLException {
 		for (int id = 100; id < 200; id++) {
 			Db.use("sqlserver").insert(Entity.create("T_USER")//
@@ -33,7 +33,7 @@ public class SqlServerTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void pageTest() throws SQLException {
 		PageResult<Entity> result = Db.use("sqlserver").page(Entity.create("T_USER"), new Page(2, 10));
 		for (Entity entity : result) {

--- a/hutool-db/src/test/java/cn/hutool/db/UpdateTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/UpdateTest.java
@@ -1,34 +1,34 @@
 package cn.hutool.db;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
 public class UpdateTest {
-	
+
 	Db db;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		db = Db.use("test");
 	}
-	
+
 	/**
 	 * 对更新做单元测试
-	 * 
+	 *
 	 * @throws SQLException SQL异常
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void updateTest() throws SQLException {
 
 		// 改
 		int update = db.update(Entity.create("user").set("age", 88), Entity.create().set("name", "unitTestUser"));
-		Assert.assertTrue(update > 0);
+		Assertions.assertTrue(update > 0);
 		Entity result2 = db.get("user", "name", "unitTestUser");
-		Assert.assertSame(88, result2.getInt("age"));
+		Assertions.assertSame(88, result2.getInt("age"));
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/UpdateTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/UpdateTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.db;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -9,10 +9,10 @@ import java.sql.SQLException;
 
 public class UpdateTest {
 
-	Db db;
+	static Db db;
 
-	@BeforeEach
-	public void init() {
+	@BeforeAll
+	public static void init() {
 		db = Db.use("test");
 	}
 

--- a/hutool-db/src/test/java/cn/hutool/db/UpdateTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/UpdateTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
+@Disabled
 public class UpdateTest {
 
 	static Db db;
@@ -22,7 +23,6 @@ public class UpdateTest {
 	 * @throws SQLException SQL异常
 	 */
 	@Test
-	@Disabled
 	public void updateTest() throws SQLException {
 
 		// 改

--- a/hutool-db/src/test/java/cn/hutool/db/dialect/DriverUtilTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/dialect/DriverUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.db.dialect;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DriverUtilTest {
 
@@ -9,6 +9,6 @@ public class DriverUtilTest {
 	public void identifyDriverTest(){
 		String url = "jdbc:h2:file:./db/test;AUTO_SERVER=TRUE;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL";
 		String driver = DriverUtil.identifyDriver(url); // driver 返回 mysql 的 driver
-		Assert.assertEquals("org.h2.Driver", driver);
+		Assertions.assertEquals("org.h2.Driver", driver);
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/meta/MetaUtilTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/meta/MetaUtilTest.java
@@ -4,8 +4,8 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.collection.CollectionUtil;
 import cn.hutool.core.util.StrUtil;
@@ -13,28 +13,28 @@ import cn.hutool.db.ds.DSFactory;
 
 /**
  * 元数据信息单元测试
- * 
+ *
  * @author Looly
  *
  */
 public class MetaUtilTest {
 	DataSource ds = DSFactory.get("test");
-	
+
 	@Test
 	public void getTablesTest() {
 		List<String> tables = MetaUtil.getTables(ds);
-		Assert.assertEquals("user", tables.get(0));
+		Assertions.assertEquals("user", tables.get(0));
 	}
 
 	@Test
 	public void getTableMetaTest() {
 		Table table = MetaUtil.getTableMeta(ds, "user");
-		Assert.assertEquals(CollectionUtil.newHashSet("id"), table.getPkNames());
+		Assertions.assertEquals(CollectionUtil.newHashSet("id"), table.getPkNames());
 	}
-	
+
 	@Test
 	public void getColumnNamesTest() {
 		String[] names = MetaUtil.getColumnNames(ds, "user");
-		Assert.assertArrayEquals(StrUtil.splitToArray("id,name,age,birthday,gender", ','), names);
+		Assertions.assertArrayEquals(StrUtil.splitToArray("id,name,age,birthday,gender", ','), names);
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/nosql/RedisDSTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/nosql/RedisDSTest.java
@@ -1,14 +1,14 @@
 package cn.hutool.db.nosql;
 
 import cn.hutool.db.nosql.redis.RedisDS;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.Jedis;
 
 public class RedisDSTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void redisDSTest(){
 		final Jedis jedis = RedisDS.create().getJedis();
 	}

--- a/hutool-db/src/test/java/cn/hutool/db/sql/ConditionBuilderTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/sql/ConditionBuilderTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.db.sql;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ConditionBuilderTest {
 
@@ -14,8 +14,8 @@ public class ConditionBuilderTest {
 
 		final ConditionBuilder builder = ConditionBuilder.of(c1, c2, c3);
 		final String sql = builder.build();
-		Assert.assertEquals("user IS NULL OR name IS NOT NULL AND group LIKE ?", sql);
-		Assert.assertEquals(1, builder.getParamValues().size());
-		Assert.assertEquals("%aaa", builder.getParamValues().get(0));
+		Assertions.assertEquals("user IS NULL OR name IS NOT NULL AND group LIKE ?", sql);
+		Assertions.assertEquals(1, builder.getParamValues().size());
+		Assertions.assertEquals("%aaa", builder.getParamValues().get(0));
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/sql/ConditionTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/sql/ConditionTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.db.sql;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
@@ -10,62 +10,62 @@ public class ConditionTest {
 	@Test
 	public void toStringTest() {
 		Condition conditionNull = new Condition("user", null);
-		Assert.assertEquals("user IS NULL", conditionNull.toString());
+		Assertions.assertEquals("user IS NULL", conditionNull.toString());
 
 		Condition conditionNotNull = new Condition("user", "!= null");
-		Assert.assertEquals("user IS NOT NULL", conditionNotNull.toString());
+		Assertions.assertEquals("user IS NOT NULL", conditionNotNull.toString());
 
 		Condition condition2 = new Condition("user", "= zhangsan");
-		Assert.assertEquals("user = ?", condition2.toString());
+		Assertions.assertEquals("user = ?", condition2.toString());
 
 		Condition conditionLike = new Condition("user", "like %aaa");
-		Assert.assertEquals("user LIKE ?", conditionLike.toString());
+		Assertions.assertEquals("user LIKE ?", conditionLike.toString());
 
 		Condition conditionIn = new Condition("user", "in 1,2,3");
-		Assert.assertEquals("user IN (?,?,?)", conditionIn.toString());
+		Assertions.assertEquals("user IN (?,?,?)", conditionIn.toString());
 
 		Condition conditionBetween = new Condition("user", "between 12 and 13");
-		Assert.assertEquals("user BETWEEN ? AND ?", conditionBetween.toString());
+		Assertions.assertEquals("user BETWEEN ? AND ?", conditionBetween.toString());
 	}
 
 	@Test
 	public void toStringNoPlaceHolderTest() {
 		Condition conditionNull = new Condition("user", null);
 		conditionNull.setPlaceHolder(false);
-		Assert.assertEquals("user IS NULL", conditionNull.toString());
+		Assertions.assertEquals("user IS NULL", conditionNull.toString());
 
 		Condition conditionNotNull = new Condition("user", "!= null");
 		conditionNotNull.setPlaceHolder(false);
-		Assert.assertEquals("user IS NOT NULL", conditionNotNull.toString());
+		Assertions.assertEquals("user IS NOT NULL", conditionNotNull.toString());
 
 		Condition conditionEquals = new Condition("user", "= zhangsan");
 		conditionEquals.setPlaceHolder(false);
-		Assert.assertEquals("user = zhangsan", conditionEquals.toString());
+		Assertions.assertEquals("user = zhangsan", conditionEquals.toString());
 
 		Condition conditionLike = new Condition("user", "like %aaa");
 		conditionLike.setPlaceHolder(false);
-		Assert.assertEquals("user LIKE '%aaa'", conditionLike.toString());
+		Assertions.assertEquals("user LIKE '%aaa'", conditionLike.toString());
 
 		Condition conditionIn = new Condition("user", "in 1,2,3");
 		conditionIn.setPlaceHolder(false);
-		Assert.assertEquals("user IN (1,2,3)", conditionIn.toString());
+		Assertions.assertEquals("user IN (1,2,3)", conditionIn.toString());
 
 		Condition conditionBetween = new Condition("user", "between 12 and 13");
 		conditionBetween.setPlaceHolder(false);
-		Assert.assertEquals("user BETWEEN 12 AND 13", conditionBetween.toString());
+		Assertions.assertEquals("user BETWEEN 12 AND 13", conditionBetween.toString());
 	}
 
 	@Test
 	public void parseTest(){
 		final Condition age = Condition.parse("age", "< 10");
-		Assert.assertEquals("age < ?", age.toString());
+		Assertions.assertEquals("age < ?", age.toString());
 		// issue I38LTM
-		Assert.assertSame(BigDecimal.class, age.getValue().getClass());
+		Assertions.assertSame(BigDecimal.class, age.getValue().getClass());
 	}
 
 	@Test
 	public void parseInTest(){
 		final Condition age = Condition.parse("age", "in 1,2,3");
-		Assert.assertEquals("age IN (?,?,?)", age.toString());
+		Assertions.assertEquals("age IN (?,?,?)", age.toString());
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/sql/SqlBuilderTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/sql/SqlBuilderTest.java
@@ -1,23 +1,23 @@
 package cn.hutool.db.sql;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SqlBuilderTest {
 
 	@Test
 	public void queryNullTest() {
 		SqlBuilder builder = SqlBuilder.create().select().from("user").where(new Condition("name", "= null"));
-		Assert.assertEquals("SELECT * FROM user WHERE name IS NULL", builder.build());
+		Assertions.assertEquals("SELECT * FROM user WHERE name IS NULL", builder.build());
 
 		SqlBuilder builder2 = SqlBuilder.create().select().from("user").where(new Condition("name", "is null"));
-		Assert.assertEquals("SELECT * FROM user WHERE name IS NULL", builder2.build());
+		Assertions.assertEquals("SELECT * FROM user WHERE name IS NULL", builder2.build());
 
 		SqlBuilder builder3 = SqlBuilder.create().select().from("user").where(new Condition("name", "!= null"));
-		Assert.assertEquals("SELECT * FROM user WHERE name IS NOT NULL", builder3.build());
+		Assertions.assertEquals("SELECT * FROM user WHERE name IS NOT NULL", builder3.build());
 
 		SqlBuilder builder4 = SqlBuilder.create().select().from("user").where(new Condition("name", "is not null"));
-		Assert.assertEquals("SELECT * FROM user WHERE name IS NOT NULL", builder4.build());
+		Assertions.assertEquals("SELECT * FROM user WHERE name IS NOT NULL", builder4.build());
 	}
 
 	@Test
@@ -29,7 +29,7 @@ public class SqlBuilderTest {
 						new Condition("username", "abc", Condition.LikeType.Contains)
 				).orderBy(new Order("id"));
 
-		Assert.assertEquals("SELECT id,username FROM user INNER JOIN role ON user.id = role.user_id WHERE age >= ? AND username LIKE ? ORDER BY id", builder.build());
+		Assertions.assertEquals("SELECT id,username FROM user INNER JOIN role ON user.id = role.user_id WHERE age >= ? AND username LIKE ? ORDER BY id", builder.build());
 	}
 
 	@Test
@@ -42,6 +42,6 @@ public class SqlBuilderTest {
 		sqlBuilder.from("user");
 		sqlBuilder.where(conditionEquals);
 		String s1 = sqlBuilder.build();
-		Assert.assertEquals("SELECT id FROM user WHERE user LIKE '%123%'", s1);
+		Assertions.assertEquals("SELECT id FROM user WHERE user LIKE '%123%'", s1);
 	}
 }

--- a/hutool-db/src/test/java/cn/hutool/db/sql/SqlFormatterTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/sql/SqlFormatterTest.java
@@ -1,6 +1,6 @@
 package cn.hutool.db.sql;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SqlFormatterTest {
 

--- a/hutool-dfa/src/test/java/cn/hutool/dfa/DfaTest.java
+++ b/hutool-dfa/src/test/java/cn/hutool/dfa/DfaTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.dfa;
 
 import cn.hutool.core.collection.CollUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -27,7 +27,7 @@ public class DfaTest {
 		// 匹配到【大】，就不再继续匹配了，因此【大土豆】不匹配
 		// 匹配到【刚出锅】，就跳过这三个字了，因此【出锅】不匹配（由于刚首先被匹配，因此长的被匹配，最短匹配只针对第一个字相同选最短）
 		List<String> matchAll = tree.matchAll(text, -1, false, false);
-		Assert.assertEquals(matchAll, CollUtil.newArrayList("大", "土^豆", "刚出锅"));
+		Assertions.assertEquals(matchAll, CollUtil.newArrayList("大", "土^豆", "刚出锅"));
 	}
 
 	/**
@@ -43,7 +43,7 @@ public class DfaTest {
 		// 【大】被匹配，最短匹配原则【大土豆】被跳过，【土豆继续被匹配】
 		// 【刚出锅】被匹配，由于不跳过已经匹配的词，【出锅】被匹配
 		List<String> matchAll = tree.matchAll(text, -1, true, false);
-		Assert.assertEquals(matchAll, CollUtil.newArrayList("大", "土^豆", "刚出锅", "出锅"));
+		Assertions.assertEquals(matchAll, CollUtil.newArrayList("大", "土^豆", "刚出锅", "出锅"));
 	}
 
 	/**
@@ -59,7 +59,7 @@ public class DfaTest {
 		// 匹配到【大】，由于到最长匹配，因此【大土豆】接着被匹配
 		// 由于【大土豆】被匹配，【土豆】被跳过，由于【刚出锅】被匹配，【出锅】被跳过
 		List<String> matchAll = tree.matchAll(text, -1, false, true);
-		Assert.assertEquals(matchAll, CollUtil.newArrayList("大", "大土^豆", "刚出锅"));
+		Assertions.assertEquals(matchAll, CollUtil.newArrayList("大", "大土^豆", "刚出锅"));
 
 	}
 
@@ -76,7 +76,7 @@ public class DfaTest {
 		// 匹配到【大】，由于到最长匹配，因此【大土豆】接着被匹配，由于不跳过已经匹配的关键词，土豆继续被匹配
 		// 【刚出锅】被匹配，由于不跳过已经匹配的词，【出锅】被匹配
 		List<String> matchAll = tree.matchAll(text, -1, true, true);
-		Assert.assertEquals(matchAll, CollUtil.newArrayList("大", "大土^豆", "土^豆", "刚出锅", "出锅"));
+		Assertions.assertEquals(matchAll, CollUtil.newArrayList("大", "大土^豆", "土^豆", "刚出锅", "出锅"));
 
 	}
 
@@ -89,7 +89,7 @@ public class DfaTest {
 		tree.addWord("tio");
 
 		List<String> all = tree.matchAll("AAAAAAAt-ioBBBBBBB");
-		Assert.assertEquals(all, CollUtil.newArrayList("t-io"));
+		Assertions.assertEquals(all, CollUtil.newArrayList("t-io"));
 	}
 
 	@Test
@@ -98,31 +98,31 @@ public class DfaTest {
 		tree.addWord("women");
 		String text = "a WOMEN todo.".toLowerCase();
 		List<String> matchAll = tree.matchAll(text, -1, false, false);
-		Assert.assertEquals("[women]", matchAll.toString());
+		Assertions.assertEquals("[women]", matchAll.toString());
 	}
 
 	@Test
 	public void clearTest(){
 		WordTree tree = new WordTree();
 		tree.addWord("黑");
-		Assert.assertTrue(tree.matchAll("黑大衣").contains("黑"));
+		Assertions.assertTrue(tree.matchAll("黑大衣").contains("黑"));
 		//clear时直接调用Map的clear并没有把endCharacterSet清理掉
 		tree.clear();
 		tree.addWords("黑大衣","红色大衣");
 
 		//clear() 覆写前 这里想匹配到黑大衣，但是却匹配到了黑
-//		Assert.assertFalse(tree.matchAll("黑大衣").contains("黑大衣"));
-//		Assert.assertTrue(tree.matchAll("黑大衣").contains("黑"));
+//		Assertions.assertFalse(tree.matchAll("黑大衣").contains("黑大衣"));
+//		Assertions.assertTrue(tree.matchAll("黑大衣").contains("黑"));
 		//clear() 覆写后
-		Assert.assertTrue(tree.matchAll("黑大衣").contains("黑大衣"));
-		Assert.assertFalse(tree.matchAll("黑大衣").contains("黑"));
-		Assert.assertTrue(tree.matchAll("红色大衣").contains("红色大衣"));
+		Assertions.assertTrue(tree.matchAll("黑大衣").contains("黑大衣"));
+		Assertions.assertFalse(tree.matchAll("黑大衣").contains("黑"));
+		Assertions.assertTrue(tree.matchAll("红色大衣").contains("红色大衣"));
 
 		//如果不覆写只能通过new出新对象才不会有问题
 		tree = new WordTree();
 		tree.addWords("黑大衣","红色大衣");
-		Assert.assertTrue(tree.matchAll("黑大衣").contains("黑大衣"));
-		Assert.assertTrue(tree.matchAll("红色大衣").contains("红色大衣"));
+		Assertions.assertTrue(tree.matchAll("黑大衣").contains("黑大衣"));
+		Assertions.assertTrue(tree.matchAll("红色大衣").contains("红色大衣"));
 	}
 
 	// ----------------------------------------------------------------------------------------------------------

--- a/hutool-dfa/src/test/java/cn/hutool/dfa/SensitiveUtilTest.java
+++ b/hutool-dfa/src/test/java/cn/hutool/dfa/SensitiveUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.dfa;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +21,7 @@ public class SensitiveUtilTest {
 		bean.setNum(100);
 		SensitiveUtil.init(wordList);
 		bean = SensitiveUtil.sensitiveFilter(bean, true, null);
-		Assert.assertEquals(bean.getStr(), "我有一颗$****，***的");
+		Assertions.assertEquals(bean.getStr(), "我有一颗$****，***的");
 	}
 
 	public static class TestBean {

--- a/hutool-extra/pom.xml
+++ b/hutool-extra/pom.xml
@@ -83,6 +83,14 @@
 					<artifactId>mvel2</artifactId>
 					<groupId>org.mvel</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.mockito</groupId>
+					<artifactId>mockito-core</artifactId>
+				</exclusion>
 			</exclusions>
 			<optional>true</optional>
 		</dependency>

--- a/hutool-extra/src/test/java/cn/hutool/extra/cglib/CglibUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/cglib/CglibUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.extra.cglib;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CglibUtilTest {
 
@@ -13,10 +13,10 @@ public class CglibUtilTest {
 
 		OtherSampleBean otherBean = new OtherSampleBean();
 		CglibUtil.copy(bean, otherBean);
-		Assert.assertEquals("Hello world", otherBean.getValue());
+		Assertions.assertEquals("Hello world", otherBean.getValue());
 
 		OtherSampleBean otherBean2 = CglibUtil.copy(bean, OtherSampleBean.class);
-		Assert.assertEquals("Hello world", otherBean2.getValue());
+		Assertions.assertEquals("Hello world", otherBean2.getValue());
 	}
 
 	@Data

--- a/hutool-extra/src/test/java/cn/hutool/extra/compress/ArchiverTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/compress/ArchiverTest.java
@@ -5,15 +5,15 @@ import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.extra.compress.archiver.StreamArchiver;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 public class ArchiverTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipTest(){
 		final File file = FileUtil.file("d:/test/compress/test.zip");
 		StreamArchiver.create(CharsetUtil.CHARSET_UTF_8, ArchiveStreamFactory.ZIP, file)
@@ -25,7 +25,7 @@ public class ArchiverTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void tarTest(){
 		final File file = FileUtil.file("d:/test/compress/test.tar");
 		StreamArchiver.create(CharsetUtil.CHARSET_UTF_8, ArchiveStreamFactory.TAR, file)
@@ -37,7 +37,7 @@ public class ArchiverTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void cpioTest(){
 		final File file = FileUtil.file("d:/test/compress/test.cpio");
 		StreamArchiver.create(CharsetUtil.CHARSET_UTF_8, ArchiveStreamFactory.CPIO, file)
@@ -49,7 +49,7 @@ public class ArchiverTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sevenZTest(){
 		final File file = FileUtil.file("d:/test/compress/test.7z");
 		CompressUtil.createArchiver(CharsetUtil.CHARSET_UTF_8, ArchiveStreamFactory.SEVEN_Z, file)

--- a/hutool-extra/src/test/java/cn/hutool/extra/compress/ExtractorTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/compress/ExtractorTest.java
@@ -3,13 +3,13 @@ package cn.hutool.extra.compress;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.extra.compress.extractor.Extractor;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ExtractorTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void zipTest(){
 		Extractor extractor = CompressUtil.createExtractor(
 				CharsetUtil.defaultCharset(),
@@ -19,7 +19,7 @@ public class ExtractorTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sevenZTest(){
 		Extractor extractor = 	CompressUtil.createExtractor(
 				CharsetUtil.defaultCharset(),

--- a/hutool-extra/src/test/java/cn/hutool/extra/emoji/EmojiUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/emoji/EmojiUtilTest.java
@@ -1,28 +1,28 @@
 package cn.hutool.extra.emoji;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EmojiUtilTest {
-	
+
 	@Test
 	public void toUnicodeTest() {
 		String emoji = EmojiUtil.toUnicode(":smile:");
-		Assert.assertEquals("😄", emoji);
+		Assertions.assertEquals("😄", emoji);
 	}
-	
+
 	@Test
 	public void toAliasTest() {
 		String alias = EmojiUtil.toAlias("😄");
-		Assert.assertEquals(":smile:", alias);
+		Assertions.assertEquals(":smile:", alias);
 	}
-	
+
 	@Test
 	public void containsEmojiTest() {
 		boolean containsEmoji = EmojiUtil.containsEmoji("测试一下是否包含EMOJ:😄");
-		Assert.assertTrue(containsEmoji);
+		Assertions.assertTrue(containsEmoji);
 		boolean notContainsEmoji = EmojiUtil.containsEmoji("不包含EMOJ:^_^");
-		Assert.assertFalse(notContainsEmoji);
+		Assertions.assertFalse(notContainsEmoji);
 
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/expression/AviatorTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/expression/AviatorTest.java
@@ -5,8 +5,8 @@ import cn.hutool.core.lang.Console;
 import cn.hutool.core.lang.Dict;
 import cn.hutool.extra.expression.engine.aviator.AviatorEngine;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
@@ -22,19 +22,19 @@ public class AviatorTest {
 		String exp =
 				"\"[foo i=\"+ foo.i + \", f=\" + foo.f + \", date.year=\" + (foo.date.year+1900) + \", date.month=\" + foo.date.month + \", bars[0].name=\" + #foo.bars[0].name + \"]\"";
 		String result = (String) engine.eval(exp, Dict.create().set("foo", foo));
-		Assert.assertEquals("[foo i=100, f=3.14, date.year=2020, date.month=10, bars[0].name=bar]", result);
+		Assertions.assertEquals("[foo i=100, f=3.14, date.year=2020, date.month=10, bars[0].name=bar]", result);
 
 		// Assignment.
 		exp = "#foo.bars[0].name='hello aviator' ; #foo.bars[0].name";
 		result = (String) engine.eval(exp, Dict.create().set("foo", foo));
-		Assert.assertEquals("hello aviator", result);
-		Assert.assertEquals("hello aviator", foo.bars[0].getName());
+		Assertions.assertEquals("hello aviator", result);
+		Assertions.assertEquals("hello aviator", foo.bars[0].getName());
 
 		exp = "foo.bars[0] = nil ; foo.bars[0]";
 		result = (String) engine.eval(exp, Dict.create().set("foo", foo));
 		Console.log("Execute expression: " + exp);
-		Assert.assertNull(result);
-		Assert.assertNull(foo.bars[0]);
+		Assertions.assertNull(result);
+		Assertions.assertNull(foo.bars[0]);
 	}
 
 	@Data

--- a/hutool-extra/src/test/java/cn/hutool/extra/expression/ExpressionUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/expression/ExpressionUtilTest.java
@@ -6,8 +6,8 @@ import cn.hutool.extra.expression.engine.jfireel.JfireELEngine;
 import cn.hutool.extra.expression.engine.mvel.MvelEngine;
 import cn.hutool.extra.expression.engine.rhino.RhinoEngine;
 import cn.hutool.extra.expression.engine.spel.SpELEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +21,7 @@ public class ExpressionUtilTest {
 				.set("b", 45)
 				.set("c", -199.100);
 		final Object eval = ExpressionUtil.eval("a-(b-c)", dict);
-		Assert.assertEquals(-143.8, (double)eval, 2);
+		Assertions.assertEquals(-143.8, (double)eval, 2);
 	}
 
 	@Test
@@ -33,7 +33,7 @@ public class ExpressionUtilTest {
 				.set("b", 45)
 				.set("c", -199.100);
 		final Object eval = engine.eval("a-(b-c)", dict);
-		Assert.assertEquals(-143.8, (double)eval, 2);
+		Assertions.assertEquals(-143.8, (double)eval, 2);
 	}
 
 	@Test
@@ -44,7 +44,7 @@ public class ExpressionUtilTest {
 		Map<String,Object> map2=new HashMap<>();
 		map2.put("a", 1);
 		Object eval1 = engine.eval(exps2, map2);
-		Assert.assertEquals(100, eval1);
+		Assertions.assertEquals(100, eval1);
 	}
 
 	@Test
@@ -56,7 +56,7 @@ public class ExpressionUtilTest {
 				.set("b", 45)
 				.set("c", -199.100);
 		final Object eval = engine.eval("a-(b-c)", dict);
-		Assert.assertEquals(-143.8, (double)eval, 2);
+		Assertions.assertEquals(-143.8, (double)eval, 2);
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class ExpressionUtilTest {
 				.set("b", 45)
 				.set("c", -199.100);
 		final Object eval = engine.eval("a-(b-c)", dict);
-		Assert.assertEquals(-143.8, (double)eval, 2);
+		Assertions.assertEquals(-143.8, (double)eval, 2);
 	}
 
 	@Test
@@ -80,7 +80,7 @@ public class ExpressionUtilTest {
 				.set("b", 45)
 				.set("c", -199.100);
 		final Object eval = engine.eval("#a-(#b-#c)", dict);
-		Assert.assertEquals(-143.8, (double)eval, 2);
+		Assertions.assertEquals(-143.8, (double)eval, 2);
 	}
 
 	@Test
@@ -92,7 +92,7 @@ public class ExpressionUtilTest {
 				.set("b", 45)
 				.set("c", -199.100);
 		final Object eval = engine.eval("a-(b-c)", dict);
-		Assert.assertEquals(-143.8, (double)eval, 2);
+		Assertions.assertEquals(-143.8, (double)eval, 2);
 	}
 
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -4,15 +4,15 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.extra.ssh.Sftp;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 public class FtpTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void cdTest() {
 		Ftp ftp = new Ftp("looly.centos");
 
@@ -23,7 +23,7 @@ public class FtpTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void uploadTest() {
 		Ftp ftp = new Ftp("localhost");
 
@@ -34,7 +34,7 @@ public class FtpTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void reconnectIfTimeoutTest() throws InterruptedException {
 		Ftp ftp = new Ftp("looly.centos");
 
@@ -58,7 +58,7 @@ public class FtpTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void recursiveDownloadFolder() {
 		Ftp ftp = new Ftp("looly.centos");
 		ftp.recursiveDownloadFolder("/",FileUtil.file("d:/test/download"));
@@ -67,7 +67,7 @@ public class FtpTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void recursiveDownloadFolderSftp() {
 		Sftp ftp = new Sftp("127.0.0.1", 22, "test", "test");
 
@@ -79,7 +79,7 @@ public class FtpTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadTest() {
 		Ftp ftp = new Ftp("localhost");
 

--- a/hutool-extra/src/test/java/cn/hutool/extra/mail/MailAccountTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/mail/MailAccountTest.java
@@ -1,9 +1,9 @@
 package cn.hutool.extra.mail;
 
 import com.sun.mail.util.MailSSLSocketFactory;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.security.GeneralSecurityException;
 
@@ -19,8 +19,8 @@ public class MailAccountTest {
 		MailAccount account = GlobalMailAccount.INSTANCE.getAccount();
 		account.getSmtpProps();
 
-		Assert.assertNotNull(account.getCharset());
-		Assert.assertTrue(account.isSslEnable());
+		Assertions.assertNotNull(account.getCharset());
+		Assertions.assertTrue(account.isSslEnable());
 	}
 
 	/**
@@ -31,7 +31,7 @@ public class MailAccountTest {
 	 * 已经测试通过
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void customPropertyTest() throws GeneralSecurityException {
 		MailAccount mailAccount = new MailAccount();
 		mailAccount.setFrom("xxx@xxx.com");

--- a/hutool-extra/src/test/java/cn/hutool/extra/mail/MailTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/mail/MailTest.java
@@ -1,9 +1,9 @@
 package cn.hutool.extra.mail;
 
 import cn.hutool.core.io.FileUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -18,20 +18,20 @@ import java.util.Properties;
 public class MailTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sendWithFileTest() {
 		MailUtil.send("hutool@foxmail.com", "测试", "<h1>邮件来自Hutool测试</h1>", true, FileUtil.file("d:/测试附件文本.txt"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sendWithLongNameFileTest() {
 		//附件名长度大于60时的测试
 		MailUtil.send("hutool@foxmail.com", "测试", "<h1>邮件来自Hutool测试</h1>", true, FileUtil.file("d:/6-LongLong一阶段平台建设周报2018.3.12-3.16.xlsx"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sendWithImageTest() {
 		Map<String, InputStream> map = new HashMap<>();
 		map.put("testImage", FileUtil.getInputStream("f:/test/me.png"));
@@ -39,13 +39,13 @@ public class MailTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sendHtmlTest() {
 		MailUtil.send("hutool@foxmail.com", "测试", "<h1>邮件来自Hutool测试</h1>", true);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sendByAccountTest() {
 		MailAccount account = new MailAccount();
 		account.setHost("smtp.yeah.net");
@@ -64,6 +64,6 @@ public class MailTest {
 		account.setDebug(true);
 		account.defaultIfEmpty();
 		Properties props = account.getSmtpProps();
-		Assert.assertEquals("true", props.getProperty("mail.debug"));
+		Assertions.assertEquals("true", props.getProperty("mail.debug"));
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/pinyin/Bopomofo4jTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/pinyin/Bopomofo4jTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.extra.pinyin;
 
 import cn.hutool.extra.pinyin.engine.bopomofo4j.Bopomofo4jEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Bopomofo4jTest {
 
@@ -11,13 +11,13 @@ public class Bopomofo4jTest {
 	@Test
 	public void getFirstLetterByBopomofo4jTest(){
 		final String result = engine.getFirstLetter("林海", "");
-		Assert.assertEquals("lh", result);
+		Assertions.assertEquals("lh", result);
 	}
 
 	@Test
 	public void getPinyinByBopomofo4jTest() {
 		final String pinyin = engine.getPinyin("你好h", " ");
-		Assert.assertEquals("ni haoh", pinyin);
+		Assertions.assertEquals("ni haoh", pinyin);
 	}
 
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/pinyin/HoubbPinyinTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/pinyin/HoubbPinyinTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.extra.pinyin;
 
 import cn.hutool.extra.pinyin.engine.houbbpinyin.HoubbPinyinEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HoubbPinyinTest {
 
@@ -11,12 +11,12 @@ public class HoubbPinyinTest {
 	@Test
 	public void getFirstLetterTest(){
 		final String result = engine.getFirstLetter("林海", "");
-		Assert.assertEquals("lh", result);
+		Assertions.assertEquals("lh", result);
 	}
 
 	@Test
 	public void getPinyinTest() {
 		final String pinyin = engine.getPinyin("你好h", " ");
-		Assert.assertEquals("ni hao h", pinyin);
+		Assertions.assertEquals("ni hao h", pinyin);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/pinyin/JpinyinTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/pinyin/JpinyinTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.extra.pinyin;
 
 import cn.hutool.extra.pinyin.engine.jpinyin.JPinyinEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JpinyinTest {
 
@@ -11,13 +11,13 @@ public class JpinyinTest {
 	@Test
 	public void getFirstLetterByPinyin4jTest(){
 		final String result = engine.getFirstLetter("林海", "");
-		Assert.assertEquals("lh", result);
+		Assertions.assertEquals("lh", result);
 	}
 
 	@Test
 	public void getPinyinByPinyin4jTest() {
 		final String pinyin = engine.getPinyin("你好h", " ");
-		Assert.assertEquals("ni hao h", pinyin);
+		Assertions.assertEquals("ni hao h", pinyin);
 	}
 
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/pinyin/Pinyin4jTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/pinyin/Pinyin4jTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.extra.pinyin;
 
 import cn.hutool.extra.pinyin.engine.pinyin4j.Pinyin4jEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Pinyin4jTest {
 
@@ -11,12 +11,12 @@ public class Pinyin4jTest {
 	@Test
 	public void getFirstLetterByPinyin4jTest(){
 		final String result = engine.getFirstLetter("林海", "");
-		Assert.assertEquals("lh", result);
+		Assertions.assertEquals("lh", result);
 	}
 
 	@Test
 	public void getPinyinByPinyin4jTest() {
 		final String pinyin = engine.getPinyin("你好h", " ");
-		Assert.assertEquals("ni hao h", pinyin);
+		Assertions.assertEquals("ni hao h", pinyin);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/pinyin/PinyinUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/pinyin/PinyinUtilTest.java
@@ -1,25 +1,25 @@
 package cn.hutool.extra.pinyin;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PinyinUtilTest {
 
 	@Test
 	public void getPinyinTest(){
 		final String pinyin = PinyinUtil.getPinyin("你好怡", " ");
-		Assert.assertEquals("ni hao yi", pinyin);
+		Assertions.assertEquals("ni hao yi", pinyin);
 	}
 
 	@Test
 	public void getFirstLetterTest(){
 		final String result = PinyinUtil.getFirstLetter("H是第一个", ", ");
-		Assert.assertEquals("h, s, d, y, g", result);
+		Assertions.assertEquals("h, s, d, y, g", result);
 	}
 
 	@Test
 	public void getFirstLetterTest2(){
 		final String result = PinyinUtil.getFirstLetter("崞阳", ", ");
-		Assert.assertEquals("g, y", result);
+		Assertions.assertEquals("g, y", result);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/pinyin/TinyPinyinTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/pinyin/TinyPinyinTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.extra.pinyin;
 
 import cn.hutool.extra.pinyin.engine.tinypinyin.TinyPinyinEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TinyPinyinTest {
 
@@ -11,12 +11,12 @@ public class TinyPinyinTest {
 	@Test
 	public void getFirstLetterByPinyin4jTest(){
 		final String result = engine.getFirstLetter("林海", "");
-		Assert.assertEquals("lh", result);
+		Assertions.assertEquals("lh", result);
 	}
 
 	@Test
 	public void getPinyinByPinyin4jTest() {
 		final String pinyin = engine.getPinyin("你好h", " ");
-		Assert.assertEquals("ni hao h", pinyin);
+		Assertions.assertEquals("ni hao h", pinyin);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/qrcode/QrCodeUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/qrcode/QrCodeUtilTest.java
@@ -28,7 +28,6 @@ public class QrCodeUtilTest {
 	}
 
 	@Test
-//	@Disabled
 	public void generateCustomTest() {
 		QrConfig config = new QrConfig();
 		config.setMargin(0);

--- a/hutool-extra/src/test/java/cn/hutool/extra/qrcode/QrCodeUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/qrcode/QrCodeUtilTest.java
@@ -6,9 +6,9 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -24,11 +24,11 @@ public class QrCodeUtilTest {
 	@Test
 	public void generateTest() {
 		final BufferedImage image = QrCodeUtil.generate("https://hutool.cn/", 300, 300);
-		Assert.assertNotNull(image);
+		Assertions.assertNotNull(image);
 	}
 
 	@Test
-//	@Ignore
+//	@Disabled
 	public void generateCustomTest() {
 		QrConfig config = new QrConfig();
 		config.setMargin(0);
@@ -41,7 +41,7 @@ public class QrCodeUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void generateWithLogoTest() {
 		String icon = FileUtil.isWindows() ? "d:/test/pic/face.jpg" : "~/Desktop/hutool/pic/face.jpg";
 		String targetPath = FileUtil.isWindows() ? "d:/test/qrcodeWithLogo.jpg" : "~/Desktop/hutool/qrcodeWithLogo.jpg";
@@ -52,14 +52,14 @@ public class QrCodeUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void decodeTest() {
 		String decode = QrCodeUtil.decode(FileUtil.file("d:/test/pic/qr.png"));
 		Console.log(decode);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void decodeTest2() {
 		// 条形码
 		String decode = QrCodeUtil.decode(FileUtil.file("d:/test/90.png"));
@@ -69,21 +69,21 @@ public class QrCodeUtilTest {
 	@Test
 	public void generateAsBase64Test() {
 		String base64 = QrCodeUtil.generateAsBase64("https://hutool.cn/", new QrConfig(400, 400), "png");
-		Assert.assertNotNull(base64);
+		Assertions.assertNotNull(base64);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void generateAsBase64Test2() {
 		byte[] bytes = FileUtil.readBytes(
 				new File("d:/test/qr.png"));
 		String encode = Base64.encode(bytes);
 		String base641 = QrCodeUtil.generateAsBase64("https://hutool.cn/", new QrConfig(400, 400), "png", encode);
-		Assert.assertNotNull(base641);
+		Assertions.assertNotNull(base641);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void decodeTest3(){
 		final String decode = QrCodeUtil.decode(ImgUtil.read("d:/test/qr_a.png"), false, true);
 		Console.log(decode);
@@ -92,6 +92,6 @@ public class QrCodeUtilTest {
 	@Test
 	public void pdf417Test(){
 		final BufferedImage image = QrCodeUtil.generate("content111", BarcodeFormat.PDF_417, QrConfig.create());
-		Assert.assertNotNull(image);
+		Assertions.assertNotNull(image);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/servlet/ServletUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/servlet/ServletUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.extra.servlet;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
 public class ServletUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		HttpServletResponse response = null;
 		byte[] bytes = "地球是我们共同的家园，需要大家珍惜.".getBytes(StandardCharsets.UTF_8);

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/EnableSpringUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/EnableSpringUtilTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
  * @author sidian
  */
 @SpringBootTest(classes = EnableSpringUtilTest.class)
+@EnableSpringUtil
 public class EnableSpringUtilTest {
 
 	@Test

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/EnableSpringUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/EnableSpringUtilTest.java
@@ -1,24 +1,20 @@
 package cn.hutool.extra.spring;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author sidian
  */
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = EnableSpringUtilTest.class)
-@EnableSpringUtil
 public class EnableSpringUtilTest {
 
 	@Test
 	public void test() {
 		// 使用@EnableSpringUtil注解后, 能获取上下文
-		Assert.assertNotNull(SpringUtil.getApplicationContext());
+		Assertions.assertNotNull(SpringUtil.getApplicationContext());
 		// 不使用时, 为null
-//        Assert.assertNull(SpringUtil.getApplicationContext());
+//        Assertions.assertNull(SpringUtil.getApplicationContext());
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 
@@ -15,6 +16,7 @@ import java.util.Map;
 import javax.annotation.Resource;
 
 @SpringBootTest(classes = {SpringUtilTest.Demo2.class})
+@EnableAutoConfiguration
 public class SpringUtilTest {
 
 	/**

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilTest.java
@@ -3,22 +3,18 @@ package cn.hutool.extra.spring;
 import cn.hutool.core.lang.TypeReference;
 import cn.hutool.core.map.MapUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import javax.annotation.Resource;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Resource;
 
-@RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {SpringUtil.class, SpringUtilTest.Demo2.class})
-//@Import(cn.hutool.extra.spring.SpringUtil.class)
+@SpringBootTest(classes = {SpringUtilTest.Demo2.class})
 public class SpringUtilTest {
 
 	/**
@@ -32,8 +28,8 @@ public class SpringUtilTest {
 		SpringUtil.registerBean("registerBean", registerBean);
 
 		Demo2 registerBean2 = SpringUtil.getBean("registerBean");
-		Assert.assertEquals(123, registerBean2.getId());
-		Assert.assertEquals("222", registerBean2.getName());
+		Assertions.assertEquals(123, registerBean2.getId());
+		Assertions.assertEquals("222", registerBean2.getName());
 
 
 	}
@@ -44,12 +40,12 @@ public class SpringUtilTest {
 	@Test
 	public void unregisterBeanTest() {
 		registerTestAutoWired();
-		Assert.assertNotNull(SpringUtil.getBean("testAutoWired"));
+		Assertions.assertNotNull(SpringUtil.getBean("testAutoWired"));
 		SpringUtil.unregisterBean("testAutoWired1");
 		try {
 			SpringUtil.getBean("testAutoWired");
 		} catch (NoSuchBeanDefinitionException e) {
-			Assert.assertEquals(e.getClass(), NoSuchBeanDefinitionException.class);
+			Assertions.assertEquals(e.getClass(), NoSuchBeanDefinitionException.class);
 		}
 	}
 
@@ -64,26 +60,26 @@ public class SpringUtilTest {
 		SpringUtil.registerBean("testAutoWired", testAutoWired);
 
 		testAutoWired = SpringUtil.getBean("testAutoWired");
-		Assert.assertNotNull(testAutoWired);
-		Assert.assertNotNull(testAutoWired.getAutowiredBean());
-		Assert.assertNotNull(testAutoWired.getResourceBean());
-		Assert.assertEquals("123", testAutoWired.getAutowiredBean().getId());
+		Assertions.assertNotNull(testAutoWired);
+		Assertions.assertNotNull(testAutoWired.getAutowiredBean());
+		Assertions.assertNotNull(testAutoWired.getResourceBean());
+		Assertions.assertEquals("123", testAutoWired.getAutowiredBean().getId());
 
 	}
 
 	@Test
 	public void getBeanTest(){
 		final Demo2 testDemo = SpringUtil.getBean("testDemo");
-		Assert.assertEquals(12345, testDemo.getId());
-		Assert.assertEquals("test", testDemo.getName());
+		Assertions.assertEquals(12345, testDemo.getId());
+		Assertions.assertEquals("test", testDemo.getName());
 	}
 
 	@Test
 	public void getBeanWithTypeReferenceTest() {
 		Map<String, Object> mapBean = SpringUtil.getBean(new TypeReference<Map<String, Object>>() {});
-		Assert.assertNotNull(mapBean);
-		Assert.assertEquals("value1", mapBean.get("key1"));
-		Assert.assertEquals("value2", mapBean.get("key2"));
+		Assertions.assertNotNull(mapBean);
+		Assertions.assertEquals("value1", mapBean.get("key1"));
+		Assertions.assertEquals("value2", mapBean.get("key2"));
 	}
 
 	@Data

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilWithAutoConfigTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilWithAutoConfigTest.java
@@ -3,21 +3,15 @@ package cn.hutool.extra.spring;
 import cn.hutool.core.lang.TypeReference;
 import cn.hutool.core.map.MapUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {SpringUtilWithAutoConfigTest.Demo2.class})
-//@Import(cn.hutool.extra.spring.SpringUtil.class)
-@EnableAutoConfiguration
 public class SpringUtilWithAutoConfigTest {
 
 	/**
@@ -31,23 +25,23 @@ public class SpringUtilWithAutoConfigTest {
 		SpringUtil.registerBean("registerBean", registerBean);
 
 		Demo2 registerBean2 = SpringUtil.getBean("registerBean");
-		Assert.assertEquals(123, registerBean2.getId());
-		Assert.assertEquals("222", registerBean2.getName());
+		Assertions.assertEquals(123, registerBean2.getId());
+		Assertions.assertEquals("222", registerBean2.getName());
 	}
 
 	@Test
 	public void getBeanTest(){
 		final Demo2 testDemo = SpringUtil.getBean("testDemo");
-		Assert.assertEquals(12345, testDemo.getId());
-		Assert.assertEquals("test", testDemo.getName());
+		Assertions.assertEquals(12345, testDemo.getId());
+		Assertions.assertEquals("test", testDemo.getName());
 	}
 
 	@Test
 	public void getBeanWithTypeReferenceTest() {
 		Map<String, Object> mapBean = SpringUtil.getBean(new TypeReference<Map<String, Object>>() {});
-		Assert.assertNotNull(mapBean);
-		Assert.assertEquals("value1", mapBean.get("key1"));
-		Assert.assertEquals("value2", mapBean.get("key2"));
+		Assertions.assertNotNull(mapBean);
+		Assertions.assertEquals("value1", mapBean.get("key1"));
+		Assertions.assertEquals("value2", mapBean.get("key2"));
 	}
 
 	@Data

--- a/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilWithAutoConfigTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/spring/SpringUtilWithAutoConfigTest.java
@@ -5,6 +5,7 @@ import cn.hutool.core.map.MapUtil;
 import lombok.Data;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 
@@ -12,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @SpringBootTest(classes = {SpringUtilWithAutoConfigTest.Demo2.class})
+@EnableAutoConfiguration
 public class SpringUtilWithAutoConfigTest {
 
 	/**

--- a/hutool-extra/src/test/java/cn/hutool/extra/ssh/JschUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ssh/JschUtilTest.java
@@ -3,20 +3,20 @@ package cn.hutool.extra.ssh;
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.lang.Console;
 import com.jcraft.jsch.Session;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Jsch工具类单元测试
- * 
+ *
  * @author looly
  *
  */
 public class JschUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void bindPortTest() {
 		//新建会话，此会话用于ssh连接到跳板机（堡垒机），此处为10.1.1.1:22
 		Session session = JschUtil.getSession("looly.centos", 22, "test", "123456");
@@ -26,13 +26,13 @@ public class JschUtilTest {
 
 
 	@Test
-	@Ignore
+	@Disabled
 	public void bindRemotePort() throws InterruptedException {
 		// 建立会话
 		Session session = JschUtil.getSession("looly.centos", 22, "test", "123456");
 		// 绑定ssh服务端8089端口到本机的8000端口上
 		boolean b = JschUtil.bindRemotePort(session, 8089, "localhost", 8000);
-		Assert.assertTrue(b);
+		Assertions.assertTrue(b);
 		// 保证一直运行
 //		while (true){
 //			Thread.sleep(3000);
@@ -40,16 +40,16 @@ public class JschUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sftpTest() {
 		Session session = JschUtil.getSession("looly.centos", 22, "root", "123456");
 		Sftp sftp = JschUtil.createSftp(session);
 		sftp.mkDirs("/opt/test/aaa/bbb");
 		Console.log("OK");
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void reconnectIfTimeoutTest() throws InterruptedException {
 		Session session = JschUtil.getSession("sunnyserver", 22,"mysftp","liuyang1234");
 		Sftp sftp = JschUtil.createSftp(session);
@@ -77,7 +77,7 @@ public class JschUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getSessionTest(){
 		JschUtil.getSession("192.168.1.134", 22, "root", "aaa", null);
 	}

--- a/hutool-extra/src/test/java/cn/hutool/extra/ssh/SftpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ssh/SftpTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.extra.ssh;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -17,10 +17,10 @@ import java.util.List;
 @Disabled
 public class SftpTest {
 
-	private SshjSftp sshjSftp;
+	private static SshjSftp sshjSftp;
 
-	@BeforeEach
-	public void init() {
+	@BeforeAll
+	public static void init() {
 		sshjSftp = new SshjSftp("ip", 22, "test", "test", CharsetUtil.CHARSET_UTF_8);
 	}
 

--- a/hutool-extra/src/test/java/cn/hutool/extra/ssh/SftpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ssh/SftpTest.java
@@ -1,9 +1,11 @@
 package cn.hutool.extra.ssh;
 
+import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
@@ -14,18 +16,22 @@ import java.util.List;
  * @author youyongkun
  * @since 5.7.18
  */
+@Disabled
 public class SftpTest {
 
-	private SshjSftp sshjSftp;
+	private static SshjSftp sshjSftp;
 
-	@Before
-	@Ignore
-	public void init() {
+	@BeforeAll
+	static void init() {
 		sshjSftp = new SshjSftp("ip", 22, "test", "test", CharsetUtil.CHARSET_UTF_8);
 	}
 
+	@AfterAll
+	static void clean() {
+		IoUtil.close(sshjSftp);
+	}
+
 	@Test
-	@Ignore
 	public void lsTest() {
 		List<String> files = sshjSftp.ls("/");
 		if (files != null && !files.isEmpty()) {
@@ -34,33 +40,28 @@ public class SftpTest {
 	}
 
 	@Test
-	@Ignore
 	public void downloadTest() {
 		sshjSftp.recursiveDownloadFolder("/home/test/temp", new File("C:\\Users\\akwangl\\Downloads\\temp"));
 	}
 
 	@Test
-	@Ignore
 	public void uploadTest() {
 		sshjSftp.upload("/home/test/temp/", new File("C:\\Users\\akwangl\\Downloads\\temp\\辽宁_20190718_104324.CIME"));
 	}
 
 	@Test
-	@Ignore
 	public void mkDirTest() {
 		boolean flag = sshjSftp.mkdir("/home/test/temp");
 		System.out.println("是否创建成功: " + flag);
 	}
 
 	@Test
-	@Ignore
 	public void mkDirsTest() {
 		// 在当前目录下批量创建目录
 		sshjSftp.mkDirs("/home/test/temp");
 	}
 
 	@Test
-	@Ignore
 	public void delDirTest() {
 		sshjSftp.delDir("/home/test/temp");
 	}

--- a/hutool-extra/src/test/java/cn/hutool/extra/ssh/SftpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ssh/SftpTest.java
@@ -1,9 +1,7 @@
 package cn.hutool.extra.ssh;
 
-import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -19,16 +17,11 @@ import java.util.List;
 @Disabled
 public class SftpTest {
 
-	private static SshjSftp sshjSftp;
+	private SshjSftp sshjSftp;
 
-	@BeforeAll
-	static void init() {
+	@BeforeEach
+	public void init() {
 		sshjSftp = new SshjSftp("ip", 22, "test", "test", CharsetUtil.CHARSET_UTF_8);
-	}
-
-	@AfterAll
-	static void clean() {
-		IoUtil.close(sshjSftp);
 	}
 
 	@Test

--- a/hutool-extra/src/test/java/cn/hutool/extra/template/TemplateUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/template/TemplateUtilTest.java
@@ -10,9 +10,9 @@ import cn.hutool.extra.template.engine.rythm.RythmEngine;
 import cn.hutool.extra.template.engine.thymeleaf.ThymeleafEngine;
 import cn.hutool.extra.template.engine.velocity.VelocityEngine;
 import cn.hutool.extra.template.engine.wit.WitEngine;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
@@ -32,13 +32,13 @@ public class TemplateUtilTest {
 		TemplateEngine engine = TemplateUtil.createEngine(new TemplateConfig());
 		Template template = engine.getTemplate("hello,${name}");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result);
+		Assertions.assertEquals("hello,hutool", result);
 
 		// classpath中获取模板
 		engine = TemplateUtil.createEngine(new TemplateConfig("templates", ResourceMode.CLASSPATH));
 		Template template2 = engine.getTemplate("beetl_test.btl");
 		String result2 = template2.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result2);
+		Assertions.assertEquals("hello,hutool", result2);
 	}
 
 	@Test
@@ -47,13 +47,13 @@ public class TemplateUtilTest {
 		TemplateEngine engine = new BeetlEngine(new TemplateConfig("templates"));
 		Template template = engine.getTemplate("hello,${name}");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result);
+		Assertions.assertEquals("hello,hutool", result);
 
 		// classpath中获取模板
 		engine = new BeetlEngine(new TemplateConfig("templates", ResourceMode.CLASSPATH));
 		Template template2 = engine.getTemplate("beetl_test.btl");
 		String result2 = template2.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result2);
+		Assertions.assertEquals("hello,hutool", result2);
 	}
 
 	@Test
@@ -63,12 +63,12 @@ public class TemplateUtilTest {
 				new TemplateConfig("templates").setCustomEngine(RythmEngine.class));
 		Template template = engine.getTemplate("hello,@name");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result);
+		Assertions.assertEquals("hello,hutool", result);
 
 		// classpath中获取模板
 		Template template2 = engine.getTemplate("rythm_test.tmpl");
 		String result2 = template2.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result2);
+		Assertions.assertEquals("hello,hutool", result2);
 	}
 
 	@Test
@@ -78,14 +78,14 @@ public class TemplateUtilTest {
 				new TemplateConfig("templates", ResourceMode.STRING).setCustomEngine(FreemarkerEngine.class));
 		Template template = engine.getTemplate("hello,${name}");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result);
+		Assertions.assertEquals("hello,hutool", result);
 
 		//ClassPath模板
 		engine = TemplateUtil.createEngine(
 				new TemplateConfig("templates", ResourceMode.CLASSPATH).setCustomEngine(FreemarkerEngine.class));
 		template = engine.getTemplate("freemarker_test.ftl");
 		result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", result);
+		Assertions.assertEquals("hello,hutool", result);
 	}
 
 	@Test
@@ -95,18 +95,18 @@ public class TemplateUtilTest {
 				new TemplateConfig("templates", ResourceMode.STRING).setCustomEngine(VelocityEngine.class));
 		Template template = engine.getTemplate("你好,$name");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("你好,hutool", result);
+		Assertions.assertEquals("你好,hutool", result);
 
 		//ClassPath模板
 		engine = TemplateUtil.createEngine(
 				new TemplateConfig("templates", ResourceMode.CLASSPATH).setCustomEngine(VelocityEngine.class));
 		template = engine.getTemplate("velocity_test.vtl");
 		result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("你好,hutool", result);
+		Assertions.assertEquals("你好,hutool", result);
 
 		template = engine.getTemplate("templates/velocity_test.vtl");
 		result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("你好,hutool", result);
+		Assertions.assertEquals("你好,hutool", result);
 	}
 
 	@Test
@@ -116,14 +116,14 @@ public class TemplateUtilTest {
 				new TemplateConfig("templates").setCustomEngine(EnjoyEngine.class));
 		Template template = engine.getTemplate("#(x + 123)");
 		String result = template.render(Dict.create().set("x", 1));
-		Assert.assertEquals("124", result);
+		Assertions.assertEquals("124", result);
 
 		//ClassPath模板
 		engine = new EnjoyEngine(
 				new TemplateConfig("templates", ResourceMode.CLASSPATH).setCustomEngine(EnjoyEngine.class));
 		template = engine.getTemplate("enjoy_test.etl");
 		result = template.render(Dict.create().set("x", 1));
-		Assert.assertEquals("124", result);
+		Assertions.assertEquals("124", result);
 	}
 
 	@Test
@@ -133,18 +133,18 @@ public class TemplateUtilTest {
 				new TemplateConfig("templates").setCustomEngine(ThymeleafEngine.class));
 		Template template = engine.getTemplate("<h3 th:text=\"${message}\"></h3>");
 		String result = template.render(Dict.create().set("message", "Hutool"));
-		Assert.assertEquals("<h3>Hutool</h3>", result);
+		Assertions.assertEquals("<h3>Hutool</h3>", result);
 
 		//ClassPath模板
 		engine = TemplateUtil.createEngine(
 				new TemplateConfig("templates", ResourceMode.CLASSPATH).setCustomEngine(ThymeleafEngine.class));
 		template = engine.getTemplate("thymeleaf_test.ttl");
 		result = template.render(Dict.create().set("message", "Hutool"));
-		Assert.assertEquals("<h3>Hutool</h3>", result);
+		Assertions.assertEquals("<h3>Hutool</h3>", result);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void renderToFileTest() {
 		TemplateEngine engine = new BeetlEngine(new TemplateConfig("templates", ResourceMode.CLASSPATH));
 		Template template = engine.getTemplate("freemarker_test.ftl");
@@ -163,7 +163,7 @@ public class TemplateUtilTest {
 		TemplateEngine engine = TemplateUtil.createEngine(config);
 		Template template = engine.getTemplate("/wit_test.wit");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", StrUtil.trim(result));
+		Assertions.assertEquals("hello,hutool", StrUtil.trim(result));
 
 		// 字符串模板
 		config = new TemplateConfig("templates", ResourceMode.STRING)
@@ -171,6 +171,6 @@ public class TemplateUtilTest {
 		engine = TemplateUtil.createEngine(config);
 		template = engine.getTemplate("<%var name;%>hello,${name}");
 		result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("hello,hutool", StrUtil.trim(result));
+		Assertions.assertEquals("hello,hutool", StrUtil.trim(result));
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/template/ThymeleafTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/template/ThymeleafTest.java
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.templateresolver.StringTemplateResolver;
 
@@ -19,7 +19,7 @@ import cn.hutool.extra.template.engine.thymeleaf.ThymeleafEngine;
 
 /**
  * Thymeleaf单元测试
- * 
+ *
  * @author looly
  *
  */
@@ -46,7 +46,7 @@ public class ThymeleafTest {
 		TemplateEngine engine = new ThymeleafEngine(new TemplateConfig());
 		Template template = engine.getTemplate("<h3 th:each=\"item : ${list}\" th:text=\"${item.name}\"></h3>");
 		String render = template.render(Dict.create().set("list", list));
-		Assert.assertEquals("<h3>a</h3><h3>b</h3><h3>2019-01-01 00:00:00</h3>", render);
+		Assertions.assertEquals("<h3>a</h3><h3>b</h3><h3>2019-01-01 00:00:00</h3>", render);
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class ThymeleafTest {
 		Context context = new Context(Locale.getDefault(), map);
 		templateEngine.process("<h3 th:each=\"item : ${list}\" th:text=\"${item.name}\"></h3>", context, writer);
 
-		Assert.assertEquals("<h3>a</h3><h3>b</h3><h3>2019-01-01 00:00:00</h3>", writer.toString());
+		Assertions.assertEquals("<h3>a</h3><h3>b</h3><h3>2019-01-01 00:00:00</h3>", writer.toString());
 	}
 
 	@SuppressWarnings("rawtypes")
@@ -94,6 +94,6 @@ public class ThymeleafTest {
 		Template template = engine.getTemplate("<h3 th:each=\"item : ${list}\" th:text=\"${item.name}\"></h3>");
 		// "<h3 th:text=\"${nestMap.nestKey}\"></h3>"
 		String render = template.render(map);
-		Assert.assertEquals("<h3>a</h3><h3>b</h3><h3>2019-01-01 00:00:00</h3>", render);
+		Assertions.assertEquals("<h3>a</h3><h3>b</h3><h3>2019-01-01 00:00:00</h3>", render);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/template/VelocityTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/template/VelocityTest.java
@@ -3,8 +3,8 @@ package cn.hutool.extra.template;
 import cn.hutool.core.lang.Dict;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.extra.template.engine.velocity.VelocityEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class VelocityTest {
 
@@ -16,6 +16,6 @@ public class VelocityTest {
 		final TemplateEngine engine = TemplateUtil.createEngine(config);
 		Template template = engine.getTemplate("velocity_test_gbk.vtl");
 		String result = template.render(Dict.create().set("name", "hutool"));
-		Assert.assertEquals("你好,hutool", result);
+		Assertions.assertEquals("你好,hutool", result);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/tokenizer/TokenizerUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/tokenizer/TokenizerUtilTest.java
@@ -9,8 +9,8 @@ import cn.hutool.extra.tokenizer.engine.jieba.JiebaEngine;
 import cn.hutool.extra.tokenizer.engine.mmseg.MmsegEngine;
 import cn.hutool.extra.tokenizer.engine.mynlp.MynlpEngine;
 import cn.hutool.extra.tokenizer.engine.word.WordEngine;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 模板引擎单元测试
@@ -35,7 +35,7 @@ public class TokenizerUtilTest {
 		TokenizerEngine engine = new HanLPEngine();
 		Result result = engine.parse(text);
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这 两 个 方法 的 区别 在于 返回 值", resultStr);
+		Assertions.assertEquals("这 两 个 方法 的 区别 在于 返回 值", resultStr);
 	}
 
 	@Test
@@ -43,7 +43,7 @@ public class TokenizerUtilTest {
 		TokenizerEngine engine = new IKAnalyzerEngine();
 		Result result = engine.parse(text);
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这两个 方法 的 区别 在于 返回值", resultStr);
+		Assertions.assertEquals("这两个 方法 的 区别 在于 返回值", resultStr);
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class TokenizerUtilTest {
 		TokenizerEngine engine = new JiebaEngine();
 		Result result = engine.parse(text);
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这 两个 方法 的 区别 在于 返回值", resultStr);
+		Assertions.assertEquals("这 两个 方法 的 区别 在于 返回值", resultStr);
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class TokenizerUtilTest {
 		TokenizerEngine engine = new SmartcnEngine();
 		Result result = engine.parse(text);
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这 两 个 方法 的 区别 在于 返回 值", resultStr);
+		Assertions.assertEquals("这 两 个 方法 的 区别 在于 返回 值", resultStr);
 	}
 
 	@Test
@@ -81,7 +81,7 @@ public class TokenizerUtilTest {
 		TokenizerEngine engine = new WordEngine();
 		Result result = engine.parse(text);
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这两个 方法 的 区别 在于 返回值", resultStr);
+		Assertions.assertEquals("这两个 方法 的 区别 在于 返回值", resultStr);
 	}
 
 	@Test
@@ -89,11 +89,11 @@ public class TokenizerUtilTest {
 		TokenizerEngine engine = new MynlpEngine();
 		Result result = engine.parse(text);
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这 两个 方法 的 区别 在于 返回 值", resultStr);
+		Assertions.assertEquals("这 两个 方法 的 区别 在于 返回 值", resultStr);
 	}
 
 	private void checkResult(Result result) {
 		String resultStr = IterUtil.join(result, " ");
-		Assert.assertEquals("这 两个 方法 的 区别 在于 返回 值", resultStr);
+		Assertions.assertEquals("这 两个 方法 的 区别 在于 返回 值", resultStr);
 	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/validation/BeanValidatorUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/validation/BeanValidatorUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.extra.validation;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.constraints.NotBlank;
 
@@ -40,14 +40,14 @@ public class BeanValidatorUtilTest {
 	@Test
 	public void beanValidatorTest() {
 		BeanValidationResult result = ValidationUtil.warpValidate(new TestClass());
-		Assert.assertFalse(result.isSuccess());
-		Assert.assertEquals(2, result.getErrorMessages().size());
+		Assertions.assertFalse(result.isSuccess());
+		Assertions.assertEquals(2, result.getErrorMessages().size());
 	}
 
 	@Test
 	public void propertyValidatorTest() {
 		BeanValidationResult result = ValidationUtil.warpValidateProperty(new TestClass(), "name");
-		Assert.assertFalse(result.isSuccess());
-		Assert.assertEquals(1, result.getErrorMessages().size());
+		Assertions.assertFalse(result.isSuccess());
+		Assertions.assertEquals(1, result.getErrorMessages().size());
 	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/ContentTypeTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/ContentTypeTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.http;
 
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * ContentType 单元测试
@@ -14,6 +14,6 @@ public class ContentTypeTest {
 	@Test
 	public void testBuild() {
 		String result = ContentType.build(ContentType.JSON, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("application/json;charset=UTF-8", result);
+		Assertions.assertEquals("application/json;charset=UTF-8", result);
 	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/DownloadTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/DownloadTest.java
@@ -4,22 +4,22 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IORuntimeException;
 import cn.hutool.core.io.StreamProgress;
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.UUID;
 
 /**
  * 下载单元测试
- * 
+ *
  * @author looly
  */
 public class DownloadTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadPicTest() {
 		String url = "http://wx.qlogo.cn/mmopen/vKhlFcibVUtNBVDjcIowlg0X8aJfHXrTNCEFBukWVH9ta99pfEN88lU39MKspCUCOP3yrFBH3y2NbV7sYtIIlon8XxLwAEqv2/0";
 		HttpUtil.downloadFile(url, "e:/pic/t3.jpg");
@@ -27,21 +27,21 @@ public class DownloadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadSizeTest() {
 		String url = "https://res.t-io.org/im/upload/img/67/8948/1119501/88097554/74541310922/85/231910/366466 - 副本.jpg";
 		HttpRequest.get(url).setSSLProtocol("TLSv1.2").executeAsync().writeBody("e:/pic/366466.jpg");
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadTest1() {
 		long size = HttpUtil.downloadFile("http://explorer.bbfriend.com/crossdomain.xml", "e:/temp/");
 		System.out.println("Download size: " + size);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadTest() {
 		// 带进度显示的文件下载
 		HttpUtil.downloadFile("http://mirrors.sohu.com/centos/7/isos/x86_64/CentOS-7-x86_64-DVD-1810.iso", FileUtil.file("d:/"), new StreamProgress() {
@@ -58,25 +58,25 @@ public class DownloadTest {
 				long speed = progressSize / (System.currentTimeMillis() - time) * 1000;
 				Console.log("已下载：{}, 速度：{}/s", FileUtil.readableFileSize(progressSize), FileUtil.readableFileSize(speed));
 			}
-			
+
 			@Override
 			public void finish() {
 				Console.log("下载完成！");
 			}
 		});
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadFileFromUrlTest1() {
 		File file = HttpUtil.downloadFileFromUrl("http://groovy-lang.org/changelogs/changelog-3.0.5.html", "d:/download/temp");
-		Assert.assertNotNull(file);
-		Assert.assertTrue(file.isFile());
-		Assert.assertTrue(file.length() > 0);
+		Assertions.assertNotNull(file);
+		Assertions.assertTrue(file.isFile());
+		Assertions.assertTrue(file.length() > 0);
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadFileFromUrlTest2() {
 		File file = null;
 		try {
@@ -85,32 +85,32 @@ public class DownloadTest {
 				public void start() {
 					System.out.println("start");
 				}
-				
+
 				@Override
 				public void progress(long progressSize) {
 					System.out.println("download size:" + progressSize);
 				}
-				
+
 				@Override
 				public void finish() {
 					System.out.println("end");
 				}
 			});
-			
-			Assert.assertNotNull(file);
-			Assert.assertTrue(file.exists());
-			Assert.assertTrue(file.isFile());
-			Assert.assertTrue(file.length() > 0);
-			Assert.assertTrue(file.getName().length() > 0);
+
+			Assertions.assertNotNull(file);
+			Assertions.assertTrue(file.exists());
+			Assertions.assertTrue(file.isFile());
+			Assertions.assertTrue(file.length() > 0);
+			Assertions.assertTrue(file.getName().length() > 0);
 		} catch (Exception e) {
-			Assert.assertTrue(e instanceof IORuntimeException);
+			Assertions.assertTrue(e instanceof IORuntimeException);
 		} finally {
 			FileUtil.del(file);
 		}
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadFileFromUrlTest3() {
 		File file = null;
 		try {
@@ -119,71 +119,71 @@ public class DownloadTest {
 				public void start() {
 					System.out.println("start");
 				}
-				
+
 				@Override
 				public void progress(long progressSize) {
 					System.out.println("download size:" + progressSize);
 				}
-				
+
 				@Override
 				public void finish() {
 					System.out.println("end");
 				}
 			});
-			
-			Assert.assertNotNull(file);
-			Assert.assertTrue(file.exists());
-			Assert.assertTrue(file.isFile());
-			Assert.assertTrue(file.length() > 0);
-			Assert.assertTrue(file.getName().length() > 0);
+
+			Assertions.assertNotNull(file);
+			Assertions.assertTrue(file.exists());
+			Assertions.assertTrue(file.isFile());
+			Assertions.assertTrue(file.length() > 0);
+			Assertions.assertTrue(file.getName().length() > 0);
 		} finally {
 			FileUtil.del(file);
 		}
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadFileFromUrlTest4() {
 		File file = null;
 		try {
 			file = HttpUtil.downloadFileFromUrl("http://groovy-lang.org/changelogs/changelog-3.0.5.html", FileUtil.file("d:/download/temp"), 1);
-			
-			Assert.assertNotNull(file);
-			Assert.assertTrue(file.exists());
-			Assert.assertTrue(file.isFile());
-			Assert.assertTrue(file.length() > 0);
-			Assert.assertTrue(file.getName().length() > 0);
+
+			Assertions.assertNotNull(file);
+			Assertions.assertTrue(file.exists());
+			Assertions.assertTrue(file.isFile());
+			Assertions.assertTrue(file.length() > 0);
+			Assertions.assertTrue(file.getName().length() > 0);
 		} catch (Exception e) {
-			Assert.assertTrue(e instanceof IORuntimeException);
+			Assertions.assertTrue(e instanceof IORuntimeException);
 		} finally {
 			FileUtil.del(file);
 		}
 	}
-	
-	
+
+
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadFileFromUrlTest5() {
 		File file = null;
 		try {
 			file = HttpUtil.downloadFileFromUrl("http://groovy-lang.org/changelogs/changelog-3.0.5.html", FileUtil.file("d:/download/temp", UUID.randomUUID().toString()));
-			
-			Assert.assertNotNull(file);
-			Assert.assertTrue(file.exists());
-			Assert.assertTrue(file.isFile());
-			Assert.assertTrue(file.length() > 0);
+
+			Assertions.assertNotNull(file);
+			Assertions.assertTrue(file.exists());
+			Assertions.assertTrue(file.isFile());
+			Assertions.assertTrue(file.length() > 0);
 		} finally {
 			FileUtil.del(file);
 		}
-		
+
 		File file1 = null;
 		try {
 			file1 = HttpUtil.downloadFileFromUrl("http://groovy-lang.org/changelogs/changelog-3.0.5.html", FileUtil.file("d:/download/temp"));
-			
-			Assert.assertNotNull(file1);
-			Assert.assertTrue(file1.exists());
-			Assert.assertTrue(file1.isFile());
-			Assert.assertTrue(file1.length() > 0);
+
+			Assertions.assertNotNull(file1);
+			Assertions.assertTrue(file1.exists());
+			Assertions.assertTrue(file1.isFile());
+			Assertions.assertTrue(file1.length() > 0);
 		} finally {
 			FileUtil.del(file1);
 		}

--- a/hutool-http/src/test/java/cn/hutool/http/HtmlUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HtmlUtilTest.java
@@ -1,160 +1,160 @@
 package cn.hutool.http;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Html单元测试
- * 
+ *
  * @author looly
  *
  */
 public class HtmlUtilTest {
-	
+
 	@Test
 	public void removeHtmlTagTest() {
 		//非闭合标签
 		String str = "pre<img src=\"xxx/dfdsfds/test.jpg\">";
 		String result = HtmlUtil.removeHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img>";
 		result = HtmlUtil.removeHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img src=\"xxx/dfdsfds/test.jpg\" />";
 		result = HtmlUtil.removeHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img />";
 		result = HtmlUtil.removeHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//包含内容标签
 		str = "pre<div class=\"test_div\">dfdsfdsfdsf</div>";
 		result = HtmlUtil.removeHtmlTag(str, "div");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//带换行
 		str = "pre<div class=\"test_div\">\r\n\t\tdfdsfdsfdsf\r\n</div>";
 		result = HtmlUtil.removeHtmlTag(str, "div");
-		Assert.assertEquals("pre", result);
+		Assertions.assertEquals("pre", result);
 	}
-	
+
 	@Test
 	public void cleanHtmlTagTest() {
 		//非闭合标签
 		String str = "pre<img src=\"xxx/dfdsfds/test.jpg\">";
 		String result = HtmlUtil.cleanHtmlTag(str);
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img>";
 		result = HtmlUtil.cleanHtmlTag(str);
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img src=\"xxx/dfdsfds/test.jpg\" />";
 		result = HtmlUtil.cleanHtmlTag(str);
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img />";
 		result = HtmlUtil.cleanHtmlTag(str);
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//包含内容标签
 		str = "pre<div class=\"test_div\">dfdsfdsfdsf</div>";
 		result = HtmlUtil.cleanHtmlTag(str);
-		Assert.assertEquals("predfdsfdsfdsf", result);
-		
+		Assertions.assertEquals("predfdsfdsfdsf", result);
+
 		//带换行
 		str = "pre<div class=\"test_div\">\r\n\t\tdfdsfdsfdsf\r\n</div><div class=\"test_div\">BBBB</div>";
 		result = HtmlUtil.cleanHtmlTag(str);
-		Assert.assertEquals("pre\r\n\t\tdfdsfdsfdsf\r\nBBBB", result);
+		Assertions.assertEquals("pre\r\n\t\tdfdsfdsfdsf\r\nBBBB", result);
 	}
-	
+
 	@Test
 	public void unwrapHtmlTagTest() {
 		//非闭合标签
 		String str = "pre<img src=\"xxx/dfdsfds/test.jpg\">";
 		String result = HtmlUtil.unwrapHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img>";
 		result = HtmlUtil.unwrapHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img src=\"xxx/dfdsfds/test.jpg\" />";
 		result = HtmlUtil.unwrapHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//闭合标签
 		str = "pre<img />";
 		result = HtmlUtil.unwrapHtmlTag(str, "img");
-		Assert.assertEquals("pre", result);
-		
+		Assertions.assertEquals("pre", result);
+
 		//包含内容标签
 		str = "pre<div class=\"test_div\">abc</div>";
 		result = HtmlUtil.unwrapHtmlTag(str, "div");
-		Assert.assertEquals("preabc", result);
-		
+		Assertions.assertEquals("preabc", result);
+
 		//带换行
 		str = "pre<div class=\"test_div\">\r\n\t\tabc\r\n</div>";
 		result = HtmlUtil.unwrapHtmlTag(str, "div");
-		Assert.assertEquals("pre\r\n\t\tabc\r\n", result);
+		Assertions.assertEquals("pre\r\n\t\tabc\r\n", result);
 	}
-	
+
 	@Test
 	public void escapeTest() {
 		String html = "<html><body>123'123'</body></html>";
 		String escape = HtmlUtil.escape(html);
-		Assert.assertEquals("&lt;html&gt;&lt;body&gt;123&#039;123&#039;&lt;/body&gt;&lt;/html&gt;", escape);
+		Assertions.assertEquals("&lt;html&gt;&lt;body&gt;123&#039;123&#039;&lt;/body&gt;&lt;/html&gt;", escape);
 		String restoreEscaped = HtmlUtil.unescape(escape);
-		Assert.assertEquals(html, restoreEscaped);
-		Assert.assertEquals("'", HtmlUtil.unescape("&apos;"));
+		Assertions.assertEquals(html, restoreEscaped);
+		Assertions.assertEquals("'", HtmlUtil.unescape("&apos;"));
 	}
-	
+
 	@Test
 	public void filterTest() {
 		String html = "<alert></alert>";
 		String filter = HtmlUtil.filter(html);
-		Assert.assertEquals("", filter);
+		Assertions.assertEquals("", filter);
 	}
-	
+
 	@Test
 	public void removeHtmlAttrTest() {
 
 		// 去除的属性加双引号测试
 		String html = "<div class=\"test_div\"></div><span class=\"test_div\"></span>";
 		String result = HtmlUtil.removeHtmlAttr(html, "class");
-		Assert.assertEquals("<div></div><span></span>", result);
+		Assertions.assertEquals("<div></div><span></span>", result);
 
 		// 去除的属性后跟空格、加单引号、不加引号测试
 		html = "<div class=test_div></div><span Class='test_div' ></span>";
 		result = HtmlUtil.removeHtmlAttr(html, "class");
-		Assert.assertEquals("<div></div><span></span>", result);
+		Assertions.assertEquals("<div></div><span></span>", result);
 
 		// 去除的属性位于标签末尾、其它属性前测试
 		html = "<div style=\"margin:100%\" class=test_div></div><span Class='test_div' width=100></span>";
 		result = HtmlUtil.removeHtmlAttr(html, "class");
-		Assert.assertEquals("<div style=\"margin:100%\"></div><span width=100></span>", result);
+		Assertions.assertEquals("<div style=\"margin:100%\"></div><span width=100></span>", result);
 
 		// 去除的属性名和值之间存在空格
 		html = "<div style = \"margin:100%\" class = test_div></div><span Class = 'test_div' width=100></span>";
 		result = HtmlUtil.removeHtmlAttr(html, "class");
-		Assert.assertEquals("<div style = \"margin:100%\"></div><span width=100></span>", result);
+		Assertions.assertEquals("<div style = \"margin:100%\"></div><span width=100></span>", result);
 	}
-	
+
 	@Test
 	public void removeAllHtmlAttrTest() {
 		String html = "<div class=\"test_div\" width=\"120\"></div>";
 		String result = HtmlUtil.removeAllHtmlAttr(html, "div");
-		Assert.assertEquals("<div></div>", result);
+		Assertions.assertEquals("<div></div>", result);
 	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -5,8 +5,8 @@ import cn.hutool.core.date.TimeInterval;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.net.SSLProtocols;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,14 +22,14 @@ public class HttpRequestTest {
 	final String url = "http://photo.qzone.qq.com/fcgi-bin/fcg_list_album?uin=88888&outstyle=2";
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getHttpsTest() {
 		String body = HttpRequest.get("https://www.hutool.cn/").timeout(10).execute().body();
 		Console.log(body);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getHttpsThenTest() {
 		HttpRequest
 				.get("https://hutool.cn")
@@ -37,7 +37,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getCookiesTest() {
 		// 检查在Connection关闭情况下Cookie是否可以正常获取
 		HttpResponse res = HttpRequest.get("https://www.oschina.net/").execute();
@@ -47,7 +47,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void toStringTest() {
 		String url = "http://gc.ditu.aliyun.com/geocoding?ccc=你好";
 
@@ -56,7 +56,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void asyncHeadTest() {
 		HttpResponse response = HttpRequest.head(url).execute();
 		Map<String, List<String>> headers = response.headers();
@@ -65,7 +65,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void asyncGetTest() {
 		TimeInterval timer = DateUtil.timer();
 		HttpResponse body = HttpRequest.get(url).charset("GBK").executeAsync();
@@ -77,7 +77,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void syncGetTest() {
 		TimeInterval timer = DateUtil.timer();
 		HttpResponse body = HttpRequest.get(url).charset("GBK").execute();
@@ -89,7 +89,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void customGetTest() {
 		// 自定义构建HTTP GET请求，发送Http GET请求，针对HTTPS安全加密，可以自定义SSL
 		HttpRequest request = HttpRequest.get(url)
@@ -103,7 +103,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getDeflateTest() {
 		String res = HttpRequest.get("https://comment.bilibili.com/67573272.xml")
 				.execute().body();
@@ -111,7 +111,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void bodyTest() {
 		String ddddd1 = HttpRequest.get("https://baijiahao.baidu.com/s").body("id=1625528941695652600").execute().body();
 		Console.log(ddddd1);
@@ -121,7 +121,7 @@ public class HttpRequestTest {
 	 * 测试GET请求附带body体是否会变更为POST
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void getLocalTest() {
 		List<String> list = new ArrayList<>();
 		list.add("hhhhh");
@@ -140,7 +140,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getWithoutEncodeTest() {
 		String url = "https://img-cloud.voc.com.cn/140/2020/09/03/c3d41b93e0d32138574af8e8b50928b376ca5ba61599127028157.png?imageMogr2/auto-orient/thumbnail/500&pid=259848";
 		HttpRequest get = HttpUtil.createGet(url);
@@ -150,7 +150,7 @@ public class HttpRequestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void followRedirectsTest(){
 		// 从5.7.19开始关闭JDK的自动重定向功能，改为手动重定向
 		// 当有多层重定向时，JDK的重定向会失效，或者说只有最后一个重定向有效，因此改为手动更易控制次数

--- a/hutool-http/src/test/java/cn/hutool/http/HttpUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpUtilTest.java
@@ -5,9 +5,9 @@ import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.ReUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.util.LinkedHashMap;
@@ -17,7 +17,7 @@ import java.util.Map;
 public class HttpUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void postTest() {
 		String result = HttpUtil.createPost("api.uhaozu.com/goods/description/1120448506")
 				.charset(CharsetUtil.UTF_8)
@@ -26,7 +26,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void postTest2() {
 		// 某些接口对Accept头有特殊要求，此处自定义头
 		String result = HttpUtil
@@ -38,14 +38,14 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getTest() {
 		String result1 = HttpUtil.get("http://photo.qzone.qq.com/fcgi-bin/fcg_list_album?uin=88888&outstyle=2", CharsetUtil.CHARSET_GBK);
 		Console.log(result1);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getTest2() {
 		// 此链接较为特殊，User-Agent去掉后进入一个JS跳转页面，如果设置了，需要开启302跳转
 		// 自定义的默认header无效
@@ -56,7 +56,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getTest3() {
 		// 测试url中带有空格的情况
 		String result1 = HttpUtil.get("http://hutool.cn:5000/kf?abc= d");
@@ -64,7 +64,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getTest4() {
 		// 测试url中带有空格的情况
 		byte[] str = HttpRequest.get("http://img01.fs.yiban.cn/mobile/2D0Y71").execute().bodyBytes();
@@ -74,7 +74,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getTest5() {
 		String url2 = "http://storage.chancecloud.com.cn/20200413_%E7%B2%A4B12313_386.pdf";
 		ByteArrayOutputStream os2 = new ByteArrayOutputStream();
@@ -85,7 +85,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void get12306Test() {
 		HttpRequest.get("https://kyfw.12306.cn/otn/")
 				.setFollowRedirects(true)
@@ -93,7 +93,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void downloadStringTest() {
 		String url = "https://www.baidu.com";
 		// 从远程直接读取字符串，需要自定义编码，直接调用JDK方法
@@ -102,7 +102,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void oschinaTest() {
 		// 请求列表页
 		String listContent = HttpUtil.get("https://www.oschina.net/action/ajax/get_more_news_list?newsType=&p=2");
@@ -122,17 +122,17 @@ public class HttpUtilTest {
 	public void decodeParamsTest() {
 		String paramsStr = "uuuu=0&a=b&c=%3F%23%40!%24%25%5E%26%3Ddsssss555555";
 		Map<String, List<String>> map = HttpUtil.decodeParams(paramsStr, CharsetUtil.UTF_8);
-		Assert.assertEquals("0", map.get("uuuu").get(0));
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("?#@!$%^&=dsssss555555", map.get("c").get(0));
+		Assertions.assertEquals("0", map.get("uuuu").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("?#@!$%^&=dsssss555555", map.get("c").get(0));
 	}
 
 	@Test
 	public void decodeParamMapTest() {
 		// 参数值存在分界标记等号时
 		Map<String, String> paramMap = HttpUtil.decodeParamMap("https://www.xxx.com/api.action?aa=123&f_token=NzBkMjQxNDM1MDVlMDliZTk1OTU3ZDI1OTI0NTBiOWQ=", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("123",paramMap.get("aa"));
-		Assert.assertEquals("NzBkMjQxNDM1MDVlMDliZTk1OTU3ZDI1OTI0NTBiOWQ=",paramMap.get("f_token"));
+		Assertions.assertEquals("123",paramMap.get("aa"));
+		Assertions.assertEquals("NzBkMjQxNDM1MDVlMDliZTk1OTU3ZDI1OTI0NTBiOWQ=",paramMap.get("f_token"));
 	}
 
 	@Test
@@ -141,7 +141,7 @@ public class HttpUtilTest {
 		Map<String, List<String>> map = HttpUtil.decodeParams(paramsStr, CharsetUtil.UTF_8);
 
 		String encodedParams = HttpUtil.toParams(map);
-		Assert.assertEquals(paramsStr, encodedParams);
+		Assertions.assertEquals(paramsStr, encodedParams);
 	}
 
 	@Test
@@ -149,52 +149,52 @@ public class HttpUtilTest {
 		// ?单独存在去除之，&单位位于末尾去除之
 		String paramsStr = "?a=b&c=d&";
 		String encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=b&c=d", encode);
+		Assertions.assertEquals("a=b&c=d", encode);
 
 		// url不参与转码
 		paramsStr = "http://www.abc.dd?a=b&c=d&";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("http://www.abc.dd?a=b&c=d", encode);
+		Assertions.assertEquals("http://www.abc.dd?a=b&c=d", encode);
 
 		// b=b中的=被当作值的一部分，不做encode
 		paramsStr = "a=b=b&c=d&";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=b=b&c=d", encode);
+		Assertions.assertEquals("a=b=b&c=d", encode);
 
 		// =d的情况被处理为key为空
 		paramsStr = "a=bbb&c=d&=d";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=bbb&c=d&=d", encode);
+		Assertions.assertEquals("a=bbb&c=d&=d", encode);
 
 		// d=的情况被处理为value为空
 		paramsStr = "a=bbb&c=d&d=";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=bbb&c=d&d=", encode);
+		Assertions.assertEquals("a=bbb&c=d&d=", encode);
 
 		// 多个&&被处理为单个，相当于空条件
 		paramsStr = "a=bbb&c=d&&&d=";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=bbb&c=d&d=", encode);
+		Assertions.assertEquals("a=bbb&c=d&d=", encode);
 
 		// &d&相当于只有键，无值得情况
 		paramsStr = "a=bbb&c=d&d&";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=bbb&c=d&d=", encode);
+		Assertions.assertEquals("a=bbb&c=d&d=", encode);
 
 		// 中文的键和值被编码
 		paramsStr = "a=bbb&c=你好&哈喽&";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("a=bbb&c=%E4%BD%A0%E5%A5%BD&%E5%93%88%E5%96%BD=", encode);
+		Assertions.assertEquals("a=bbb&c=%E4%BD%A0%E5%A5%BD&%E5%93%88%E5%96%BD=", encode);
 
 		// URL原样输出
 		paramsStr = "https://www.hutool.cn/";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals(paramsStr, encode);
+		Assertions.assertEquals(paramsStr, encode);
 
 		// URL原样输出
 		paramsStr = "https://www.hutool.cn/?";
 		encode = HttpUtil.encodeParams(paramsStr, CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("https://www.hutool.cn/", encode);
+		Assertions.assertEquals("https://www.hutool.cn/", encode);
 	}
 
 	@Test
@@ -202,55 +202,55 @@ public class HttpUtilTest {
 		// 开头的？被去除
 		String a = "?a=b&c=d&";
 		Map<String, List<String>> map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("d", map.get("c").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("d", map.get("c").get(0));
 
 		// =e被当作空为key，e为value
 		a = "?a=b&c=d&=e";
 		map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("d", map.get("c").get(0));
-		Assert.assertEquals("e", map.get("").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("d", map.get("c").get(0));
+		Assertions.assertEquals("e", map.get("").get(0));
 
 		// 多余的&去除
 		a = "?a=b&c=d&=e&&&&";
 		map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("d", map.get("c").get(0));
-		Assert.assertEquals("e", map.get("").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("d", map.get("c").get(0));
+		Assertions.assertEquals("e", map.get("").get(0));
 
 		// 值为空
 		a = "?a=b&c=d&e=";
 		map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("d", map.get("c").get(0));
-		Assert.assertEquals("", map.get("e").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("d", map.get("c").get(0));
+		Assertions.assertEquals("", map.get("e").get(0));
 
 		// &=被作为键和值都为空
 		a = "a=b&c=d&=";
 		map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("d", map.get("c").get(0));
-		Assert.assertEquals("", map.get("").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("d", map.get("c").get(0));
+		Assertions.assertEquals("", map.get("").get(0));
 
 		// &e&这类单独的字符串被当作key
 		a = "a=b&c=d&e&";
 		map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("b", map.get("a").get(0));
-		Assert.assertEquals("d", map.get("c").get(0));
-		Assert.assertNull(map.get("e").get(0));
-		Assert.assertNull(map.get("").get(0));
+		Assertions.assertEquals("b", map.get("a").get(0));
+		Assertions.assertEquals("d", map.get("c").get(0));
+		Assertions.assertNull(map.get("e").get(0));
+		Assertions.assertNull(map.get("").get(0));
 
 		// 被编码的键和值被还原
 		a = "a=bbb&c=%E4%BD%A0%E5%A5%BD&%E5%93%88%E5%96%BD=";
 		map = HttpUtil.decodeParams(a, CharsetUtil.UTF_8);
-		Assert.assertEquals("bbb", map.get("a").get(0));
-		Assert.assertEquals("你好", map.get("c").get(0));
-		Assert.assertEquals("", map.get("哈喽").get(0));
+		Assertions.assertEquals("bbb", map.get("a").get(0));
+		Assertions.assertEquals("你好", map.get("c").get(0));
+		Assertions.assertEquals("", map.get("哈喽").get(0));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void patchTest() {
 		// 验证patch请求是否可用
 		String body = HttpRequest.patch("https://www.baidu.com").execute().body();
@@ -271,12 +271,12 @@ public class HttpUtilTest {
 		param.put("Version", "1.0");
 
 		String urlWithForm = HttpUtil.urlWithForm("http://api.hutool.cn/login?type=aaa", param, CharsetUtil.CHARSET_UTF_8, false);
-		Assert.assertEquals(
+		Assertions.assertEquals(
 				"http://api.hutool.cn/login?type=aaa&AccessKeyId=123&Action=DescribeDomainRecords&Format=date&DomainName=lesper.cn&SignatureMethod=POST&SignatureNonce=123&SignatureVersion=4.3.1&Timestamp=123432453&Version=1.0",
 				urlWithForm);
 
 		urlWithForm = HttpUtil.urlWithForm("http://api.hutool.cn/login?type=aaa", param, CharsetUtil.CHARSET_UTF_8, false);
-		Assert.assertEquals(
+		Assertions.assertEquals(
 				"http://api.hutool.cn/login?type=aaa&AccessKeyId=123&Action=DescribeDomainRecords&Format=date&DomainName=lesper.cn&SignatureMethod=POST&SignatureNonce=123&SignatureVersion=4.3.1&Timestamp=123432453&Version=1.0",
 				urlWithForm);
 	}
@@ -284,38 +284,38 @@ public class HttpUtilTest {
 	@Test
 	public void getCharsetTest() {
 		String charsetName = ReUtil.get(HttpUtil.CHARSET_PATTERN, "Charset=UTF-8;fq=0.9", 1);
-		Assert.assertEquals("UTF-8", charsetName);
+		Assertions.assertEquals("UTF-8", charsetName);
 
 		charsetName = ReUtil.get(HttpUtil.META_CHARSET_PATTERN, "<meta charset=utf-8", 1);
-		Assert.assertEquals("utf-8", charsetName);
+		Assertions.assertEquals("utf-8", charsetName);
 		charsetName = ReUtil.get(HttpUtil.META_CHARSET_PATTERN, "<meta charset='utf-8'", 1);
-		Assert.assertEquals("utf-8", charsetName);
+		Assertions.assertEquals("utf-8", charsetName);
 		charsetName = ReUtil.get(HttpUtil.META_CHARSET_PATTERN, "<meta charset=\"utf-8\"", 1);
-		Assert.assertEquals("utf-8", charsetName);
+		Assertions.assertEquals("utf-8", charsetName);
 		charsetName = ReUtil.get(HttpUtil.META_CHARSET_PATTERN, "<meta charset = \"utf-8\"", 1);
-		Assert.assertEquals("utf-8", charsetName);
+		Assertions.assertEquals("utf-8", charsetName);
 	}
 
 	@Test
 	public void normalizeParamsTest() {
 		String encodeResult = HttpUtil.normalizeParams("参数", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("%E5%8F%82%E6%95%B0", encodeResult);
+		Assertions.assertEquals("%E5%8F%82%E6%95%B0", encodeResult);
 	}
 
 	@Test
 	public void normalizeBlankParamsTest() {
 		String encodeResult = HttpUtil.normalizeParams("", CharsetUtil.CHARSET_UTF_8);
-		Assert.assertEquals("", encodeResult);
+		Assertions.assertEquals("", encodeResult);
 	}
 
 	@Test
 	public void getMimeTypeTest() {
 		String mimeType = HttpUtil.getMimeType("aaa.aaa");
-		Assert.assertNull(mimeType);
+		Assertions.assertNull(mimeType);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getWeixinTest(){
 		// 测试特殊URL，即URL中有&amp;情况是否请求正常
 		String url = "https://mp.weixin.qq.com/s?__biz=MzI5NjkyNTIxMg==&amp;mid=100000465&amp;idx=1&amp;sn=1044c0d19723f74f04f4c1da34eefa35&amp;chksm=6cbda3a25bca2ab4516410db6ce6e125badaac2f8c5548ea6e18eab6dc3c5422cb8cbe1095f7";
@@ -324,7 +324,7 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getNocovTest(){
 		String url = "https://qiniu.nocov.cn/medical-manage%2Ftest%2FBANNER_IMG%2F444004467954556928%2F1595215173047icon.png~imgReduce?e=1597081986&token=V2lJYVgQgAv_sbypfEZ0qpKs6TzD1q5JIDVr0Tw8:89cbBkLLwEc9JsMoCLkAEOu820E=";
 		final String s = HttpUtil.get(url);
@@ -332,21 +332,21 @@ public class HttpUtilTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void sinajsTest(){
 		final String s = HttpUtil.get("http://hq.sinajs.cn/list=sh600519");
 		Console.log(s);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void gimg2Test(){
 		byte[] bytes = HttpUtil.downloadBytes("https://gimg2.baidu.com/image_search/src=http%3A%2F%2Fpic.jj20.com%2Fup%2Fallimg%2F1114%2F0H320120Z3%2F200H3120Z3-6-1200.jpg&refer=http%3A%2F%2Fpic.jj20.com&app=2002&size=f9999,10000&q=a80&n=0&g=0n&fmt=jpeg?sec=1621996490&t=8c384c2823ea453da15a1b9cd5183eea");
 		Console.log(Base64.encode(bytes));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void acplayTest(){
 		final String body = HttpRequest.get("https://api.acplay.net/api/v2/bangumi/9541")
 				.execute().body();

--- a/hutool-http/src/test/java/cn/hutool/http/HttpsTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpsTest.java
@@ -2,8 +2,8 @@ package cn.hutool.http;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.thread.ThreadUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -13,7 +13,7 @@ public class HttpsTest {
 	 * 测试单例的SSLSocketFactory是否有线程安全问题
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void getTest() {
 		final AtomicInteger count = new AtomicInteger();
 		for(int i =0; i < 100; i++){

--- a/hutool-http/src/test/java/cn/hutool/http/RestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/RestTest.java
@@ -2,9 +2,9 @@ package cn.hutool.http;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.json.JSONUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Rest类型请求单元测试
@@ -20,11 +20,11 @@ public class RestTest {
 				.body(JSONUtil.createObj()
 						.set("aaa", "aaaValue")
 						.set("键2", "值2").toString());
-		Assert.assertEquals("application/json;charset=UTF-8", request.header("Content-Type"));
+		Assertions.assertEquals("application/json;charset=UTF-8", request.header("Content-Type"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void postTest() {
 		HttpRequest request = HttpRequest.post("http://localhost:8090/rest/restTest/")//
 				.body(JSONUtil.createObj()
@@ -34,7 +34,7 @@ public class RestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void postTest2() {
 		String result = HttpUtil.post("http://localhost:8090/rest/restTest/", JSONUtil.createObj()//
 				.set("aaa", "aaaValue")
@@ -43,7 +43,7 @@ public class RestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getWithBodyTest() {
 		HttpRequest request = HttpRequest.get("http://localhost:8888/restTest")//
 				.header(Header.CONTENT_TYPE, "application/json")
@@ -54,7 +54,7 @@ public class RestTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void getWithBodyTest2() {
 		HttpRequest request = HttpRequest.get("https://ad.oceanengine.com/open_api/2/advertiser/info/")//
 				// Charles代理

--- a/hutool-http/src/test/java/cn/hutool/http/UploadTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/UploadTest.java
@@ -2,8 +2,8 @@ package cn.hutool.http;
 
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -22,7 +22,7 @@ public class UploadTest {
 	 * 多文件上传测试
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void uploadFilesTest() {
 		File file = FileUtil.file("d:\\图片1.JPG");
 		File file2 = FileUtil.file("d:\\图片3.png");
@@ -37,7 +37,7 @@ public class UploadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void uploadFileTest() {
 		File file = FileUtil.file("D:\\face.jpg");
 
@@ -50,7 +50,7 @@ public class UploadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void uploadTest2() {
 		//客户端
 		String url = "http://192.168.1.200:8888/meta/upload/img";

--- a/hutool-http/src/test/java/cn/hutool/http/body/MultipartBodyTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/body/MultipartBodyTest.java
@@ -3,8 +3,8 @@ package cn.hutool.http.body;
 import cn.hutool.core.io.resource.StringResource;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.http.HttpResource;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class MultipartBodyTest {
 
 		final MultipartBody body = MultipartBody.create(form, CharsetUtil.CHARSET_UTF_8);
 
-		Assert.assertNotNull(body.toString());
+		Assertions.assertNotNull(body.toString());
 //		Console.log(body);
 	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/useragent/UserAgentUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.http.useragent;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class UserAgentUtilTest {
 
@@ -10,14 +10,14 @@ public class UserAgentUtilTest {
 		String uaStr = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.835.163 Safari/535.1";
 
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("Chrome", ua.getBrowser().toString());
-		Assert.assertEquals("14.0.835.163", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("535.1", ua.getEngineVersion());
-		Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
-		Assert.assertEquals("6.1", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("Chrome", ua.getBrowser().toString());
+		Assertions.assertEquals("14.0.835.163", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("535.1", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
+		Assertions.assertEquals("6.1", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
@@ -25,182 +25,182 @@ public class UserAgentUtilTest {
 		String uaStr = "User-Agent:Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5";
 
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("Safari", ua.getBrowser().toString());
-		Assert.assertEquals("5.0.2", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("533.17.9", ua.getEngineVersion());
-		Assert.assertEquals("iPhone", ua.getOs().toString());
-		Assert.assertEquals("4_3_3", ua.getOsVersion());
-		Assert.assertEquals("iPhone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Safari", ua.getBrowser().toString());
+		Assertions.assertEquals("5.0.2", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("533.17.9", ua.getEngineVersion());
+		Assertions.assertEquals("iPhone", ua.getOs().toString());
+		Assertions.assertEquals("4_3_3", ua.getOsVersion());
+		Assertions.assertEquals("iPhone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseMiui10WithChromeTest() {
 		String uaStr = "Mozilla/5.0 (Linux; Android 9; MIX 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("Chrome", ua.getBrowser().toString());
-		Assert.assertEquals("70.0.3538.80", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("9", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Chrome", ua.getBrowser().toString());
+		Assertions.assertEquals("70.0.3538.80", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("9", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseHuaweiPhoneWithNativeBrowserTest() {
 		String uaString = "Mozilla/5.0 (Linux; Android 10; EML-AL00 Build/HUAWEIEML-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("Android Browser", ua.getBrowser().toString());
-		Assert.assertEquals("4.0", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("10", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Android Browser", ua.getBrowser().toString());
+		Assertions.assertEquals("4.0", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("10", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseSamsungPhoneWithNativeBrowserTest() {
 		String uaString = "Dalvik/2.1.0 (Linux; U; Android 9; SM-G950U Build/PPR1.180610.011)";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("Android Browser", ua.getBrowser().toString());
-		Assert.assertNull(ua.getVersion());
-		Assert.assertEquals("Unknown", ua.getEngine().toString());
-		Assert.assertNull(ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("9", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Android Browser", ua.getBrowser().toString());
+		Assertions.assertNull(ua.getVersion());
+		Assertions.assertEquals("Unknown", ua.getEngine().toString());
+		Assertions.assertNull(ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("9", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseWindows10WithChromeTest() {
 		String uaStr = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("Chrome", ua.getBrowser().toString());
-		Assert.assertEquals("70.0.3538.102", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
-		Assert.assertEquals("10.0", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("Chrome", ua.getBrowser().toString());
+		Assertions.assertEquals("70.0.3538.102", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
+		Assertions.assertEquals("10.0", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseWindows10WithIe11Test() {
 		String uaStr = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSIE11", ua.getBrowser().toString());
-		Assert.assertEquals("11.0", ua.getVersion());
-		Assert.assertEquals("Trident", ua.getEngine().toString());
-		Assert.assertEquals("7.0", ua.getEngineVersion());
-		Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
-		Assert.assertEquals("10.0", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("MSIE11", ua.getBrowser().toString());
+		Assertions.assertEquals("11.0", ua.getVersion());
+		Assertions.assertEquals("Trident", ua.getEngine().toString());
+		Assertions.assertEquals("7.0", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
+		Assertions.assertEquals("10.0", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseWindows10WithIeMobileLumia520Test() {
 		String uaStr = "Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537 ";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("IEMobile", ua.getBrowser().toString());
-		Assert.assertEquals("11.0", ua.getVersion());
-		Assert.assertEquals("Trident", ua.getEngine().toString());
-		Assert.assertEquals("7.0", ua.getEngineVersion());
-		Assert.assertEquals("Windows Phone", ua.getOs().toString());
-		Assert.assertEquals("8.1", ua.getOsVersion());
-		Assert.assertEquals("Windows Phone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("IEMobile", ua.getBrowser().toString());
+		Assertions.assertEquals("11.0", ua.getVersion());
+		Assertions.assertEquals("Trident", ua.getEngine().toString());
+		Assertions.assertEquals("7.0", ua.getEngineVersion());
+		Assertions.assertEquals("Windows Phone", ua.getOs().toString());
+		Assertions.assertEquals("8.1", ua.getOsVersion());
+		Assertions.assertEquals("Windows Phone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseWindows10WithIe8EmulatorTest() {
 		String uaStr = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSIE", ua.getBrowser().toString());
-		Assert.assertEquals("8.0", ua.getVersion());
-		Assert.assertEquals("Trident", ua.getEngine().toString());
-		Assert.assertEquals("4.0", ua.getEngineVersion());
-		Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
-		Assert.assertEquals("6.1", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("MSIE", ua.getBrowser().toString());
+		Assertions.assertEquals("8.0", ua.getVersion());
+		Assertions.assertEquals("Trident", ua.getEngine().toString());
+		Assertions.assertEquals("4.0", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
+		Assertions.assertEquals("6.1", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseWindows10WithEdgeTest() {
 		String uaStr = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17763";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSEdge", ua.getBrowser().toString());
-		Assert.assertEquals("18.17763", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
-		Assert.assertEquals("10.0", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("MSEdge", ua.getBrowser().toString());
+		Assertions.assertEquals("18.17763", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
+		Assertions.assertEquals("10.0", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseEdgeOnLumia950XLTest() {
 		String uaStr = "Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 950XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Mobile Safari/537.36 Edge/15.14900";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSEdge", ua.getBrowser().toString());
-		Assert.assertEquals("15.14900", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows Phone", ua.getOs().toString());
-		Assert.assertEquals("10.0", ua.getOsVersion());
-		Assert.assertEquals("Windows Phone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("MSEdge", ua.getBrowser().toString());
+		Assertions.assertEquals("15.14900", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows Phone", ua.getOs().toString());
+		Assertions.assertEquals("10.0", ua.getOsVersion());
+		Assertions.assertEquals("Windows Phone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseChromeOnWindowsServer2012R2Test() {
 		String uaStr = "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("Chrome", ua.getBrowser().toString());
-		Assert.assertEquals("63.0.3239.132", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 8.1 or Winsows Server 2012R2", ua.getOs().toString());
-		Assert.assertEquals("6.3", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("Chrome", ua.getBrowser().toString());
+		Assertions.assertEquals("63.0.3239.132", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 8.1 or Winsows Server 2012R2", ua.getOs().toString());
+		Assertions.assertEquals("6.3", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseIE11OnWindowsServer2008R2Test() {
 		String uaStr = "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSIE11", ua.getBrowser().toString());
-		Assert.assertEquals("11.0", ua.getVersion());
-		Assert.assertEquals("Trident", ua.getEngine().toString());
-		Assert.assertEquals("7.0", ua.getEngineVersion());
-		Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
-		Assert.assertEquals("6.1", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("MSIE11", ua.getBrowser().toString());
+		Assertions.assertEquals("11.0", ua.getVersion());
+		Assertions.assertEquals("Trident", ua.getEngine().toString());
+		Assertions.assertEquals("7.0", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
+		Assertions.assertEquals("6.1", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseEdgeTest() {
 		String uaStr = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.69 Safari/537.36 Edg/81.0.416.34";
 		UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSEdge", ua.getBrowser().toString());
-		Assert.assertEquals("81.0.416.34", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
-		Assert.assertEquals("10.0", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("MSEdge", ua.getBrowser().toString());
+		Assertions.assertEquals("81.0.416.34", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
+		Assertions.assertEquals("10.0", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	/**
@@ -210,153 +210,153 @@ public class UserAgentUtilTest {
 	public void parseMicroMessengerTest() {
 		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Mobile/15A372 MicroMessenger/7.0.17(0x17001127) NetType/WIFI Language/zh_CN";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("MicroMessenger", ua.getBrowser().toString());
-		Assert.assertEquals("7.0.17", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("604.1.38", ua.getEngineVersion());
-		Assert.assertEquals("iPhone", ua.getOs().toString());
-		Assert.assertEquals("11_0", ua.getOsVersion());
-		Assert.assertEquals("iPhone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("MicroMessenger", ua.getBrowser().toString());
+		Assertions.assertEquals("7.0.17", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("604.1.38", ua.getEngineVersion());
+		Assertions.assertEquals("iPhone", ua.getOs().toString());
+		Assertions.assertEquals("11_0", ua.getOsVersion());
+		Assertions.assertEquals("iPhone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseWorkWxTest() {
 		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 wxwork/3.0.31 MicroMessenger/7.0.1 Language/zh";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("wxwork", ua.getBrowser().toString());
-		Assert.assertEquals("3.0.31", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("605.1.15", ua.getEngineVersion());
-		Assert.assertEquals("iPhone", ua.getOs().toString());
-		Assert.assertEquals("iPhone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("wxwork", ua.getBrowser().toString());
+		Assertions.assertEquals("3.0.31", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("605.1.15", ua.getEngineVersion());
+		Assertions.assertEquals("iPhone", ua.getOs().toString());
+		Assertions.assertEquals("iPhone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseQQTest() {
 		String uaString = "User-Agent: MQQBrowser/26 Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; MB200 Build/GRJ22; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("QQBrowser", ua.getBrowser().toString());
-		Assert.assertEquals("26", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("533.1", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("2.3.7", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("QQBrowser", ua.getBrowser().toString());
+		Assertions.assertEquals("26", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("533.1", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("2.3.7", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseDingTalkTest() {
 		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/18A373 AliApp(DingTalk/5.1.33) com.laiwang.DingTalk/13976299 Channel/201200 language/zh-Hans-CN WK";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("DingTalk", ua.getBrowser().toString());
-		Assert.assertEquals("5.1.33", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("605.1.15", ua.getEngineVersion());
-		Assert.assertEquals("iPhone", ua.getOs().toString());
-		Assert.assertEquals("14_0", ua.getOsVersion());
-		Assert.assertEquals("iPhone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("DingTalk", ua.getBrowser().toString());
+		Assertions.assertEquals("5.1.33", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("605.1.15", ua.getEngineVersion());
+		Assertions.assertEquals("iPhone", ua.getOs().toString());
+		Assertions.assertEquals("14_0", ua.getOsVersion());
+		Assertions.assertEquals("iPhone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseAlipayTest() {
 		String uaString = "Mozilla/5.0 (Linux; U; Android 7.0; zh-CN; FRD-AL00 Build/HUAWEIFRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.3.8.909 UWS/2.10.2.5 Mobile Safari/537.36 UCBS/2.10.2.5 Nebula AlipayDefined(nt:WIFI,ws:360|0|3.0) AliApp(AP/10.0.18.062203) AlipayClient/10.0.18.062203 Language/zh-Hans useStatusBar/true";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("Alipay", ua.getBrowser().toString());
-		Assert.assertEquals("10.0.18.062203", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("7.0", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Alipay", ua.getBrowser().toString());
+		Assertions.assertEquals("10.0.18.062203", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("7.0", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseTaobaoTest() {
 		String uaString = "Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; MI 2C Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 AliApp(TB/4.9.2) WindVane/5.2.2 TBANDROID/700342@taobao_android_4.9.2 720X1280";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("Taobao", ua.getBrowser().toString());
-		Assert.assertEquals("4.9.2", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("4.4.4", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Taobao", ua.getBrowser().toString());
+		Assertions.assertEquals("4.9.2", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("4.4.4", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseUCTest() {
 		String uaString = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 UBrowser/4.0.3214.0 Safari/537.36";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("UCBrowser", ua.getBrowser().toString());
-		Assert.assertEquals("4.0.3214.0", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
-		Assert.assertEquals("6.1", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("UCBrowser", ua.getBrowser().toString());
+		Assertions.assertEquals("4.0.3214.0", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 7 or Windows Server 2008R2", ua.getOs().toString());
+		Assertions.assertEquals("6.1", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseUCTest2() {
 		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X; zh-CN) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/16G102 UCBrowser/12.7.6.1251 Mobile AliApp(TUnionSDK/0.1.20.3)";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("UCBrowser", ua.getBrowser().toString());
-		Assert.assertEquals("12.7.6.1251", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.51.1", ua.getEngineVersion());
-		Assert.assertEquals("iPhone", ua.getOs().toString());
-		Assert.assertEquals("12_4_1", ua.getOsVersion());
-		Assert.assertEquals("iPhone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("UCBrowser", ua.getBrowser().toString());
+		Assertions.assertEquals("12.7.6.1251", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.51.1", ua.getEngineVersion());
+		Assertions.assertEquals("iPhone", ua.getOs().toString());
+		Assertions.assertEquals("12_4_1", ua.getOsVersion());
+		Assertions.assertEquals("iPhone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseQuarkTest() {
 		String uaString = "Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_1 like Mac OS X; zh-cn) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/16G102 Quark/3.6.2.993 Mobile";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("Quark", ua.getBrowser().toString());
-		Assert.assertEquals("3.6.2.993", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("601.1.46", ua.getEngineVersion());
-		Assert.assertEquals("iPhone", ua.getOs().toString());
-		Assert.assertEquals("12_4_1", ua.getOsVersion());
-		Assert.assertEquals("iPhone", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("Quark", ua.getBrowser().toString());
+		Assertions.assertEquals("3.6.2.993", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("601.1.46", ua.getEngineVersion());
+		Assertions.assertEquals("iPhone", ua.getOs().toString());
+		Assertions.assertEquals("12_4_1", ua.getOsVersion());
+		Assertions.assertEquals("iPhone", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
 	public void parseWxworkTest() {
 		String uaString = "Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36 QBCore/4.0.1326.400 QQBrowser/9.0.2524.400 Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 Safari/537.36 wxwork/3.1.10 (MicroMessenger/6.2) WindowsWechat";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("wxwork", ua.getBrowser().toString());
-		Assert.assertEquals("3.1.10", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
-		Assert.assertEquals("10.0", ua.getOsVersion());
-		Assert.assertEquals("Windows", ua.getPlatform().toString());
-		Assert.assertFalse(ua.isMobile());
+		Assertions.assertEquals("wxwork", ua.getBrowser().toString());
+		Assertions.assertEquals("3.1.10", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Windows 10 or Windows Server 2016", ua.getOs().toString());
+		Assertions.assertEquals("10.0", ua.getOsVersion());
+		Assertions.assertEquals("Windows", ua.getPlatform().toString());
+		Assertions.assertFalse(ua.isMobile());
 	}
 
 	@Test
 	public void parseWxworkMobileTest() {
 		String uaString = "Mozilla/5.0 (Linux; Android 10; JSN-AL00 Build/HONORJSN-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.120 MQQBrowser/6.2 TBS/045710 Mobile Safari/537.36 wxwork/3.1.10 ColorScheme/Light MicroMessenger/7.0.1 NetType/WIFI Language/zh Lang/zh";
 		UserAgent ua = UserAgentUtil.parse(uaString);
-		Assert.assertEquals("wxwork", ua.getBrowser().toString());
-		Assert.assertEquals("3.1.10", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("10", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("wxwork", ua.getBrowser().toString());
+		Assertions.assertEquals("3.1.10", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("10", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 
 	@Test
@@ -364,13 +364,13 @@ public class UserAgentUtilTest {
 		// https://gitee.com/dromara/hutool/issues/I4MCBP
 		String uaStr = "userAgent: Mozilla/5.0 (Linux; Android 11; MI 9 Transparent Edition) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.55 Mobile Safari/537.36 EdgA/96.0.1054.36";
 		final UserAgent ua = UserAgentUtil.parse(uaStr);
-		Assert.assertEquals("MSEdge", ua.getBrowser().toString());
-		Assert.assertEquals("96.0.1054.36", ua.getVersion());
-		Assert.assertEquals("Webkit", ua.getEngine().toString());
-		Assert.assertEquals("537.36", ua.getEngineVersion());
-		Assert.assertEquals("Android", ua.getOs().toString());
-		Assert.assertEquals("11", ua.getOsVersion());
-		Assert.assertEquals("Android", ua.getPlatform().toString());
-		Assert.assertTrue(ua.isMobile());
+		Assertions.assertEquals("MSEdge", ua.getBrowser().toString());
+		Assertions.assertEquals("96.0.1054.36", ua.getVersion());
+		Assertions.assertEquals("Webkit", ua.getEngine().toString());
+		Assertions.assertEquals("537.36", ua.getEngineVersion());
+		Assertions.assertEquals("Android", ua.getOs().toString());
+		Assertions.assertEquals("11", ua.getOsVersion());
+		Assertions.assertEquals("Android", ua.getPlatform().toString());
+		Assertions.assertTrue(ua.isMobile());
 	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/webservice/SoapClientTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/webservice/SoapClientTest.java
@@ -2,8 +2,8 @@ package cn.hutool.http.webservice;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.soap.SOAPException;
 import javax.xml.soap.SOAPMessage;
@@ -17,7 +17,7 @@ import javax.xml.soap.SOAPMessage;
 public class SoapClientTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void requestTest() {
 		SoapClient client = SoapClient.create("http://www.webxml.com.cn/WebServices/IpAddressSearchWebService.asmx")
 		.setMethod("web:getCountryCityByIp", "http://WebXml.com.cn/")
@@ -30,7 +30,7 @@ public class SoapClientTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void requestForMessageTest() throws SOAPException {
 		SoapClient client = SoapClient.create("http://www.webxml.com.cn/WebServices/IpAddressSearchWebService.asmx")
 				.setMethod("web:getCountryCityByIp", "http://WebXml.com.cn/")

--- a/hutool-json/src/test/java/cn/hutool/json/CustomSerializeTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/CustomSerializeTest.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import cn.hutool.json.serialize.JSONObjectSerializer;
 import lombok.ToString;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
@@ -12,12 +12,12 @@ public class CustomSerializeTest {
 	@Test
 	public void serializeTest() {
 		JSONUtil.putSerializer(CustomBean.class, (JSONObjectSerializer<CustomBean>) (json, bean) -> json.set("customName", bean.name));
-		
+
 		CustomBean customBean = new CustomBean();
 		customBean.name = "testName";
-		
+
 		JSONObject obj = JSONUtil.parseObj(customBean);
-		Assert.assertEquals("testName", obj.getStr("customName"));
+		Assertions.assertEquals("testName", obj.getStr("customName"));
 	}
 
 	@Test
@@ -27,10 +27,10 @@ public class CustomSerializeTest {
 			customBean.name = ((JSONObject)json).getStr("customName");
 			return customBean;
 		});
-		
+
 		String jsonStr = "{\"customName\":\"testName\"}";
 		CustomBean bean = JSONUtil.parseObj(jsonStr).toBean(CustomBean.class);
-		Assert.assertEquals("testName", bean.name);
+		Assertions.assertEquals("testName", bean.name);
 	}
 
 	@ToString

--- a/hutool-json/src/test/java/cn/hutool/json/Issue1075Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue1075Test.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Issue1075Test {
 
@@ -12,16 +12,16 @@ public class Issue1075Test {
 	public void testToBean() {
 		// 在不忽略大小写的情况下，f2、fac都不匹配
 		ObjA o2 = JSONUtil.toBean(jsonStr, ObjA.class);
-		Assert.assertNull(o2.getFAC());
-		Assert.assertNull(o2.getF2());
+		Assertions.assertNull(o2.getFAC());
+		Assertions.assertNull(o2.getF2());
 	}
 
 	@Test
 	public void testToBeanIgnoreCase() {
 		// 在忽略大小写的情况下，f2、fac都匹配
 		ObjA o2 = JSONUtil.parseObj(jsonStr, JSONConfig.create().setIgnoreCase(true)).toBean(ObjA.class);
-		Assert.assertEquals("fac", o2.getFAC());
-		Assert.assertEquals("f2", o2.getF2());
+		Assertions.assertEquals("fac", o2.getFAC());
+		Assertions.assertEquals("f2", o2.getF2());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/Issue1101Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue1101Test.java
@@ -4,8 +4,8 @@ import cn.hutool.core.bean.BeanUtil;
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.lang.TypeReference;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.TreeSet;
@@ -21,7 +21,7 @@ public class Issue1101Test {
 		final JSONArray objects = JSONUtil.parseArray(json);
 		final TreeSet<TreeNodeDto> convert = Convert.convert(new TypeReference<TreeSet<TreeNodeDto>>() {
 		}, objects);
-		Assert.assertEquals(2, convert.size());
+		Assertions.assertEquals(2, convert.size());
 	}
 
 	@Test
@@ -58,11 +58,11 @@ public class Issue1101Test {
 		final JSONObject jsonObject = JSONUtil.parseObj(json);
 
 		final TreeNode treeNode = JSONUtil.toBean(jsonObject, TreeNode.class);
-		Assert.assertEquals(2, treeNode.getChildren().size());
+		Assertions.assertEquals(2, treeNode.getChildren().size());
 
 		TreeNodeDto dto = new TreeNodeDto();
 		BeanUtil.copyProperties(treeNode, dto, true);
-		Assert.assertEquals(2, dto.getChildren().size());
+		Assertions.assertEquals(2, dto.getChildren().size());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/Issue1200Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue1200Test.java
@@ -3,8 +3,8 @@ package cn.hutool.json;
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.json.test.bean.ResultBean;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * 测试在bean转换时使用BeanConverter，默认忽略转换失败的字段。
@@ -16,7 +16,7 @@ import org.junit.Test;
 public class Issue1200Test {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void toBeanTest(){
 		final JSONObject jsonObject = JSONUtil.parseObj(ResourceUtil.readUtf8Str("issue1200.json"));
 		Console.log(jsonObject);

--- a/hutool-json/src/test/java/cn/hutool/json/Issue488Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue488Test.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.lang.TypeReference;
@@ -14,21 +14,21 @@ public class Issue488Test {
 	@Test
 	public void toBeanTest() {
 		String jsonStr = ResourceUtil.readUtf8Str("issue488.json");
-		
+
 		ResultSuccess<List<EmailAddress>> result = JSONUtil.toBean(jsonStr,
 				new TypeReference<ResultSuccess<List<EmailAddress>>>() {}, false);
-		
-		Assert.assertEquals("https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.emailAddress)", result.getContext());
-		
+
+		Assertions.assertEquals("https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.emailAddress)", result.getContext());
+
 		List<EmailAddress> adds = result.getValue();
-		Assert.assertEquals("会议室101", adds.get(0).getName());
-		Assert.assertEquals("MeetingRoom101@abc.com", adds.get(0).getAddress());
-		Assert.assertEquals("会议室102", adds.get(1).getName());
-		Assert.assertEquals("MeetingRoom102@abc.com", adds.get(1).getAddress());
-		Assert.assertEquals("会议室103", adds.get(2).getName());
-		Assert.assertEquals("MeetingRoom103@abc.com", adds.get(2).getAddress());
-		Assert.assertEquals("会议室219", adds.get(3).getName());
-		Assert.assertEquals("MeetingRoom219@abc.com", adds.get(3).getAddress());
+		Assertions.assertEquals("会议室101", adds.get(0).getName());
+		Assertions.assertEquals("MeetingRoom101@abc.com", adds.get(0).getAddress());
+		Assertions.assertEquals("会议室102", adds.get(1).getName());
+		Assertions.assertEquals("MeetingRoom102@abc.com", adds.get(1).getAddress());
+		Assertions.assertEquals("会议室103", adds.get(2).getName());
+		Assertions.assertEquals("MeetingRoom103@abc.com", adds.get(2).getAddress());
+		Assertions.assertEquals("会议室219", adds.get(3).getName());
+		Assertions.assertEquals("MeetingRoom219@abc.com", adds.get(3).getAddress());
 	}
 
 	@Test
@@ -40,17 +40,17 @@ public class Issue488Test {
 
 		ResultSuccess<List<EmailAddress>> result = resultList.get(0);
 
-		Assert.assertEquals("https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.emailAddress)", result.getContext());
+		Assertions.assertEquals("https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.emailAddress)", result.getContext());
 
 		List<EmailAddress> adds = result.getValue();
-		Assert.assertEquals("会议室101", adds.get(0).getName());
-		Assert.assertEquals("MeetingRoom101@abc.com", adds.get(0).getAddress());
-		Assert.assertEquals("会议室102", adds.get(1).getName());
-		Assert.assertEquals("MeetingRoom102@abc.com", adds.get(1).getAddress());
-		Assert.assertEquals("会议室103", adds.get(2).getName());
-		Assert.assertEquals("MeetingRoom103@abc.com", adds.get(2).getAddress());
-		Assert.assertEquals("会议室219", adds.get(3).getName());
-		Assert.assertEquals("MeetingRoom219@abc.com", adds.get(3).getAddress());
+		Assertions.assertEquals("会议室101", adds.get(0).getName());
+		Assertions.assertEquals("MeetingRoom101@abc.com", adds.get(0).getAddress());
+		Assertions.assertEquals("会议室102", adds.get(1).getName());
+		Assertions.assertEquals("MeetingRoom102@abc.com", adds.get(1).getAddress());
+		Assertions.assertEquals("会议室103", adds.get(2).getName());
+		Assertions.assertEquals("MeetingRoom103@abc.com", adds.get(2).getAddress());
+		Assertions.assertEquals("会议室219", adds.get(3).getName());
+		Assertions.assertEquals("MeetingRoom219@abc.com", adds.get(3).getAddress());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/Issue644Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue644Test.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
@@ -19,10 +19,10 @@ public class Issue644Test {
 		final JSONObject jsonObject = JSONUtil.parseObj(beanWithDate);
 
 		BeanWithDate beanWithDate2 = JSONUtil.toBean(jsonObject, BeanWithDate.class);
-		Assert.assertEquals(beanWithDate.getDate(), beanWithDate2.getDate());
+		Assertions.assertEquals(beanWithDate.getDate(), beanWithDate2.getDate());
 
 		beanWithDate2 = JSONUtil.toBean(jsonObject.toString(), BeanWithDate.class);
-		Assert.assertEquals(beanWithDate.getDate(), beanWithDate2.getDate());
+		Assertions.assertEquals(beanWithDate.getDate(), beanWithDate2.getDate());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/Issue677Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue677Test.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import cn.hutool.core.date.DateUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
@@ -19,7 +19,7 @@ public class Issue677Test {
 
 		final String jsonStr = JSONUtil.toJsonStr(dto);
 		final AuditResultDto auditResultDto = JSONUtil.toBean(jsonStr, AuditResultDto.class);
-		Assert.assertEquals("Mon Dec 15 00:00:00 CST 1969", auditResultDto.getDate().toString());
+		Assertions.assertEquals("Mon Dec 15 00:00:00 CST 1969", auditResultDto.getDate().toString());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/Issue867Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue867Test.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import cn.hutool.core.annotation.Alias;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Issue867Test {
 
@@ -11,9 +11,9 @@ public class Issue867Test {
 	public void toBeanTest(){
 		String json = "{\"abc_1d\":\"123\",\"abc_d\":\"456\",\"abc_de\":\"789\"}";
 		Test02 bean = JSONUtil.toBean(JSONUtil.parseObj(json),Test02.class);
-		Assert.assertEquals("123", bean.getAbc1d());
-		Assert.assertEquals("456", bean.getAbcD());
-		Assert.assertEquals("789", bean.getAbcDe());
+		Assertions.assertEquals("123", bean.getAbc1d());
+		Assertions.assertEquals("456", bean.getAbcD());
+		Assertions.assertEquals("789", bean.getAbcDe());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI1AU86Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI1AU86Test.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import cn.hutool.core.collection.CollUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -32,7 +32,7 @@ public class IssueI1AU86Test {
 
 		final List<Vcc> vccs = jsonArray.toList(Vcc.class);
 		for (Vcc vcc : vccs) {
-			Assert.assertNotNull(vcc);
+			Assertions.assertNotNull(vcc);
 		}
 	}
 

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI1F8M2.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI1F8M2.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
@@ -14,8 +14,8 @@ public class IssueI1F8M2 {
 	public void toBeanTest() {
 		String jsonStr = "{\"eventType\":\"fee\",\"fwdAlertingTime\":\"2020-04-22 16:34:13\",\"fwdAnswerTime\":\"\"}";
 		Param param = JSONUtil.toBean(jsonStr, Param.class);
-		Assert.assertEquals("2020-04-22T16:34:13", param.getFwdAlertingTime().toString());
-		Assert.assertNull(param.getFwdAnswerTime());
+		Assertions.assertEquals("2020-04-22T16:34:13", param.getFwdAlertingTime().toString());
+		Assertions.assertNull(param.getFwdAnswerTime());
 	}
 
 	// Param类的字段

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI1H2VN.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI1H2VN.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -18,11 +18,11 @@ public class IssueI1H2VN {
 		String jsonStr = "{'conditionsVo':[{'column':'StockNo','value':'abc','type':'='},{'column':'CheckIncoming','value':'1','type':'='}]," +
 				"'queryVo':{'conditionsVo':[{'column':'StockNo','value':'abc','type':'='},{'column':'CheckIncoming','value':'1','type':'='}],'queryVo':null}}";
 		QueryVo vo = JSONUtil.toBean(jsonStr, QueryVo.class);
-		Assert.assertEquals(2, vo.getConditionsVo().size());
+		Assertions.assertEquals(2, vo.getConditionsVo().size());
 		final QueryVo subVo = vo.getQueryVo();
-		Assert.assertNotNull(subVo);
-		Assert.assertEquals(2, subVo.getConditionsVo().size());
-		Assert.assertNull(subVo.getQueryVo());
+		Assertions.assertNotNull(subVo);
+		Assertions.assertEquals(2, subVo.getConditionsVo().size());
+		Assertions.assertNull(subVo.getQueryVo());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI3BS4S.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI3BS4S.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import cn.hutool.core.bean.BeanUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
@@ -17,7 +17,7 @@ public class IssueI3BS4S {
 		String jsonStr = "{date: '2021-03-17T06:31:33.99'}";
 		final Bean1 bean1 = new Bean1();
 		BeanUtil.copyProperties(JSONUtil.parseObj(jsonStr), bean1);
-		Assert.assertEquals("2021-03-17T06:31:33.099", bean1.getDate().toString());
+		Assertions.assertEquals("2021-03-17T06:31:33.099", bean1.getDate().toString());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI3EGJP.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI3EGJP.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import cn.hutool.core.bean.BeanUtil;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class IssueI3EGJP {
 
@@ -14,8 +14,8 @@ public class IssueI3EGJP {
 		paramJson.set("is_booleanb", true);
 		ConvertDO convertDO = BeanUtil.toBean(paramJson, ConvertDO.class);
 
-		Assert.assertTrue(convertDO.isBooleana());
-		Assert.assertTrue(convertDO.getIsBooleanb());
+		Assertions.assertTrue(convertDO.isBooleana());
+		Assertions.assertTrue(convertDO.getIsBooleanb());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI49VZBTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI49VZBTest.java
@@ -3,8 +3,8 @@ package cn.hutool.json;
 import cn.hutool.core.convert.Convert;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.stream.Stream;
 
@@ -65,12 +65,12 @@ public class IssueI49VZBTest {
 	public void toBeanTest(){
 		String str = "{type: \"password\"}";
 		final UPOpendoor upOpendoor = JSONUtil.toBean(str, UPOpendoor.class);
-		Assert.assertEquals(NBCloudKeyType.password, upOpendoor.getType());
+		Assertions.assertEquals(NBCloudKeyType.password, upOpendoor.getType());
 	}
 
 	@Test
 	public void enumConvertTest(){
 		final NBCloudKeyType type = Convert.toEnum(NBCloudKeyType.class, "snapKey");
-		Assert.assertEquals(NBCloudKeyType.snapKey, type);
+		Assertions.assertEquals(NBCloudKeyType.snapKey, type);
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/IssuesI44E4HTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssuesI44E4HTest.java
@@ -5,8 +5,8 @@ import cn.hutool.json.serialize.JSONDeserializer;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * 测试自定义反序列化
@@ -23,7 +23,7 @@ public class IssuesI44E4HTest {
 
 		String jsonStr = "{\"md\":\"value1\"}";
 		final TestDto testDto = JSONUtil.toBean(jsonStr, TestDto.class);
-		Assert.assertEquals("value1", testDto.getMd().getValue());
+		Assertions.assertEquals("value1", testDto.getMd().getValue());
 	}
 
 	@Getter

--- a/hutool-json/src/test/java/cn/hutool/json/JSONArrayTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONArrayTest.java
@@ -11,8 +11,8 @@ import cn.hutool.json.test.bean.Exam;
 import cn.hutool.json.test.bean.JsonNode;
 import cn.hutool.json.test.bean.KeyBean;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,10 +27,12 @@ import java.util.Map;
  */
 public class JSONArrayTest {
 
-	@Test(expected = JSONException.class)
+	@Test
 	public void createJSONArrayTest(){
-		// 集合类不支持转为JSONObject
-		new JSONArray(new JSONObject(), JSONConfig.create());
+		Assertions.assertThrows(JSONException.class, () -> {
+			// 集合类不支持转为JSONObject
+			new JSONArray(new JSONObject(), JSONConfig.create());
+		});
 	}
 
 	@Test
@@ -38,7 +40,7 @@ public class JSONArrayTest {
 		final List<String> aaa = ListUtil.of("aaa", null);
 		String jsonStr = JSONUtil.toJsonStr(JSONUtil.parse(aaa,
 				JSONConfig.create().setIgnoreNullValue(false)));
-		Assert.assertEquals("[\"aaa\",null]", jsonStr);
+		Assertions.assertEquals("[\"aaa\",null]", jsonStr);
 	}
 
 	@Test
@@ -51,25 +53,25 @@ public class JSONArrayTest {
 		array.add("value2");
 		array.add("value3");
 
-		Assert.assertEquals(array.get(0), "value1");
+		Assertions.assertEquals(array.get(0), "value1");
 	}
 
 	@Test
 	public void parseTest() {
 		String jsonStr = "[\"value1\", \"value2\", \"value3\"]";
 		JSONArray array = JSONUtil.parseArray(jsonStr);
-		Assert.assertEquals(array.get(0), "value1");
+		Assertions.assertEquals(array.get(0), "value1");
 	}
 
 	@Test
 	public void parseWithNullTest() {
 		String jsonStr = "[{\"grep\":\"4.8\",\"result\":\"右\"},{\"grep\":\"4.8\",\"result\":null}]";
 		JSONArray jsonArray = JSONUtil.parseArray(jsonStr);
-		Assert.assertFalse(jsonArray.getJSONObject(1).containsKey("result"));
+		Assertions.assertFalse(jsonArray.getJSONObject(1).containsKey("result"));
 
 		// 不忽略null，则null的键值对被保留
 		jsonArray = new JSONArray(jsonStr, false);
-		Assert.assertTrue(jsonArray.getJSONObject(1).containsKey("result"));
+		Assertions.assertTrue(jsonArray.getJSONObject(1).containsKey("result"));
 	}
 
 	@Test
@@ -78,7 +80,7 @@ public class JSONArrayTest {
 
 		JSONObject obj0 = array.getJSONObject(0);
 		Exam exam = JSONUtil.toBean(obj0, Exam.class);
-		Assert.assertEquals("0", exam.getAnswerArray()[0].getSeq());
+		Assertions.assertEquals("0", exam.getAnswerArray()[0].getSeq());
 	}
 
 	@Test
@@ -93,8 +95,8 @@ public class JSONArrayTest {
 		ArrayList<KeyBean> list = CollUtil.newArrayList(b1, b2);
 
 		JSONArray jsonArray = JSONUtil.parseArray(list);
-		Assert.assertEquals("aValue1", jsonArray.getJSONObject(0).getStr("akey"));
-		Assert.assertEquals("bValue2", jsonArray.getJSONObject(1).getStr("bkey"));
+		Assertions.assertEquals("aValue1", jsonArray.getJSONObject(0).getStr("akey"));
+		Assertions.assertEquals("bValue2", jsonArray.getJSONObject(1).getStr("bkey"));
 	}
 
 	@Test
@@ -103,8 +105,8 @@ public class JSONArrayTest {
 		JSONArray array = JSONUtil.parseArray(jsonStr);
 
 		List<Exam> list = array.toList(Exam.class);
-		Assert.assertFalse(list.isEmpty());
-		Assert.assertSame(Exam.class, list.get(0).getClass());
+		Assertions.assertFalse(list.isEmpty());
+		Assertions.assertSame(Exam.class, list.get(0).getClass());
 	}
 
 	@Test
@@ -114,14 +116,14 @@ public class JSONArrayTest {
 		JSONArray array = JSONUtil.parseArray(jsonArr);
 		List<User> userList = JSONUtil.toList(array, User.class);
 
-		Assert.assertFalse(userList.isEmpty());
-		Assert.assertSame(User.class, userList.get(0).getClass());
+		Assertions.assertFalse(userList.isEmpty());
+		Assertions.assertSame(User.class, userList.get(0).getClass());
 
-		Assert.assertEquals(Integer.valueOf(111), userList.get(0).getId());
-		Assert.assertEquals(Integer.valueOf(112), userList.get(1).getId());
+		Assertions.assertEquals(Integer.valueOf(111), userList.get(0).getId());
+		Assertions.assertEquals(Integer.valueOf(112), userList.get(1).getId());
 
-		Assert.assertEquals("test1", userList.get(0).getName());
-		Assert.assertEquals("test2", userList.get(1).getName());
+		Assertions.assertEquals("test1", userList.get(0).getName());
+		Assertions.assertEquals("test2", userList.get(1).getName());
 	}
 
 	@Test
@@ -132,14 +134,14 @@ public class JSONArrayTest {
 
 		List<Dict> list = JSONUtil.toList(array, Dict.class);
 
-		Assert.assertFalse(list.isEmpty());
-		Assert.assertSame(Dict.class, list.get(0).getClass());
+		Assertions.assertFalse(list.isEmpty());
+		Assertions.assertSame(Dict.class, list.get(0).getClass());
 
-		Assert.assertEquals(Integer.valueOf(111), list.get(0).getInt("id"));
-		Assert.assertEquals(Integer.valueOf(112), list.get(1).getInt("id"));
+		Assertions.assertEquals(Integer.valueOf(111), list.get(0).getInt("id"));
+		Assertions.assertEquals(Integer.valueOf(112), list.get(1).getInt("id"));
 
-		Assert.assertEquals("test1", list.get(0).getStr("name"));
-		Assert.assertEquals("test2", list.get(1).getStr("name"));
+		Assertions.assertEquals("test1", list.get(0).getStr("name"));
+		Assertions.assertEquals("test2", list.get(1).getStr("name"));
 	}
 
 	@Test
@@ -149,8 +151,8 @@ public class JSONArrayTest {
 
 		//noinspection SuspiciousToArrayCall
 		Exam[] list = array.toArray(new Exam[0]);
-		Assert.assertNotEquals(0, list.length);
-		Assert.assertSame(Exam.class, list[0].getClass());
+		Assertions.assertNotEquals(0, list.length);
+		Assertions.assertSame(Exam.class, list[0].getClass());
 	}
 
 	/**
@@ -162,17 +164,19 @@ public class JSONArrayTest {
 		JSONArray ja = JSONUtil.parseArray(json);
 
 		List<KeyBean> list = ja.toList(KeyBean.class);
-		Assert.assertNull(list.get(0));
-		Assert.assertEquals("avalue", list.get(1).getAkey());
-		Assert.assertEquals("bvalue", list.get(1).getBkey());
+		Assertions.assertNull(list.get(0));
+		Assertions.assertEquals("avalue", list.get(1).getAkey());
+		Assertions.assertEquals("bvalue", list.get(1).getBkey());
 	}
 
-	@Test(expected = ConvertException.class)
+	@Test
 	public void toListWithErrorTest(){
-		String json = "[['aaa',{'akey':'avalue','bkey':'bvalue'}]]";
-		JSONArray ja = JSONUtil.parseArray(json);
+		Assertions.assertThrows(ConvertException.class, () -> {
+			String json = "[['aaa',{'akey':'avalue','bkey':'bvalue'}]]";
+			JSONArray ja = JSONUtil.parseArray(json);
 
-		ja.toBean(new TypeReference<List<List<KeyBean>>>() {});
+			ja.toBean(new TypeReference<List<List<KeyBean>>>() {});
+		});
 	}
 
 	@Test
@@ -185,28 +189,28 @@ public class JSONArrayTest {
 		JSONArray jsonArray = JSONUtil.parseArray(mapList);
 		List<JsonNode> nodeList = jsonArray.toList(JsonNode.class);
 
-		Assert.assertEquals(Long.valueOf(0L), nodeList.get(0).getId());
-		Assert.assertEquals(Long.valueOf(1L), nodeList.get(1).getId());
-		Assert.assertEquals(Long.valueOf(0L), nodeList.get(2).getId());
-		Assert.assertEquals(Long.valueOf(0L), nodeList.get(3).getId());
+		Assertions.assertEquals(Long.valueOf(0L), nodeList.get(0).getId());
+		Assertions.assertEquals(Long.valueOf(1L), nodeList.get(1).getId());
+		Assertions.assertEquals(Long.valueOf(0L), nodeList.get(2).getId());
+		Assertions.assertEquals(Long.valueOf(0L), nodeList.get(3).getId());
 
-		Assert.assertEquals(Integer.valueOf(0), nodeList.get(0).getParentId());
-		Assert.assertEquals(Integer.valueOf(1), nodeList.get(1).getParentId());
-		Assert.assertEquals(Integer.valueOf(0), nodeList.get(2).getParentId());
-		Assert.assertEquals(Integer.valueOf(0), nodeList.get(3).getParentId());
+		Assertions.assertEquals(Integer.valueOf(0), nodeList.get(0).getParentId());
+		Assertions.assertEquals(Integer.valueOf(1), nodeList.get(1).getParentId());
+		Assertions.assertEquals(Integer.valueOf(0), nodeList.get(2).getParentId());
+		Assertions.assertEquals(Integer.valueOf(0), nodeList.get(3).getParentId());
 
-		Assert.assertEquals("0", nodeList.get(0).getName());
-		Assert.assertEquals("1", nodeList.get(1).getName());
-		Assert.assertEquals("+0", nodeList.get(2).getName());
-		Assert.assertEquals("-0", nodeList.get(3).getName());
+		Assertions.assertEquals("0", nodeList.get(0).getName());
+		Assertions.assertEquals("1", nodeList.get(1).getName());
+		Assertions.assertEquals("+0", nodeList.get(2).getName());
+		Assertions.assertEquals("-0", nodeList.get(3).getName());
 	}
 
 	@Test
 	public void getByPathTest(){
 		String jsonStr = "[{\"id\": \"1\",\"name\": \"a\"},{\"id\": \"2\",\"name\": \"b\"}]";
 		final JSONArray jsonArray = JSONUtil.parseArray(jsonStr);
-		Assert.assertEquals("b", jsonArray.getByPath("[1].name"));
-		Assert.assertEquals("b", JSONUtil.getByPath(jsonArray, "[1].name"));
+		Assertions.assertEquals("b", jsonArray.getByPath("[1].name"));
+		Assertions.assertEquals("b", JSONUtil.getByPath(jsonArray, "[1].name"));
 	}
 
 	@Test
@@ -214,7 +218,7 @@ public class JSONArrayTest {
 		final JSONArray jsonArray = new JSONArray();
 		jsonArray.put(3, "test");
 		// 第三个位置插入值，0~2都是null
-		Assert.assertEquals(4, jsonArray.size());
+		Assertions.assertEquals(4, jsonArray.size());
 	}
 
 	// https://github.com/dromara/hutool/issues/1858
@@ -222,8 +226,8 @@ public class JSONArrayTest {
 	public void putTest2(){
 		final JSONArray jsonArray = new JSONArray();
 		jsonArray.put(0, 1);
-		Assert.assertEquals(1, jsonArray.size());
-		Assert.assertEquals(1, jsonArray.get(0));
+		Assertions.assertEquals(1, jsonArray.size());
+		Assertions.assertEquals(1, jsonArray.get(0));
 	}
 
 	private static Map<String, String> buildMap(String id, String parentId, String name) {
@@ -249,7 +253,7 @@ public class JSONArrayTest {
 				.set(true);
 
 		final String s = json1.toJSONString(0, (pair) -> pair.getValue().equals("value2"));
-		Assert.assertEquals("[\"value2\"]", s);
+		Assertions.assertEquals("[\"value2\"]", s);
 	}
 
 	@Test
@@ -261,7 +265,7 @@ public class JSONArrayTest {
 				.set(true);
 
 		final String s = json1.toJSONString(0, (pair) -> false == pair.getValue().equals("value2"));
-		Assert.assertEquals("[\"value1\",\"value3\",true]", s);
+		Assertions.assertEquals("[\"value1\",\"value3\",true]", s);
 	}
 
 	@Test
@@ -269,6 +273,6 @@ public class JSONArrayTest {
 		final JSONArray array = JSONUtil.createArray(JSONConfig.create().setIgnoreNullValue(false));
 		array.set(null);
 
-		Assert.assertEquals("[null]", array.toString());
+		Assertions.assertEquals("[null]", array.toString());
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/JSONBeanParserTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONBeanParserTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JSONBeanParserTest {
 
@@ -10,9 +10,9 @@ public class JSONBeanParserTest {
 	public void parseTest(){
 		String jsonStr = "{\"customName\": \"customValue\", \"customAddress\": \"customAddressValue\"}";
 		final TestBean testBean = JSONUtil.toBean(jsonStr, TestBean.class);
-		Assert.assertNotNull(testBean);
-		Assert.assertEquals("customValue", testBean.getName());
-		Assert.assertEquals("customAddressValue", testBean.getAddress());
+		Assertions.assertNotNull(testBean);
+		Assertions.assertEquals("customValue", testBean.getName());
+		Assertions.assertEquals("customAddressValue", testBean.getAddress());
 	}
 
 	@Data

--- a/hutool-json/src/test/java/cn/hutool/json/JSONConvertTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONConvertTest.java
@@ -4,8 +4,8 @@ import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.json.test.bean.ExamInfoDict;
 import cn.hutool.json.test.bean.PerfectEvaluationProductResVo;
 import cn.hutool.json.test.bean.UserInfoDict;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,7 +14,7 @@ import java.util.Map;
 
 /**
  * JSON转换单元测试
- * 
+ *
  * @author Looly，质量过关
  *
  */
@@ -55,14 +55,14 @@ public class JSONConvertTest {
 		tempMap.put("toSendManIdCard", 1);
 
 		JSONObject obj = JSONUtil.parseObj(tempMap);
-		Assert.assertEquals(new Integer(1), obj.getInt("toSendManIdCard"));
+		Assertions.assertEquals(new Integer(1), obj.getInt("toSendManIdCard"));
 
 		JSONObject examInfoDictsJson = obj.getJSONObject("userInfoDict");
-		Assert.assertEquals(new Integer(1), examInfoDictsJson.getInt("id"));
-		Assert.assertEquals("质量过关", examInfoDictsJson.getStr("realName"));
-		
+		Assertions.assertEquals(new Integer(1), examInfoDictsJson.getInt("id"));
+		Assertions.assertEquals("质量过关", examInfoDictsJson.getStr("realName"));
+
 		Object id = JSONUtil.getByPath(obj, "userInfoDict.examInfoDict[0].id");
-		Assert.assertEquals(1, id);
+		Assertions.assertEquals(1, id);
 	}
 
 	@Test
@@ -76,18 +76,18 @@ public class JSONConvertTest {
 
 		JSONObject jsonObject = JSONUtil.parseObj(examJson).getJSONObject("examInfoDicts");
 		UserInfoDict userInfoDict = jsonObject.toBean(UserInfoDict.class);
-		
-		Assert.assertEquals(userInfoDict.getId(), new Integer(1));
-		Assert.assertEquals(userInfoDict.getRealName(), "质量过关");
+
+		Assertions.assertEquals(userInfoDict.getId(), new Integer(1));
+		Assertions.assertEquals(userInfoDict.getRealName(), "质量过关");
 
 		//============
 
 		String jsonStr = "{\"id\":null,\"examInfoDict\":[{\"answerIs\":1, \"id\":null}]}";//JSONUtil.toJsonStr(userInfoDict1);
 		JSONObject jsonObject2 = JSONUtil.parseObj(jsonStr);//.getJSONObject("examInfoDicts");
 		UserInfoDict userInfoDict2 = jsonObject2.toBean(UserInfoDict.class);
-		Assert.assertNull(userInfoDict2.getId());
+		Assertions.assertNull(userInfoDict2.getId());
 	}
-	
+
 	/**
 	 * 针对Bean中Setter返回this测试是否可以成功调用Setter方法并注入
 	 */
@@ -96,8 +96,8 @@ public class JSONConvertTest {
 		String jsonStr = ResourceUtil.readUtf8Str("evaluation.json");
 		JSONObject obj = JSONUtil.parseObj(jsonStr);
 		PerfectEvaluationProductResVo vo = obj.toBean(PerfectEvaluationProductResVo.class);
-		
-		Assert.assertEquals(obj.getStr("HA001"), vo.getHA001());
-		Assert.assertEquals(obj.getInt("costTotal"), vo.getCostTotal());
+
+		Assertions.assertEquals(obj.getStr("HA001"), vo.getHA001());
+		Assertions.assertEquals(obj.getInt("costTotal"), vo.getCostTotal());
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/JSONNullTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONNullTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.json;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JSONNullTest {
 
@@ -12,12 +12,12 @@ public class JSONNullTest {
 				"            \"device_status_date\": null,\n" +
 				"            \"imsi\": null,\n" +
 				"            \"act_date\": \"2021-07-23T06:23:26.000+00:00\"}");
-		Assert.assertEquals(JSONNull.class, bodyjson.get("device_model").getClass());
-		Assert.assertEquals(JSONNull.class, bodyjson.get("device_status_date").getClass());
-		Assert.assertEquals(JSONNull.class, bodyjson.get("imsi").getClass());
+		Assertions.assertEquals(JSONNull.class, bodyjson.get("device_model").getClass());
+		Assertions.assertEquals(JSONNull.class, bodyjson.get("device_status_date").getClass());
+		Assertions.assertEquals(JSONNull.class, bodyjson.get("imsi").getClass());
 
 		bodyjson.getConfig().setIgnoreNullValue(true);
-		Assert.assertEquals("{\"act_date\":\"2021-07-23T06:23:26.000+00:00\"}", bodyjson.toString());
+		Assertions.assertEquals("{\"act_date\":\"2021-07-23T06:23:26.000+00:00\"}", bodyjson.toString());
 	}
 
 	@Test
@@ -27,8 +27,8 @@ public class JSONNullTest {
 				"            \"device_status_date\": null,\n" +
 				"            \"imsi\": null,\n" +
 				"            \"act_date\": \"2021-07-23T06:23:26.000+00:00\"}", true, true);
-		Assert.assertFalse(bodyjson.containsKey("device_model"));
-		Assert.assertFalse(bodyjson.containsKey("device_status_date"));
-		Assert.assertFalse(bodyjson.containsKey("imsi"));
+		Assertions.assertFalse(bodyjson.containsKey("device_model"));
+		Assertions.assertFalse(bodyjson.containsKey("device_status_date"));
+		Assertions.assertFalse(bodyjson.containsKey("imsi"));
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/JSONObjectTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONObjectTest.java
@@ -24,9 +24,9 @@ import cn.hutool.json.test.bean.report.CaseReport;
 import cn.hutool.json.test.bean.report.StepReport;
 import cn.hutool.json.test.bean.report.SuiteReport;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -45,7 +45,7 @@ import java.util.Set;
 public class JSONObjectTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void toStringTest() {
 		String str = "{\"code\": 500, \"data\":null}";
 		JSONObject jsonObject = new JSONObject(str);
@@ -59,7 +59,7 @@ public class JSONObjectTest {
 		String str = "{\"test\":\"关于开展2018年度“文明集体”、“文明职工”评选表彰活动的通知\"}";
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		JSONObject json = new JSONObject(str);
-		Assert.assertEquals(str, json.toString());
+		Assertions.assertEquals(str, json.toString());
 	}
 
 	/**
@@ -70,17 +70,17 @@ public class JSONObjectTest {
 		JSONObject json = Objects.requireNonNull(JSONUtil.createObj()//
 						.set("dateTime", DateUtil.parse("2019-05-02 22:12:01")))//
 				.setDateFormat(DatePattern.NORM_DATE_PATTERN);
-		Assert.assertEquals("{\"dateTime\":\"2019-05-02\"}", json.toString());
+		Assertions.assertEquals("{\"dateTime\":\"2019-05-02\"}", json.toString());
 	}
 
 	@Test
 	public void toStringWithDateTest() {
 		JSONObject json = JSONUtil.createObj().set("date", DateUtil.parse("2019-05-08 19:18:21"));
 		assert json != null;
-		Assert.assertEquals("{\"date\":1557314301000}", json.toString());
+		Assertions.assertEquals("{\"date\":1557314301000}", json.toString());
 
 		json = Objects.requireNonNull(JSONUtil.createObj().set("date", DateUtil.parse("2019-05-08 19:18:21"))).setDateFormat(DatePattern.NORM_DATE_PATTERN);
-		Assert.assertEquals("{\"date\":\"2019-05-08\"}", json.toString());
+		Assertions.assertEquals("{\"date\":\"2019-05-08\"}", json.toString());
 	}
 
 
@@ -99,22 +99,22 @@ public class JSONObjectTest {
 		// putAll操作会覆盖相同key的值，因此a,b两个key的值改变，c的值不变
 		json1.putAll(json2);
 
-		Assert.assertEquals(json1.get("a"), "value21");
-		Assert.assertEquals(json1.get("b"), "value22");
-		Assert.assertEquals(json1.get("c"), "value3");
+		Assertions.assertEquals(json1.get("a"), "value21");
+		Assertions.assertEquals(json1.get("b"), "value22");
+		Assertions.assertEquals(json1.get("c"), "value3");
 	}
 
 	@Test
 	public void parseStringTest() {
 		String jsonStr = "{\"b\":\"value2\",\"c\":\"value3\",\"a\":\"value1\", \"d\": true, \"e\": null}";
 		JSONObject jsonObject = JSONUtil.parseObj(jsonStr);
-		Assert.assertEquals(jsonObject.get("a"), "value1");
-		Assert.assertEquals(jsonObject.get("b"), "value2");
-		Assert.assertEquals(jsonObject.get("c"), "value3");
-		Assert.assertEquals(jsonObject.get("d"), true);
+		Assertions.assertEquals(jsonObject.get("a"), "value1");
+		Assertions.assertEquals(jsonObject.get("b"), "value2");
+		Assertions.assertEquals(jsonObject.get("c"), "value3");
+		Assertions.assertEquals(jsonObject.get("d"), true);
 
-		Assert.assertTrue(jsonObject.containsKey("e"));
-		Assert.assertEquals(jsonObject.get("e"), JSONNull.NULL);
+		Assertions.assertTrue(jsonObject.containsKey("e"));
+		Assertions.assertEquals(jsonObject.get("e"), JSONNull.NULL);
 	}
 
 	@Test
@@ -122,8 +122,8 @@ public class JSONObjectTest {
 		String jsonStr = "{\"file_name\":\"RMM20180127009_731.000\",\"error_data\":\"201121151350701001252500000032 18973908335 18973908335 13601893517 201711211700152017112115135420171121 6594000000010100000000000000000000000043190101701001910072 100001100 \",\"error_code\":\"F140\",\"error_info\":\"最早发送时间格式错误，该字段可以为空，当不为空时正确填写格式为“YYYYMMDDHHMISS”\",\"app_name\":\"inter-pre-check\"}";
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		JSONObject json = new JSONObject(jsonStr);
-		Assert.assertEquals("F140", json.getStr("error_code"));
-		Assert.assertEquals("最早发送时间格式错误，该字段可以为空，当不为空时正确填写格式为“YYYYMMDDHHMISS”", json.getStr("error_info"));
+		Assertions.assertEquals("F140", json.getStr("error_code"));
+		Assertions.assertEquals("最早发送时间格式错误，该字段可以为空，当不为空时正确填写格式为“YYYYMMDDHHMISS”", json.getStr("error_info"));
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public class JSONObjectTest {
 		String jsonStr = "{\"test\":\"体”、“文\"}";
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		JSONObject json = new JSONObject(jsonStr);
-		Assert.assertEquals("体”、“文", json.getStr("test"));
+		Assertions.assertEquals("体”、“文", json.getStr("test"));
 	}
 
 	@Test
@@ -139,12 +139,12 @@ public class JSONObjectTest {
 		String jsonStr = "{'msg':'这里还没有内容','data':{'cards':[]},'ok':0}";
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		JSONObject json = new JSONObject(jsonStr);
-		Assert.assertEquals(new Integer(0), json.getInt("ok"));
-		Assert.assertEquals(new JSONArray(), json.getJSONObject("data").getJSONArray("cards"));
+		Assertions.assertEquals(new Integer(0), json.getInt("ok"));
+		Assertions.assertEquals(new JSONArray(), json.getJSONObject("data").getJSONArray("cards"));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void parseStringWithBomTest() {
 		String jsonStr = FileUtil.readUtf8String("f:/test/jsontest.txt");
 		JSONObject json = new JSONObject(jsonStr);
@@ -159,8 +159,8 @@ public class JSONObjectTest {
 		String jsonStr = "{\"a\":\"<div>aaa</div>\"}";
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		JSONObject json = new JSONObject(jsonStr);
-		Assert.assertEquals("<div>aaa</div>", json.get("a"));
-		Assert.assertEquals(jsonStr, json.toString());
+		Assertions.assertEquals("<div>aaa</div>", json.get("a"));
+		Assertions.assertEquals(jsonStr, json.toString());
 	}
 
 	@Test
@@ -173,14 +173,14 @@ public class JSONObjectTest {
 				.set("list", JSONUtil.createArray().set("a").set("b")).set("testEnum", "TYPE_A");
 
 		TestBean bean = json.toBean(TestBean.class);
-		Assert.assertEquals("a", bean.getList().get(0));
-		Assert.assertEquals("b", bean.getList().get(1));
+		Assertions.assertEquals("a", bean.getList().get(0));
+		Assertions.assertEquals("b", bean.getList().get(1));
 
-		Assert.assertEquals("strValue1", bean.getBeanValue().getValue1());
+		Assertions.assertEquals("strValue1", bean.getBeanValue().getValue1());
 		// BigDecimal转换检查
-		Assert.assertEquals(new BigDecimal("234"), bean.getBeanValue().getValue2());
+		Assertions.assertEquals(new BigDecimal("234"), bean.getBeanValue().getValue2());
 		// 枚举转换检查
-		Assert.assertEquals(TestEnum.TYPE_A, bean.getTestEnum());
+		Assertions.assertEquals(TestEnum.TYPE_A, bean.getTestEnum());
 	}
 
 	@Test
@@ -193,9 +193,9 @@ public class JSONObjectTest {
 
 		TestBean bean = json.toBean(TestBean.class);
 		// 当JSON中为字符串"null"时应被当作字符串处理
-		Assert.assertEquals("null", bean.getStrValue());
+		Assertions.assertEquals("null", bean.getStrValue());
 		// 当JSON中为字符串"null"时Bean中的字段类型不匹配应在ignoreError模式下忽略注入
-		Assert.assertNull(bean.getBeanValue());
+		Assertions.assertNull(bean.getBeanValue());
 	}
 
 	@Test
@@ -209,16 +209,16 @@ public class JSONObjectTest {
 		JSONObject json = JSONUtil.parseObj(userA);
 		UserA userA2 = json.toBean(UserA.class);
 		// 测试数组
-		Assert.assertEquals("seq1", userA2.getSqs().get(0).getSeq());
+		Assertions.assertEquals("seq1", userA2.getSqs().get(0).getSeq());
 		// 测试带换行符等特殊字符转换是否成功
-		Assert.assertTrue(StrUtil.isNotBlank(userA2.getName()));
+		Assertions.assertTrue(StrUtil.isNotBlank(userA2.getName()));
 	}
 
 	@Test
 	public void toBeanWithNullTest() {
 		String jsonStr = "{'data':{'userName':'ak','password': null}}";
 		UserWithMap user = JSONUtil.toBean(JSONUtil.parseObj(jsonStr), UserWithMap.class);
-		Assert.assertTrue(user.getData().containsKey("password"));
+		Assertions.assertTrue(user.getData().containsKey("password"));
 	}
 
 	@Test
@@ -226,7 +226,7 @@ public class JSONObjectTest {
 		String json = "{\"data\":{\"b\": \"c\"}}";
 
 		UserWithMap map = JSONUtil.toBean(json, UserWithMap.class);
-		Assert.assertEquals("c", map.getData().get("b"));
+		Assertions.assertEquals("c", map.getData().get("b"));
 	}
 
 	@Test
@@ -238,12 +238,12 @@ public class JSONObjectTest {
 		// 第一层
 		List<CaseReport> caseReports = bean.getCaseReports();
 		CaseReport caseReport = caseReports.get(0);
-		Assert.assertNotNull(caseReport);
+		Assertions.assertNotNull(caseReport);
 
 		// 第二层
 		List<StepReport> stepReports = caseReports.get(0).getStepReports();
 		StepReport stepReport = stepReports.get(0);
-		Assert.assertNotNull(stepReport);
+		Assertions.assertNotNull(stepReport);
 	}
 
 	/**
@@ -259,13 +259,13 @@ public class JSONObjectTest {
 						.set("userId", "测试用户1"));
 
 		TokenAuthWarp2 bean = json.toBean(TokenAuthWarp2.class);
-		Assert.assertEquals("http://test.com", bean.getTargetUrl());
-		Assert.assertEquals("true", bean.getSuccess());
+		Assertions.assertEquals("http://test.com", bean.getTargetUrl());
+		Assertions.assertEquals("true", bean.getSuccess());
 
 		TokenAuthResponse result = bean.getResult();
-		Assert.assertNotNull(result);
-		Assert.assertEquals("tokenTest", result.getToken());
-		Assert.assertEquals("测试用户1", result.getUserId());
+		Assertions.assertNotNull(result);
+		Assertions.assertEquals("tokenTest", result.getToken());
+		Assertions.assertEquals("测试用户1", result.getUserId());
 	}
 
 	/**
@@ -278,7 +278,7 @@ public class JSONObjectTest {
 				"\"secret\":\"dsadadqwdqs121d1e2\",\"message\":\"hello world\"},\"code\":100,\"" +
 				"message\":\"validate message\"}";
 		ResultDto<?> dto = JSONUtil.toBean(jsonStr, ResultDto.class);
-		Assert.assertEquals("validate message", dto.getMessage());
+		Assertions.assertEquals("validate message", dto.getMessage());
 	}
 
 	@Test
@@ -290,8 +290,8 @@ public class JSONObjectTest {
 
 		JSONObject json = JSONUtil.parseObj(userA, false, true);
 
-		Assert.assertTrue(json.containsKey("a"));
-		Assert.assertTrue(json.getJSONArray("sqs").getJSONObject(0).containsKey("seq"));
+		Assertions.assertTrue(json.containsKey("a"));
+		Assertions.assertTrue(json.getJSONArray("sqs").getJSONObject(0).containsKey("seq"));
 	}
 
 	@Test
@@ -305,10 +305,10 @@ public class JSONObjectTest {
 
 		JSONObject json = JSONUtil.parseObj(bean, false);
 		// 枚举转换检查
-		Assert.assertEquals("TYPE_B", json.get("testEnum"));
+		Assertions.assertEquals("TYPE_B", json.get("testEnum"));
 
 		TestBean bean2 = json.toBean(TestBean.class);
-		Assert.assertEquals(bean.toString(), bean2.toString());
+		Assertions.assertEquals(bean.toString(), bean2.toString());
 	}
 
 	@Test
@@ -318,9 +318,9 @@ public class JSONObjectTest {
 				.set("data", "{\"jobId\": \"abc\", \"videoUrl\": \"http://a.com/a.mp4\"}");
 
 		JSONBean bean = json.toBean(JSONBean.class);
-		Assert.assertEquals(22, bean.getCode());
-		Assert.assertEquals("abc", bean.getData().getObj("jobId"));
-		Assert.assertEquals("http://a.com/a.mp4", bean.getData().getObj("videoUrl"));
+		Assertions.assertEquals(22, bean.getCode());
+		Assertions.assertEquals("abc", bean.getData().getObj("jobId"));
+		Assertions.assertEquals("http://a.com/a.mp4", bean.getData().getObj("videoUrl"));
 	}
 
 	@Test
@@ -333,8 +333,8 @@ public class JSONObjectTest {
 		JSONObject userAJson = JSONUtil.parseObj(userA);
 		UserB userB = JSONUtil.toBean(userAJson, UserB.class);
 
-		Assert.assertEquals(userA.getName(), userB.getName());
-		Assert.assertEquals(userA.getDate(), userB.getDate());
+		Assertions.assertEquals(userA.getName(), userB.getName());
+		Assertions.assertEquals(userA.getDate(), userB.getDate());
 	}
 
 	@Test
@@ -349,7 +349,7 @@ public class JSONObjectTest {
 		userAJson.setDateFormat("yyyy-MM-dd");
 
 		UserA bean = JSONUtil.toBean(userAJson.toString(), UserA.class);
-		Assert.assertEquals(DateUtil.parse("2018-10-25"), bean.getDate());
+		Assertions.assertEquals(DateUtil.parse("2018-10-25"), bean.getDate());
 	}
 
 	@Test
@@ -359,7 +359,7 @@ public class JSONObjectTest {
 				.set("name", "nameValue")
 				.set("date", "08:00:00");
 		UserA bean = JSONUtil.toBean(userAJson.toString(), UserA.class);
-		Assert.assertEquals(DateUtil.today() + " 08:00:00", DateUtil.date(bean.getDate()).toString());
+		Assertions.assertEquals(DateUtil.today() + " 08:00:00", DateUtil.date(bean.getDate()).toString());
 	}
 
 	@Test
@@ -370,19 +370,19 @@ public class JSONObjectTest {
 		userA.setDate(new Date());
 
 		JSONObject userAJson = JSONUtil.parseObj(userA);
-		Assert.assertFalse(userAJson.containsKey("a"));
+		Assertions.assertFalse(userAJson.containsKey("a"));
 
 		JSONObject userAJsonWithNullValue = JSONUtil.parseObj(userA, false);
-		Assert.assertTrue(userAJsonWithNullValue.containsKey("a"));
-		Assert.assertTrue(userAJsonWithNullValue.containsKey("sqs"));
+		Assertions.assertTrue(userAJsonWithNullValue.containsKey("a"));
+		Assertions.assertTrue(userAJsonWithNullValue.containsKey("sqs"));
 	}
 
 	@Test
 	public void specialCharTest() {
 		String json = "{\"pattern\": \"[abc]\b\u2001\", \"pattern2Json\": {\"patternText\": \"[ab]\\b\"}}";
 		JSONObject obj = JSONUtil.parseObj(json);
-		Assert.assertEquals("[abc]\\b\\u2001", obj.getStrEscaped("pattern"));
-		Assert.assertEquals("{\"patternText\":\"[ab]\\b\"}", obj.getStrEscaped("pattern2Json"));
+		Assertions.assertEquals("[abc]\\b\\u2001", obj.getStrEscaped("pattern"));
+		Assertions.assertEquals("{\"patternText\":\"[ab]\\b\"}", obj.getStrEscaped("pattern2Json"));
 	}
 
 	@Test
@@ -391,12 +391,12 @@ public class JSONObjectTest {
 		JSONObject jsonObject = JSONUtil.parseObj(json);
 
 		// 没有转义按照默认规则显示
-		Assert.assertEquals("yyb\nbbb", jsonObject.getStr("name"));
+		Assertions.assertEquals("yyb\nbbb", jsonObject.getStr("name"));
 		// 转义按照字符串显示
-		Assert.assertEquals("yyb\\nbbb", jsonObject.getStrEscaped("name"));
+		Assertions.assertEquals("yyb\\nbbb", jsonObject.getStrEscaped("name"));
 
 		String bbb = jsonObject.getStr("bbb", "defaultBBB");
-		Assert.assertEquals("defaultBBB", bbb);
+		Assertions.assertEquals("defaultBBB", bbb);
 	}
 
 	@Test
@@ -406,15 +406,15 @@ public class JSONObjectTest {
 		beanWithAlias.setValue2(35);
 
 		final JSONObject jsonObject = JSONUtil.parseObj(beanWithAlias);
-		Assert.assertEquals("张三", jsonObject.getStr("name"));
-		Assert.assertEquals(new Integer(35), jsonObject.getInt("age"));
+		Assertions.assertEquals("张三", jsonObject.getStr("name"));
+		Assertions.assertEquals(new Integer(35), jsonObject.getInt("age"));
 
 		JSONObject json = JSONUtil.createObj()
 				.set("name", "张三")
 				.set("age", 35);
 		final BeanWithAlias bean = JSONUtil.toBean(Objects.requireNonNull(json).toString(), BeanWithAlias.class);
-		Assert.assertEquals("张三", bean.getValue1());
-		Assert.assertEquals(new Integer(35), bean.getValue2());
+		Assertions.assertEquals("张三", bean.getValue1());
+		Assertions.assertEquals(new Integer(35), bean.getValue2());
 	}
 
 	@Test
@@ -427,7 +427,7 @@ public class JSONObjectTest {
 		json.append("date", DateUtil.parse("2020-06-05 11:16:11"));
 		json.append("bbb", "222");
 		json.append("aaa", "123");
-		Assert.assertEquals("{\"date\":[\"2020-06-05 11:16:11\"],\"bbb\":[\"222\"],\"aaa\":[\"123\"]}", json.toString());
+		Assertions.assertEquals("{\"date\":[\"2020-06-05 11:16:11\"],\"bbb\":[\"222\"],\"aaa\":[\"123\"]}", json.toString());
 	}
 
 	@Test
@@ -444,11 +444,11 @@ public class JSONObjectTest {
 
 		String jsonStr = "{\"date\":\"2020#06#05\",\"bbb\":\"222\",\"aaa\":\"123\"}";
 
-		Assert.assertEquals(jsonStr, json.toString());
+		Assertions.assertEquals(jsonStr, json.toString());
 
 		// 解析测试
 		final JSONObject parse = JSONUtil.parseObj(jsonStr, jsonConfig);
-		Assert.assertEquals(DateUtil.beginOfDay(date), parse.getDate("date"));
+		Assertions.assertEquals(DateUtil.beginOfDay(date), parse.getDate("date"));
 	}
 
 	@Test
@@ -465,11 +465,11 @@ public class JSONObjectTest {
 
 		String jsonStr = "{\"date\":1591326971,\"bbb\":\"222\",\"aaa\":\"123\"}";
 
-		Assert.assertEquals(jsonStr, json.toString());
+		Assertions.assertEquals(jsonStr, json.toString());
 
 		// 解析测试
 		final JSONObject parse = JSONUtil.parseObj(jsonStr, jsonConfig);
-		Assert.assertEquals(date, parse.getDate("date"));
+		Assertions.assertEquals(date, parse.getDate("date"));
 	}
 
 	@Test
@@ -477,7 +477,7 @@ public class JSONObjectTest {
 		String timeStr = "1970-01-01 00:00:00";
 		final JSONObject jsonObject = JSONUtil.createObj().set("time", timeStr);
 		final Timestamp time = jsonObject.get("time", Timestamp.class);
-		Assert.assertEquals("1970-01-01 00:00:00.0", time.toString());
+		Assertions.assertEquals("1970-01-01 00:00:00.0", time.toString());
 	}
 
 	public enum TestEnum {
@@ -522,11 +522,11 @@ public class JSONObjectTest {
 	public void parseBeanSameNameTest() {
 		final SameNameBean sameNameBean = new SameNameBean();
 		final JSONObject parse = JSONUtil.parseObj(sameNameBean);
-		Assert.assertEquals("123", parse.getStr("username"));
-		Assert.assertEquals("abc", parse.getStr("userName"));
+		Assertions.assertEquals("123", parse.getStr("username"));
+		Assertions.assertEquals("abc", parse.getStr("userName"));
 
 		// 测试ignore注解是否有效
-		Assert.assertNull(parse.getStr("fieldToIgnore"));
+		Assertions.assertNull(parse.getStr("fieldToIgnore"));
 	}
 
 	/**
@@ -562,13 +562,15 @@ public class JSONObjectTest {
 		final Map.Entry<String, String> next = entries.iterator().next();
 
 		final JSONObject jsonObject = JSONUtil.parseObj(next);
-		Assert.assertEquals("{\"test\":\"testValue\"}", jsonObject.toString());
+		Assertions.assertEquals("{\"test\":\"testValue\"}", jsonObject.toString());
 	}
 
-	@Test(expected = JSONException.class)
+	@Test
 	public void createJSONObjectTest() {
-		// 集合类不支持转为JSONObject
-		new JSONObject(new JSONArray(), JSONConfig.create());
+		Assertions.assertThrows(JSONException.class, () -> {
+			// 集合类不支持转为JSONObject
+			new JSONObject(new JSONArray(), JSONConfig.create());
+		});
 	}
 
 	@Test
@@ -577,26 +579,26 @@ public class JSONObjectTest {
 		map.put("c", 2.0F);
 
 		final String s = JSONUtil.toJsonStr(map);
-		Assert.assertEquals("{\"c\":2}", s);
+		Assertions.assertEquals("{\"c\":2}", s);
 	}
 
 	@Test
 	public void accumulateTest() {
 		final JSONObject jsonObject = JSONUtil.createObj().accumulate("key1", "value1");
-		Assert.assertEquals("{\"key1\":\"value1\"}", jsonObject.toString());
+		Assertions.assertEquals("{\"key1\":\"value1\"}", jsonObject.toString());
 
 		jsonObject.accumulate("key1", "value2");
-		Assert.assertEquals("{\"key1\":[\"value1\",\"value2\"]}", jsonObject.toString());
+		Assertions.assertEquals("{\"key1\":[\"value1\",\"value2\"]}", jsonObject.toString());
 
 		jsonObject.accumulate("key1", "value3");
-		Assert.assertEquals("{\"key1\":[\"value1\",\"value2\",\"value3\"]}", jsonObject.toString());
+		Assertions.assertEquals("{\"key1\":[\"value1\",\"value2\",\"value3\"]}", jsonObject.toString());
 	}
 
 	@Test
 	public void putByPathTest() {
 		JSONObject json = new JSONObject();
 		json.putByPath("aa.bb", "BB");
-		Assert.assertEquals("{\"aa\":{\"bb\":\"BB\"}}", json.toString());
+		Assertions.assertEquals("{\"aa\":{\"bb\":\"BB\"}}", json.toString());
 	}
 
 
@@ -604,7 +606,7 @@ public class JSONObjectTest {
 	public void bigDecimalTest() {
 		String jsonStr = "{\"orderId\":\"1704747698891333662002277\"}";
 		BigDecimalBean bigDecimalBean = JSONUtil.toBean(jsonStr, BigDecimalBean.class);
-		Assert.assertEquals("{\"orderId\":1704747698891333662002277}", JSONUtil.toJsonStr(bigDecimalBean));
+		Assertions.assertEquals("{\"orderId\":1704747698891333662002277}", JSONUtil.toJsonStr(bigDecimalBean));
 	}
 
 	@Data
@@ -622,7 +624,7 @@ public class JSONObjectTest {
 				.set("d", true);
 
 		final String s = json1.toJSONString(0, (pair) -> pair.getKey().equals("b"));
-		Assert.assertEquals("{\"b\":\"value2\"}", s);
+		Assertions.assertEquals("{\"b\":\"value2\"}", s);
 	}
 
 	@Test
@@ -634,7 +636,7 @@ public class JSONObjectTest {
 				.set("d", true);
 
 		final String s = json1.toJSONString(0, (pair) -> false == pair.getKey().equals("b"));
-		Assert.assertEquals("{\"a\":\"value1\",\"c\":\"value3\",\"d\":true}", s);
+		Assertions.assertEquals("{\"a\":\"value1\",\"c\":\"value3\",\"d\":true}", s);
 	}
 
 	@Test
@@ -654,7 +656,7 @@ public class JSONObjectTest {
 			// 除了"b"，其他都去掉
 			return false;
 		});
-		Assert.assertEquals("{\"b\":\"value2_edit\"}", s);
+		Assertions.assertEquals("{\"b\":\"value2_edit\"}", s);
 	}
 
 	@Test
@@ -667,6 +669,6 @@ public class JSONObjectTest {
 			pair.setValue(ObjectUtil.defaultIfNull(pair.getValue(), StrUtil.EMPTY));
 			return true;
 		});
-		Assert.assertEquals("{\"a\":\"\",\"b\":\"value2\"}", s);
+		Assertions.assertEquals("{\"a\":\"\",\"b\":\"value2\"}", s);
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/JSONPathTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONPathTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.json;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * JSON路径单元测试
@@ -15,9 +15,9 @@ public class JSONPathTest {
 	public void getByPathTest() {
 		String json = "[{\"id\":\"1\",\"name\":\"xingming\"},{\"id\":\"2\",\"name\":\"mingzi\"}]";
 		Object value = JSONUtil.parseArray(json).getByPath("[0].name");
-		Assert.assertEquals("xingming", value);
+		Assertions.assertEquals("xingming", value);
 		value = JSONUtil.parseArray(json).getByPath("[1].name");
-		Assert.assertEquals("mingzi", value);
+		Assertions.assertEquals("mingzi", value);
 	}
 
 	@Test
@@ -25,6 +25,6 @@ public class JSONPathTest {
 		String str = "{'accountId':111}";
 		JSON json = JSONUtil.parse(str);
 		Long accountId = JSONUtil.getByPath(json, "$.accountId", 0L);
-		Assert.assertEquals(111L, accountId.longValue());
+		Assertions.assertEquals(111L, accountId.longValue());
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/JSONStrFormatterTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONStrFormatterTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * JSON字符串格式化单元测试
@@ -15,21 +15,21 @@ public class JSONStrFormatterTest {
 	public void formatTest() {
 		String json = "{'age':23,'aihao':['pashan','movies'],'name':{'firstName':'zhang','lastName':'san','aihao':['pashan','movies','name':{'firstName':'zhang','lastName':'san','aihao':['pashan','movies']}]}}";
 		String result = JSONStrFormatter.format(json);
-		Assert.assertNotNull(result);
+		Assertions.assertNotNull(result);
 	}
 
 	@Test
 	public void formatTest2() {
 		String json = "{\"abc\":{\"def\":\"\\\"[ghi]\"}}";
 		String result = JSONStrFormatter.format(json);
-		Assert.assertNotNull(result);
+		Assertions.assertNotNull(result);
 	}
 
 	@Test
 	public void formatTest3() {
 		String json = "{\"id\":13,\"title\":\"《标题》\",\"subtitle\":\"副标题z'c'z'xv'c'xv\",\"user_id\":6,\"type\":0}";
 		String result = JSONStrFormatter.format(json);
-		Assert.assertNotNull(result);
+		Assertions.assertNotNull(result);
 	}
 
 	@Test

--- a/hutool-json/src/test/java/cn/hutool/json/JSONSupportTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONSupportTest.java
@@ -2,8 +2,8 @@ package cn.hutool.json;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JSONSupportTest {
 
@@ -23,10 +23,10 @@ public class JSONSupportTest {
 
 
 		final TestBean testBean = JSONUtil.toBean(jsonstr, TestBean.class);
-		Assert.assertEquals("https://hutool.cn", testBean.getLocation());
-		Assert.assertEquals("这是一条测试消息", testBean.getMessage());
-		Assert.assertEquals("123456789", testBean.getRequestId());
-		Assert.assertEquals("987654321", testBean.getTraceId());
+		Assertions.assertEquals("https://hutool.cn", testBean.getLocation());
+		Assertions.assertEquals("这是一条测试消息", testBean.getMessage());
+		Assertions.assertEquals("123456789", testBean.getRequestId());
+		Assertions.assertEquals("987654321", testBean.getTraceId());
 	}
 
 	@EqualsAndHashCode(callSuper = true)

--- a/hutool-json/src/test/java/cn/hutool/json/JSONUtilTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/JSONUtilTest.java
@@ -8,8 +8,8 @@ import cn.hutool.core.util.NumberUtil;
 import cn.hutool.json.test.bean.Price;
 import cn.hutool.json.test.bean.UserA;
 import cn.hutool.json.test.bean.UserC;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -23,19 +23,23 @@ public class JSONUtilTest {
 	/**
 	 * 出现语法错误时报错，检查解析\x字符时是否会导致死循环异常
 	 */
-	@Test(expected = JSONException.class)
+	@Test
 	public void parseTest() {
-		JSONArray jsonArray = JSONUtil.parseArray("[{\"a\":\"a\\x]");
-		Console.log(jsonArray);
+		Assertions.assertThrows(JSONException.class, () -> {
+			JSONArray jsonArray = JSONUtil.parseArray("[{\"a\":\"a\\x]");
+			Console.log(jsonArray);
+		});
 	}
 
 	/**
 	 * 数字解析为JSONArray报错
 	 */
-	@Test(expected = JSONException.class)
+	@Test
 	public void parseNumberTest() {
-		JSONArray json = JSONUtil.parseArray(123L);
-		Console.log(json);
+		Assertions.assertThrows(JSONException.class, () -> {
+			JSONArray json = JSONUtil.parseArray(123L);
+			Console.log(json);
+		});
 	}
 
 	/**
@@ -44,7 +48,7 @@ public class JSONUtilTest {
 	@Test
 	public void parseNumberTest2() {
 		JSONObject json = JSONUtil.parseObj(123L);
-		Assert.assertEquals(new JSONObject(), json);
+		Assertions.assertEquals(new JSONObject(), json);
 	}
 
 	@Test
@@ -65,7 +69,7 @@ public class JSONUtilTest {
 
 		String str = JSONUtil.toJsonPrettyStr(map);
 		JSONUtil.parse(str);
-		Assert.assertNotNull(str);
+		Assertions.assertNotNull(str);
 	}
 
 	@Test
@@ -80,10 +84,10 @@ public class JSONUtilTest {
 
 		JSONObject jsonObject = JSONUtil.parseObj(data);
 
-		Assert.assertTrue(jsonObject.containsKey("model"));
-		Assert.assertEquals(1, jsonObject.getJSONObject("model").getInt("type").intValue());
-		Assert.assertEquals("17610836523", jsonObject.getJSONObject("model").getStr("mobile"));
-		// Assert.assertEquals("{\"model\":{\"type\":1,\"mobile\":\"17610836523\"}}", jsonObject.toString());
+		Assertions.assertTrue(jsonObject.containsKey("model"));
+		Assertions.assertEquals(1, jsonObject.getJSONObject("model").getInt("type").intValue());
+		Assertions.assertEquals("17610836523", jsonObject.getJSONObject("model").getStr("mobile"));
+		// Assertions.assertEquals("{\"model\":{\"type\":1,\"mobile\":\"17610836523\"}}", jsonObject.toString());
 	}
 
 	@Test
@@ -98,11 +102,11 @@ public class JSONUtilTest {
 		map.put("user", object.toString());
 
 		JSONObject json = JSONUtil.parseObj(map);
-		Assert.assertEquals("{\"name\":\"123123\",\"value\":\"\\\\\",\"value2\":\"</\"}", json.get("user"));
-		Assert.assertEquals("{\"user\":\"{\\\"name\\\":\\\"123123\\\",\\\"value\\\":\\\"\\\\\\\\\\\",\\\"value2\\\":\\\"</\\\"}\"}", json.toString());
+		Assertions.assertEquals("{\"name\":\"123123\",\"value\":\"\\\\\",\"value2\":\"</\"}", json.get("user"));
+		Assertions.assertEquals("{\"user\":\"{\\\"name\\\":\\\"123123\\\",\\\"value\\\":\\\"\\\\\\\\\\\",\\\"value2\\\":\\\"</\\\"}\"}", json.toString());
 
 		JSONObject json2 = JSONUtil.parseObj(json.toString());
-		Assert.assertEquals("{\"name\":\"123123\",\"value\":\"\\\\\",\"value2\":\"</\"}", json2.get("user"));
+		Assertions.assertEquals("{\"name\":\"123123\",\"value\":\"\\\\\",\"value2\":\"</\"}", json2.get("user"));
 	}
 
 	@Test
@@ -116,7 +120,7 @@ public class JSONUtilTest {
 			put("c", "c");
 		}};
 
-		Assert.assertEquals("{\"attributes\":\"a\",\"b\":\"b\",\"c\":\"c\"}", JSONUtil.toJsonStr(sortedMap));
+		Assertions.assertEquals("{\"attributes\":\"a\",\"b\":\"b\",\"c\":\"c\"}", JSONUtil.toJsonStr(sortedMap));
 	}
 
 	/**
@@ -127,7 +131,7 @@ public class JSONUtilTest {
 		String json = "{\"ADT\":[[{\"BookingCode\":[\"N\",\"N\"]}]]}";
 
 		Price price = JSONUtil.toBean(json, Price.class);
-		Assert.assertEquals("N", price.getADT().get(0).get(0).getBookingCode().get(0));
+		Assertions.assertEquals("N", price.getADT().get(0).get(0).getBookingCode().get(0));
 	}
 
 	@Test
@@ -135,36 +139,36 @@ public class JSONUtilTest {
 		// 测试JSONObject转为Bean中字符串字段的情况
 		String json = "{\"id\":123,\"name\":\"张三\",\"prop\":{\"gender\":\"男\", \"age\":18}}";
 		UserC user = JSONUtil.toBean(json, UserC.class);
-		Assert.assertNotNull(user.getProp());
+		Assertions.assertNotNull(user.getProp());
 		String prop = user.getProp();
 		JSONObject propJson = JSONUtil.parseObj(prop);
-		Assert.assertEquals("男", propJson.getStr("gender"));
-		Assert.assertEquals(18, propJson.getInt("age").intValue());
-		// Assert.assertEquals("{\"age\":18,\"gender\":\"男\"}", user.getProp());
+		Assertions.assertEquals("男", propJson.getStr("gender"));
+		Assertions.assertEquals(18, propJson.getInt("age").intValue());
+		// Assertions.assertEquals("{\"age\":18,\"gender\":\"男\"}", user.getProp());
 	}
 
 	@Test
 	public void getStrTest() {
 		String html = "{\"name\":\"Something must have been changed since you leave\"}";
 		JSONObject jsonObject = JSONUtil.parseObj(html);
-		Assert.assertEquals("Something must have been changed since you leave", jsonObject.getStr("name"));
+		Assertions.assertEquals("Something must have been changed since you leave", jsonObject.getStr("name"));
 	}
 
 	@Test
 	public void getStrTest2() {
 		String html = "{\"name\":\"Something\\u00a0must have been changed since you leave\"}";
 		JSONObject jsonObject = JSONUtil.parseObj(html);
-		Assert.assertEquals("Something\\u00a0must\\u00a0have\\u00a0been\\u00a0changed\\u00a0since\\u00a0you\\u00a0leave", jsonObject.getStrEscaped("name"));
+		Assertions.assertEquals("Something\\u00a0must\\u00a0have\\u00a0been\\u00a0changed\\u00a0since\\u00a0you\\u00a0leave", jsonObject.getStrEscaped("name"));
 	}
 
 	@Test
 	public void parseFromXmlTest() {
 		String s = "<sfzh>640102197312070614</sfzh><sfz>640102197312070614X</sfz><name>aa</name><gender>1</gender>";
 		JSONObject json = JSONUtil.parseFromXml(s);
-		Assert.assertEquals(640102197312070614L, json.get("sfzh"));
-		Assert.assertEquals("640102197312070614X", json.get("sfz"));
-		Assert.assertEquals("aa", json.get("name"));
-		Assert.assertEquals(1, json.get("gender"));
+		Assertions.assertEquals(640102197312070614L, json.get("sfzh"));
+		Assertions.assertEquals("640102197312070614X", json.get("sfz"));
+		Assertions.assertEquals("aa", json.get("name"));
+		Assertions.assertEquals(1, json.get("gender"));
 	}
 
 	@Test
@@ -172,7 +176,7 @@ public class JSONUtilTest {
 		String json = "{\"test\": 12.00}";
 		final JSONObject jsonObject = JSONUtil.parseObj(json);
 		//noinspection BigDecimalMethodWithoutRoundingCalled
-		Assert.assertEquals("12.00", jsonObject.getBigDecimal("test").setScale(2).toString());
+		Assertions.assertEquals("12.00", jsonObject.getBigDecimal("test").setScale(2).toString());
 	}
 
 	@Test
@@ -180,7 +184,7 @@ public class JSONUtilTest {
 		final JSONObject jsonObject = JSONUtil.createObj()
 		.set("test2", (JSONString) () -> NumberUtil.decimalFormat("#.0", 12.00D));
 
-		Assert.assertEquals("{\"test2\":12.0}", jsonObject.toString());
+		Assertions.assertEquals("{\"test2\":12.0}", jsonObject.toString());
 	}
 
 	@Test
@@ -188,16 +192,16 @@ public class JSONUtilTest {
 		// 默认去除多余的0
 		final JSONObject jsonObjectDefault = JSONUtil.createObj()
 				.set("test2", 12.00D);
-		Assert.assertEquals("{\"test2\":12}", jsonObjectDefault.toString());
+		Assertions.assertEquals("{\"test2\":12}", jsonObjectDefault.toString());
 
 		// 不去除多余的0
 		final JSONObject jsonObject = JSONUtil.createObj(JSONConfig.create().setStripTrailingZeros(false))
 				.set("test2", 12.00D);
-		Assert.assertEquals("{\"test2\":12.0}", jsonObject.toString());
+		Assertions.assertEquals("{\"test2\":12.0}", jsonObject.toString());
 
 		// 去除多余的0
 		jsonObject.getConfig().setStripTrailingZeros(true);
-		Assert.assertEquals("{\"test2\":12}", jsonObject.toString());
+		Assertions.assertEquals("{\"test2\":12}", jsonObject.toString());
 	}
 
 	@Test
@@ -207,7 +211,7 @@ public class JSONUtilTest {
 				"    \"test\": \"\\\\地库地库\",\n" +
 				"}");
 
-		Assert.assertEquals("\\地库地库", jsonObject.getObj("test"));
+		Assertions.assertEquals("\\地库地库", jsonObject.getObj("test"));
 	}
 
 	@Test
@@ -215,13 +219,13 @@ public class JSONUtilTest {
 		//https://github.com/looly/hutool/issues/1399
 		// SQLException实现了Iterable接口，默认是遍历之，会栈溢出，修正后只返回string
 		final JSONObject set = JSONUtil.createObj().set("test", new SQLException("test"));
-		Assert.assertEquals("{\"test\":\"java.sql.SQLException: test\"}", set.toString());
+		Assertions.assertEquals("{\"test\":\"java.sql.SQLException: test\"}", set.toString());
 	}
 
 	@Test
 	public void parseBigNumberTest(){
 		// 科学计数法使用BigDecimal处理，默认输出非科学计数形式
 		String str = "{\"test\":100000054128897953e4}";
-		Assert.assertEquals("{\"test\":1000000541288979530000}", JSONUtil.parseObj(str).toString());
+		Assertions.assertEquals("{\"test\":1000000541288979530000}", JSONUtil.parseObj(str).toString());
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/ParseBeanTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/ParseBeanTest.java
@@ -2,15 +2,15 @@ package cn.hutool.json;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.collection.CollUtil;
 
 /**
  * 测试Bean中嵌套List等对象时是否完整转换<br>
  * 同时测试私有class是否可以有效实例化
- * 
+ *
  * @author looly
  *
  */
@@ -23,7 +23,7 @@ public class ParseBeanTest {
 		c1.setTest("test1");
 		C c2 = new C();
 		c2.setTest("test2");
-		
+
 		B b1 = new B();
 		b1.setCs(CollUtil.newArrayList(c1, c2));
 		B b2 = new B();
@@ -34,7 +34,7 @@ public class ParseBeanTest {
 
 		JSONObject json = JSONUtil.parseObj(a);
 		A a1 = JSONUtil.toBean(json, A.class);
-		Assert.assertEquals(json.toString(), JSONUtil.toJsonStr(a1));
+		Assertions.assertEquals(json.toString(), JSONUtil.toJsonStr(a1));
 	}
 
 }

--- a/hutool-json/src/test/java/cn/hutool/json/Pr192Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Pr192Test.java
@@ -1,7 +1,7 @@
 package cn.hutool.json;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -14,7 +14,7 @@ public class Pr192Test {
 		String number = "1234.123456789123456";
 		String jsonString = "{\"create\":{\"details\":[{\"price\":" + number + "}]}}";
 		WebCreate create = JSONUtil.toBean(jsonString, WebCreate.class);
-		Assert.assertEquals(number,create.getCreate().getDetails().get(0).getPrice().toString());
+		Assertions.assertEquals(number,create.getCreate().getDetails().get(0).getPrice().toString());
 	}
 
 	static class WebCreate {

--- a/hutool-json/src/test/java/cn/hutool/json/TransientTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/TransientTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.json;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TransientTest {
 
@@ -20,6 +20,6 @@ public class TransientTest {
 
 		final JSONObject jsonObject = new JSONObject(detailBill,
 				JSONConfig.create().setTransientSupport(false));
-		Assert.assertEquals("{\"bizNo\":\"bizNo\"}", jsonObject.toString());
+		Assertions.assertEquals("{\"bizNo\":\"bizNo\"}", jsonObject.toString());
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/issueIVMD5/IssueIVMD5Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/issueIVMD5/IssueIVMD5Test.java
@@ -2,41 +2,41 @@ package cn.hutool.json.issueIVMD5;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.core.lang.TypeReference;
 import cn.hutool.json.JSONUtil;
 
 public class IssueIVMD5Test {
-	
+
 	/**
 	 * 测试泛型对象中有泛型字段的转换成功与否
 	 */
 	@Test
 	public void toBeanTest() {
 		String jsonStr = ResourceUtil.readUtf8Str("issueIVMD5.json");
-		
+
 		TypeReference<BaseResult<StudentInfo>> typeReference = new TypeReference<BaseResult<StudentInfo>>() {};
 		BaseResult<StudentInfo> bean = JSONUtil.toBean(jsonStr, typeReference.getType(), false);
-		
+
 		StudentInfo data2 = bean.getData2();
-		Assert.assertEquals("B4DDF491FDF34074AE7A819E1341CB6C", data2.getAccountId());
+		Assertions.assertEquals("B4DDF491FDF34074AE7A819E1341CB6C", data2.getAccountId());
 	}
-	
+
 	/**
 	 * 测试泛型对象中有包含泛型字段的类型的转换成功与否，比如List&lt;T&gt; list
 	 */
 	@Test
 	public void toBeanTest2() {
 		String jsonStr = ResourceUtil.readUtf8Str("issueIVMD5.json");
-		
+
 		TypeReference<BaseResult<StudentInfo>> typeReference = new TypeReference<BaseResult<StudentInfo>>() {};
 		BaseResult<StudentInfo> bean = JSONUtil.toBean(jsonStr, typeReference.getType(), false);
-		
+
 		List<StudentInfo> data = bean.getData();
 		StudentInfo studentInfo = data.get(0);
-		Assert.assertEquals("B4DDF491FDF34074AE7A819E1341CB6C", studentInfo.getAccountId());
+		Assertions.assertEquals("B4DDF491FDF34074AE7A819E1341CB6C", studentInfo.getAccountId());
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/issues1881Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/issues1881Test.java
@@ -3,7 +3,7 @@ package cn.hutool.json;
 import cn.hutool.core.lang.Console;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/hutool-json/src/test/java/cn/hutool/json/xml/XMLTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/xml/XMLTest.java
@@ -3,9 +3,8 @@ package cn.hutool.json.xml;
 import cn.hutool.json.JSONObject;
 import cn.hutool.json.JSONUtil;
 import cn.hutool.json.XML;
-import org.junit.Assert;
-import org.junit.Test;
-import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class XMLTest {
 
@@ -15,7 +14,8 @@ public class XMLTest {
 				.set("aaa", "你好")
 				.set("键2", "test");
 		final String s = JSONUtil.toXmlStr(put);
-		Assert.assertThat(s, CoreMatchers.anyOf(CoreMatchers.is("<aaa>你好</aaa><键2>test</键2>"), CoreMatchers.is("<键2>test</键2><aaa>你好</aaa>")));
+		Assertions.assertTrue("<aaa>你好</aaa><键2>test</键2>".equals(s)
+				|| "<键2>test</键2><aaa>你好</aaa>".equals(s));
 	}
 
 	@Test
@@ -23,10 +23,10 @@ public class XMLTest {
 		String xml = "<a>•</a>";
 		JSONObject jsonObject = XML.toJSONObject(xml);
 
-		Assert.assertEquals("{\"a\":\"•\"}", jsonObject.toString());
+		Assertions.assertEquals("{\"a\":\"•\"}", jsonObject.toString());
 
 		String xml2 = XML.toXml(JSONUtil.parseObj(jsonObject));
-		Assert.assertEquals(xml, xml2);
+		Assertions.assertEquals(xml, xml2);
 	}
 
 	@Test
@@ -34,9 +34,9 @@ public class XMLTest {
 		JSONObject jsonObject = JSONUtil.createObj().set("content","123456");
 
 		String xml = XML.toXml(jsonObject);
-		Assert.assertEquals("123456", xml);
+		Assertions.assertEquals("123456", xml);
 
 		xml = XML.toXml(jsonObject, null, new String[0]);
-		Assert.assertEquals("<content>123456</content>", xml);
+		Assertions.assertEquals("<content>123456</content>", xml);
 	}
 }

--- a/hutool-jwt/src/test/java/cn/hutool/jwt/JWTSignerTest.java
+++ b/hutool-jwt/src/test/java/cn/hutool/jwt/JWTSignerTest.java
@@ -5,8 +5,8 @@ import cn.hutool.crypto.KeyUtil;
 import cn.hutool.jwt.signers.AlgorithmUtil;
 import cn.hutool.jwt.signers.JWTSigner;
 import cn.hutool.jwt.signers.JWTSignerUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JWTSignerTest {
 
@@ -14,7 +14,7 @@ public class JWTSignerTest {
 	public void hs256Test(){
 		String id = "hs256";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKey(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -30,7 +30,7 @@ public class JWTSignerTest {
 	public void hs384Test(){
 		String id = "hs384";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKey(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -39,7 +39,7 @@ public class JWTSignerTest {
 	public void hs512Test(){
 		String id = "hs512";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKey(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -48,7 +48,7 @@ public class JWTSignerTest {
 	public void rs256Test(){
 		String id = "rs256";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -57,7 +57,7 @@ public class JWTSignerTest {
 	public void rs384Test(){
 		String id = "rs384";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -66,7 +66,7 @@ public class JWTSignerTest {
 	public void rs512Test(){
 		String id = "rs512";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -75,7 +75,7 @@ public class JWTSignerTest {
 	public void es256Test(){
 		String id = "es256";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -84,7 +84,7 @@ public class JWTSignerTest {
 	public void es384Test(){
 		String id = "es384";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -93,7 +93,7 @@ public class JWTSignerTest {
 	public void es512Test(){
 		String id = "es512";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -102,7 +102,7 @@ public class JWTSignerTest {
 	public void ps256Test(){
 		String id = "ps256";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -111,7 +111,7 @@ public class JWTSignerTest {
 	public void ps384Test(){
 		String id = "ps384";
 		final JWTSigner signer = JWTSignerUtil.createSigner(id, KeyUtil.generateKeyPair(AlgorithmUtil.getAlgorithm(id)));
-		Assert.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
+		Assertions.assertEquals(AlgorithmUtil.getAlgorithm(id), signer.getAlgorithm());
 
 		signAndVerify(signer);
 	}
@@ -125,6 +125,6 @@ public class JWTSignerTest {
 				.setSigner(signer);
 
 		String token = jwt.sign();
-		Assert.assertTrue(JWT.of(token).verify(signer));
+		Assertions.assertTrue(JWT.of(token).verify(signer));
 	}
 }

--- a/hutool-jwt/src/test/java/cn/hutool/jwt/JWTTest.java
+++ b/hutool-jwt/src/test/java/cn/hutool/jwt/JWTTest.java
@@ -3,8 +3,8 @@ package cn.hutool.jwt;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.jwt.signers.JWTSignerUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JWTTest {
 
@@ -23,9 +23,9 @@ public class JWTTest {
 				"bXlSnqVeJXWqUIt7HyEhgKNVlIPjkumHlAwFY-5YCtk";
 
 		String token = jwt.sign();
-		Assert.assertEquals(rightToken, token);
+		Assertions.assertEquals(rightToken, token);
 
-		Assert.assertTrue(JWT.of(rightToken).setKey(key).verify());
+		Assertions.assertTrue(JWT.of(rightToken).setKey(key).verify());
 	}
 
 	@Test
@@ -36,17 +36,17 @@ public class JWTTest {
 
 		final JWT jwt = JWT.of(rightToken);
 
-		Assert.assertTrue(jwt.setKey("1234567890".getBytes()).verify());
+		Assertions.assertTrue(jwt.setKey("1234567890".getBytes()).verify());
 
 		//header
-		Assert.assertEquals("JWT", jwt.getHeader(JWTHeader.TYPE));
-		Assert.assertEquals("HS256", jwt.getHeader(JWTHeader.ALGORITHM));
-		Assert.assertNull(jwt.getHeader(JWTHeader.CONTENT_TYPE));
+		Assertions.assertEquals("JWT", jwt.getHeader(JWTHeader.TYPE));
+		Assertions.assertEquals("HS256", jwt.getHeader(JWTHeader.ALGORITHM));
+		Assertions.assertNull(jwt.getHeader(JWTHeader.CONTENT_TYPE));
 
 		//payload
-		Assert.assertEquals("1234567890", jwt.getPayload("sub"));
-		Assert.assertEquals("looly", jwt.getPayload("name"));
-		Assert.assertEquals(true, jwt.getPayload("admin"));
+		Assertions.assertEquals("1234567890", jwt.getPayload("sub"));
+		Assertions.assertEquals("looly", jwt.getPayload("name"));
+		Assertions.assertEquals(true, jwt.getPayload("admin"));
 	}
 
 	@Test
@@ -61,22 +61,23 @@ public class JWTTest {
 				"eyJzdWIiOiIxMjM0NTY3ODkwIiwiYWRtaW4iOnRydWUsIm5hbWUiOiJsb29seSJ9.";
 
 		String token = jwt.sign();
-		Assert.assertEquals(token, token);
+		Assertions.assertEquals(token, token);
 
-		Assert.assertTrue(JWT.of(rightToken).setSigner(JWTSignerUtil.none()).verify());
+		Assertions.assertTrue(JWT.of(rightToken).setSigner(JWTSignerUtil.none()).verify());
 	}
 
 	/**
 	 * 必须定义签名器
 	 */
-	@Test(expected = JWTException.class)
+	@Test
 	public void needSignerTest(){
-		JWT jwt = JWT.create()
-				.setPayload("sub", "1234567890")
-				.setPayload("name", "looly")
-				.setPayload("admin", true);
-
-		jwt.sign();
+		Assertions.assertThrows(JWTException.class, () -> {
+			JWT jwt = JWT.create()
+					.setPayload("sub", "1234567890")
+					.setPayload("name", "looly")
+					.setPayload("admin", true);
+			jwt.sign();
+		});
 	}
 
 	@Test
@@ -86,6 +87,6 @@ public class JWTTest {
 				"aixF1eKlAKS_k3ynFnStE7-IRGiD5YaqznvK2xEjBew";
 
 		final boolean verify = JWT.of(token).setKey(StrUtil.utf8Bytes("123456")).verify();
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 }

--- a/hutool-jwt/src/test/java/cn/hutool/jwt/JWTUtilTest.java
+++ b/hutool-jwt/src/test/java/cn/hutool/jwt/JWTUtilTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.jwt;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,17 +30,17 @@ public class JWTUtilTest {
 				"U2aQkC2THYV9L0fTN-yBBI7gmo5xhmvMhATtu8v0zEA";
 		final JWT jwt = JWTUtil.parseToken(rightToken);
 
-		Assert.assertTrue(jwt.setKey("1234567890".getBytes()).verify());
+		Assertions.assertTrue(jwt.setKey("1234567890".getBytes()).verify());
 
 		//header
-		Assert.assertEquals("JWT", jwt.getHeader(JWTHeader.TYPE));
-		Assert.assertEquals("HS256", jwt.getHeader(JWTHeader.ALGORITHM));
-		Assert.assertNull(jwt.getHeader(JWTHeader.CONTENT_TYPE));
+		Assertions.assertEquals("JWT", jwt.getHeader(JWTHeader.TYPE));
+		Assertions.assertEquals("HS256", jwt.getHeader(JWTHeader.ALGORITHM));
+		Assertions.assertNull(jwt.getHeader(JWTHeader.CONTENT_TYPE));
 
 		//payload
-		Assert.assertEquals("1234567890", jwt.getPayload("sub"));
-		Assert.assertEquals("looly", jwt.getPayload("name"));
-		Assert.assertEquals(true, jwt.getPayload("admin"));
+		Assertions.assertEquals("1234567890", jwt.getPayload("sub"));
+		Assertions.assertEquals("looly", jwt.getPayload("name"));
+		Assertions.assertEquals(true, jwt.getPayload("admin"));
 	}
 
 	@Test
@@ -50,6 +50,6 @@ public class JWTUtilTest {
 				"aixF1eKlAKS_k3ynFnStE7-IRGiD5YaqznvK2xEjBew";
 
 		final boolean verify = JWTUtil.verify(token, "123456".getBytes());
-		Assert.assertTrue(verify);
+		Assertions.assertTrue(verify);
 	}
 }

--- a/hutool-jwt/src/test/java/cn/hutool/jwt/JWTValidatorTest.java
+++ b/hutool-jwt/src/test/java/cn/hutool/jwt/JWTValidatorTest.java
@@ -3,26 +3,30 @@ package cn.hutool.jwt;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.exceptions.ValidateException;
 import cn.hutool.jwt.signers.JWTSignerUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class JWTValidatorTest {
 
-	@Test(expected = ValidateException.class)
+	@Test
 	public void expiredAtTest(){
-		String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
-		JWTValidator.of(token).validateDate(DateUtil.date());
+		Assertions.assertThrows(ValidateException.class, () -> {
+			String token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0Nzc1OTJ9.isvT0Pqx0yjnZk53mUFSeYFJLDs-Ls9IsNAm86gIdZo";
+			JWTValidator.of(token).validateDate(DateUtil.date());
+		});
 	}
 
-	@Test(expected = ValidateException.class)
+	@Test
 	public void issueAtTest(){
-		final String token = JWT.create()
-				.setIssuedAt(DateUtil.date())
-				.setKey("123456".getBytes())
-				.sign();
+		Assertions.assertThrows(ValidateException.class, () -> {
+			final String token = JWT.create()
+					.setIssuedAt(DateUtil.date())
+					.setKey("123456".getBytes())
+					.sign();
 
-		// 签发时间早于被检查的时间
-		JWTValidator.of(token).validateDate(DateUtil.yesterday());
+			// 签发时间早于被检查的时间
+			JWTValidator.of(token).validateDate(DateUtil.yesterday());
+		});
 	}
 
 	@Test
@@ -36,12 +40,14 @@ public class JWTValidatorTest {
 		JWTValidator.of(token).validateDate(DateUtil.date());
 	}
 
-	@Test(expected = ValidateException.class)
+	@Test
 	public void notBeforeTest(){
-		final JWT jwt = JWT.create()
-				.setNotBefore(DateUtil.date());
+		Assertions.assertThrows(ValidateException.class, () -> {
+			final JWT jwt = JWT.create()
+					.setNotBefore(DateUtil.date());
 
-		JWTValidator.of(jwt).validateDate(DateUtil.yesterday());
+			JWTValidator.of(jwt).validateDate(DateUtil.yesterday());
+		});
 	}
 
 	@Test
@@ -67,16 +73,18 @@ public class JWTValidatorTest {
 		String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJNb0xpIiwiZXhwIjoxNjI0OTU4MDk0NTI4LCJpYXQiOjE2MjQ5NTgwMzQ1MjAsInVzZXIiOiJ1c2VyIn0.L0uB38p9sZrivbmP0VlDe--j_11YUXTu3TfHhfQhRKc";
 		byte[] key = "1234567890".getBytes();
 		boolean validate = JWT.of(token).setKey(key).validate(0);
-		Assert.assertFalse(validate);
+		Assertions.assertFalse(validate);
 	}
 
-	@Test(expected = ValidateException.class)
+	@Test
 	public void validateDateTest(){
-		final JWT jwt = JWT.create()
-				.setPayload("id", 123)
-				.setPayload("username", "hutool")
-				.setExpiresAt(DateUtil.parse("2021-10-13 09:59:00"));
+		Assertions.assertThrows(ValidateException.class, () -> {
+			final JWT jwt = JWT.create()
+					.setPayload("id", 123)
+					.setPayload("username", "hutool")
+					.setExpiresAt(DateUtil.parse("2021-10-13 09:59:00"));
 
-		JWTValidator.of(jwt).validateDate(DateUtil.date());
+			JWTValidator.of(jwt).validateDate(DateUtil.date());
+		});
 	}
 }

--- a/hutool-log/src/test/java/cn/hutool/log/test/CustomLogTest.java
+++ b/hutool-log/src/test/java/cn/hutool/log/test/CustomLogTest.java
@@ -11,7 +11,7 @@ import cn.hutool.log.dialect.log4j2.Log4j2LogFactory;
 import cn.hutool.log.dialect.slf4j.Slf4jLogFactory;
 import cn.hutool.log.dialect.tinylog.TinyLog2Factory;
 import cn.hutool.log.dialect.tinylog.TinyLogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * 日志门面单元测试
@@ -19,15 +19,15 @@ import org.junit.Test;
  *
  */
 public class CustomLogTest {
-	
+
 	private static final String LINE = "----------------------------------------------------------------------";
-	
+
 	@Test
 	public void consoleLogTest(){
 		LogFactory factory = new ConsoleLogFactory();
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
 	}
 
@@ -40,24 +40,24 @@ public class CustomLogTest {
 		log.info(null);
 		log.info((String)null);
 	}
-	
+
 	@Test
 	public void commonsLogTest(){
 		LogFactory factory = new ApacheCommonsLogFactory();
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info(null);
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
 	}
-	
+
 	@Test
 	public void tinyLogTest(){
 		LogFactory factory = new TinyLogFactory();
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info(null);
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
@@ -73,7 +73,7 @@ public class CustomLogTest {
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
 	}
-	
+
 	@Test
 	public void log4j2LogTest(){
 		LogFactory factory = new Log4j2LogFactory();
@@ -86,47 +86,47 @@ public class CustomLogTest {
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
 	}
-	
+
 	@Test
 	public void log4jLogTest(){
 		LogFactory factory = new Log4jLogFactory();
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info(null);
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
-		
+
 	}
-	
+
 	@Test
 	public void jbossLogTest(){
 		LogFactory factory = new JbossLogFactory();
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info(null);
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
 	}
-	
+
 	@Test
 	public void jdkLogTest(){
 		LogFactory factory = new JdkLogFactory();
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info(null);
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);
 	}
-	
+
 	@Test
 	public void slf4jTest(){
 		LogFactory factory = new Slf4jLogFactory(false);
 		LogFactory.setCurrentLogFactory(factory);
 		Log log = LogFactory.get();
-		
+
 		log.info(null);
 		log.info((String)null);
 		log.info("This is custom '{}' log\n{}", factory.getName(), LINE);

--- a/hutool-log/src/test/java/cn/hutool/log/test/LogTest.java
+++ b/hutool-log/src/test/java/cn/hutool/log/test/LogTest.java
@@ -1,7 +1,7 @@
 package cn.hutool.log.test;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.log.Log;
 import cn.hutool.log.LogFactory;
@@ -13,25 +13,25 @@ import cn.hutool.log.level.Level;
  *
  */
 public class LogTest {
-	
+
 	@Test
 	public void logTest(){
 		Log log = LogFactory.get();
-		
+
 		// 自动选择日志实现
 		log.debug("This is {} log", Level.DEBUG);
 		log.info("This is {} log", Level.INFO);
 		log.warn("This is {} log", Level.WARN);
-		
+
 //		Exception e = new Exception("test Exception");
 //		log.error(e, "This is {} log", Level.ERROR);
 	}
-	
+
 	/**
 	 * 兼容slf4j日志消息格式测试，即第二个参数是异常对象时正常输出异常信息
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void logWithExceptionTest() {
 		Log log = LogFactory.get();
 		Exception e = new Exception("test Exception");

--- a/hutool-log/src/test/java/cn/hutool/log/test/LogTubeTest.java
+++ b/hutool-log/src/test/java/cn/hutool/log/test/LogTubeTest.java
@@ -3,7 +3,7 @@ package cn.hutool.log.test;
 import cn.hutool.log.Log;
 import cn.hutool.log.LogFactory;
 import cn.hutool.log.dialect.logtube.LogTubeLogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogTubeTest {
 

--- a/hutool-log/src/test/java/cn/hutool/log/test/StaticLogTest.java
+++ b/hutool-log/src/test/java/cn/hutool/log/test/StaticLogTest.java
@@ -1,6 +1,6 @@
 package cn.hutool.log.test;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.log.StaticLog;
 

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/BigExcelWriteTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/BigExcelWriteTest.java
@@ -10,8 +10,8 @@ import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.IndexedColors;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,13 +22,13 @@ import java.util.Map;
 
 /**
  * 写出Excel单元测试
- * 
+ *
  * @author looly
  */
 public class BigExcelWriteTest {
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest2() {
 		List<String> row = CollUtil.newArrayList("姓名", "加班日期", "下班时间", "加班时长", "餐补", "车补次数", "车补", "总计");
 		BigExcelWriter overtimeWriter = ExcelUtil.getBigWriter("e:/excel/single_line.xlsx");
@@ -37,7 +37,7 @@ public class BigExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		List<?> row1 = CollUtil.newArrayList("aaaaa", "bb", "cc", "dd", DateUtil.date(), 3.22676575765);
 		List<?> row2 = CollUtil.newArrayList("aa1", "bb1", "cc1", "dd1", DateUtil.date(), 250.7676);
@@ -50,7 +50,7 @@ public class BigExcelWriteTest {
 			//超大列表写出测试
 			rows.add(ObjectUtil.clone(row1));
 		}
-		
+
 		String filePath = "e:/bigWriteTest.xlsx";
 		FileUtil.del(filePath);
 		// 通过工具类创建writer
@@ -66,9 +66,9 @@ public class BigExcelWriteTest {
 		// 关闭writer，释放内存
 		writer.close();
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void mergeTest() {
 		List<?> row1 = CollUtil.newArrayList("aa", "bb", "cc", "dd", DateUtil.date(), 3.22676575765);
 		List<?> row2 = CollUtil.newArrayList("aa1", "bb1", "cc1", "dd1", DateUtil.date(), 250.7676);
@@ -89,16 +89,16 @@ public class BigExcelWriteTest {
 		writer.merge(row1.size() - 1, "测试标题");
 		// 一次性写出内容，使用默认样式
 		writer.write(rows);
-		
+
 		// 合并单元格后的标题行，使用默认标题样式
 		writer.merge(7, 10, 4, 10, "测试Merge", false);
-		
+
 		// 关闭writer，释放内存
 		writer.close();
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapTest() {
 		Map<String, Object> row1 = new LinkedHashMap<>();
 		row1.put("姓名", "张三");
@@ -120,14 +120,14 @@ public class BigExcelWriteTest {
 		String path = "e:/bigWriteMapTest.xlsx";
 		FileUtil.del(path);
 		BigExcelWriter writer = ExcelUtil.getBigWriter(path);
-		
+
 		//设置内容字体
 		Font font = writer.createFont();
 		font.setBold(true);
-		font.setColor(Font.COLOR_RED); 
-		font.setItalic(true); 
+		font.setColor(Font.COLOR_RED);
+		font.setItalic(true);
 		writer.getStyleSet().setFont(font, true);
-		
+
 		// 合并单元格后的标题行，使用默认标题样式
 		writer.merge(row1.size() - 1, "一班成绩单");
 		// 一次性写出内容，使用默认样式
@@ -135,9 +135,9 @@ public class BigExcelWriteTest {
 		// 关闭writer，释放内存
 		writer.close();
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapTest2() {
 		Map<String, Object> row1 = MapUtil.newHashMap(true);
 		row1.put("姓名", "张三");
@@ -145,12 +145,12 @@ public class BigExcelWriteTest {
 		row1.put("成绩", 88.32);
 		row1.put("是否合格", true);
 		row1.put("考试日期", DateUtil.date());
-		
+
 		// 通过工具类创建writer
 		String path = "e:/bigWriteMapTest2.xlsx";
 		FileUtil.del(path);
 		BigExcelWriter writer = ExcelUtil.getBigWriter(path);
-		
+
 		// 一次性写出内容，使用默认样式
 		writer.writeRow(row1, true);
 		// 关闭writer，释放内存
@@ -158,7 +158,7 @@ public class BigExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeBeanTest() {
 		cn.hutool.poi.excel.TestBean bean1 = new cn.hutool.poi.excel.TestBean();
 		bean1.setName("张三");
@@ -192,9 +192,9 @@ public class BigExcelWriteTest {
 		// 关闭writer，释放内存
 		writer.close();
 	}
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void writeCellValueTest() {
 		String path = "d:/test/cellValueTest.xlsx";
 		FileUtil.del(path);
@@ -204,7 +204,7 @@ public class BigExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void closeTest() {
 		final Map<String, ?> map1 = MapUtil.of("id", "123456");
 		final Map<String, ?> map2 = MapUtil.of("id", "123457");
@@ -217,7 +217,7 @@ public class BigExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void issue1210() {
 		// 通过工具类创建writer
 		String path = "d:/test/issue1210.xlsx";

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/CellEditorTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/CellEditorTest.java
@@ -4,30 +4,31 @@ import cn.hutool.poi.excel.cell.CellEditor;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.poi.ss.usermodel.Cell;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.List;
 
 public class CellEditorTest {
 
-	@org.junit.Test
-	public void readTest(){
+	@Test
+	public void readTest() {
 		ExcelReader excelReader= ExcelUtil.getReader("cell_editor_test.xlsx");
 		excelReader.setCellEditor(new ExcelHandler());
-		List<Test> excelReaderObjects=excelReader.readAll(Test.class);
+		List<Test1> excelReaderObjects=excelReader.readAll(Test1.class);
 
-		Assert.assertEquals("0", excelReaderObjects.get(0).getTest1());
-		Assert.assertEquals("b", excelReaderObjects.get(0).getTest2());
-		Assert.assertEquals("0", excelReaderObjects.get(1).getTest1());
-		Assert.assertEquals("b1", excelReaderObjects.get(1).getTest2());
-		Assert.assertEquals("0", excelReaderObjects.get(2).getTest1());
-		Assert.assertEquals("c2", excelReaderObjects.get(2).getTest2());
+		Assertions.assertEquals("0", excelReaderObjects.get(0).getTest1());
+		Assertions.assertEquals("b", excelReaderObjects.get(0).getTest2());
+		Assertions.assertEquals("0", excelReaderObjects.get(1).getTest1());
+		Assertions.assertEquals("b1", excelReaderObjects.get(1).getTest2());
+		Assertions.assertEquals("0", excelReaderObjects.get(2).getTest1());
+		Assertions.assertEquals("c2", excelReaderObjects.get(2).getTest2());
 	}
 
 	@AllArgsConstructor
 	@Data
-	public static class Test implements Serializable {
+	public static class Test1 implements Serializable {
 		private static final long serialVersionUID = 1L;
 
 		private String test1;
@@ -35,7 +36,7 @@ public class CellEditorTest {
 	}
 
 	public static class ExcelHandler implements CellEditor {
-		@ Override
+		@Override
 		public Object edit(Cell cell, Object o) {
 			if (cell.getColumnIndex()==0 && cell.getRowIndex() != 0){
 				o="0";

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/CellUtilTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/CellUtilTest.java
@@ -1,15 +1,15 @@
 package cn.hutool.poi.excel;
 
 import org.apache.poi.ss.usermodel.BuiltinFormats;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import cn.hutool.core.lang.Console;
 
 public class CellUtilTest {
-	
+
 	@Test
-	@Ignore
+	@Disabled
 	public void isDateTest() {
 		String[] all = BuiltinFormats.getAll();
 		for(int i = 0 ; i < all.length; i++) {

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelFileUtilTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelFileUtilTest.java
@@ -2,8 +2,8 @@ package cn.hutool.poi.excel;
 
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IoUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
@@ -13,8 +13,8 @@ public class ExcelFileUtilTest {
 	public void xlsTest(){
 		InputStream in = FileUtil.getInputStream("aaa.xls");
 		try{
-			Assert.assertTrue(ExcelFileUtil.isXls(in));
-			Assert.assertFalse(ExcelFileUtil.isXlsx(in));
+			Assertions.assertTrue(ExcelFileUtil.isXls(in));
+			Assertions.assertFalse(ExcelFileUtil.isXlsx(in));
 		} finally {
 			IoUtil.close(in);
 		}
@@ -24,8 +24,8 @@ public class ExcelFileUtilTest {
 	public void xlsxTest(){
 		InputStream in = FileUtil.getInputStream("aaa.xlsx");
 		try{
-			Assert.assertFalse(ExcelFileUtil.isXls(in));
-			Assert.assertTrue(ExcelFileUtil.isXlsx(in));
+			Assertions.assertFalse(ExcelFileUtil.isXls(in));
+			Assertions.assertTrue(ExcelFileUtil.isXlsx(in));
 		} finally {
 			IoUtil.close(in);
 		}

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelReadTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelReadTest.java
@@ -6,9 +6,9 @@ import cn.hutool.core.map.MapUtil;
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.poi.excel.cell.CellHandler;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -27,7 +27,7 @@ public class ExcelReadTest {
 
 		//读取单个单元格内容测试
 		Object value = reader.readCellValue(1, 2);
-		Assert.assertEquals("仓库", value);
+		Assertions.assertEquals("仓库", value);
 
 		Map<String, String> headerAlias = MapUtil.newHashMap();
 		headerAlias.put("用户姓名", "userName");
@@ -38,17 +38,17 @@ public class ExcelReadTest {
 
 		// 读取list时默认首个非空行为标题
 		List<List<Object>> read = reader.read();
-		Assert.assertEquals("userName", read.get(0).get(0));
-		Assert.assertEquals("storageName", read.get(0).get(1));
-		Assert.assertEquals("checkPerm", read.get(0).get(2));
-		Assert.assertEquals("allotAuditPerm", read.get(0).get(3));
+		Assertions.assertEquals("userName", read.get(0).get(0));
+		Assertions.assertEquals("storageName", read.get(0).get(1));
+		Assertions.assertEquals("checkPerm", read.get(0).get(2));
+		Assertions.assertEquals("allotAuditPerm", read.get(0).get(3));
 
 		List<Map<String, Object>> readAll = reader.readAll();
 		for (Map<String, Object> map : readAll) {
-			Assert.assertTrue(map.containsKey("userName"));
-			Assert.assertTrue(map.containsKey("storageName"));
-			Assert.assertTrue(map.containsKey("checkPerm"));
-			Assert.assertTrue(map.containsKey("allotAuditPerm"));
+			Assertions.assertTrue(map.containsKey("userName"));
+			Assertions.assertTrue(map.containsKey("storageName"));
+			Assertions.assertTrue(map.containsKey("checkPerm"));
+			Assertions.assertTrue(map.containsKey("allotAuditPerm"));
 		}
 	}
 
@@ -57,7 +57,7 @@ public class ExcelReadTest {
 		ExcelReader reader = ExcelUtil.getReader(ResourceUtil.getStream("priceIndex.xls"));
 		List<Map<String, Object>> readAll = reader.readAll();
 
-		Assert.assertEquals(4, readAll.size());
+		Assertions.assertEquals(4, readAll.size());
 	}
 
 	@Test
@@ -66,22 +66,22 @@ public class ExcelReadTest {
 		List<List<Object>> readAll = reader.read();
 
 		// 标题
-		Assert.assertEquals("姓名", readAll.get(0).get(0));
-		Assert.assertEquals("性别", readAll.get(0).get(1));
-		Assert.assertEquals("年龄", readAll.get(0).get(2));
-		Assert.assertEquals("鞋码", readAll.get(0).get(3));
+		Assertions.assertEquals("姓名", readAll.get(0).get(0));
+		Assertions.assertEquals("性别", readAll.get(0).get(1));
+		Assertions.assertEquals("年龄", readAll.get(0).get(2));
+		Assertions.assertEquals("鞋码", readAll.get(0).get(3));
 
 		// 第一行
-		Assert.assertEquals("张三", readAll.get(1).get(0));
-		Assert.assertEquals("男", readAll.get(1).get(1));
-		Assert.assertEquals(11L, readAll.get(1).get(2));
-		Assert.assertEquals(41.5D, readAll.get(1).get(3));
+		Assertions.assertEquals("张三", readAll.get(1).get(0));
+		Assertions.assertEquals("男", readAll.get(1).get(1));
+		Assertions.assertEquals(11L, readAll.get(1).get(2));
+		Assertions.assertEquals(41.5D, readAll.get(1).get(3));
 	}
 
 	@Test
 	public void excelReadAsTextTest() {
 		ExcelReader reader = ExcelUtil.getReader(ResourceUtil.getStream("aaa.xlsx"));
-		Assert.assertNotNull(reader.readAsText(false));
+		Assertions.assertNotNull(reader.readAsText(false));
 	}
 
 	@Test
@@ -94,16 +94,16 @@ public class ExcelReadTest {
 		// }
 
 		// 标题
-		Assert.assertEquals("姓名", readAll.get(0).get(0));
-		Assert.assertEquals("性别", readAll.get(0).get(1));
-		Assert.assertEquals("年龄", readAll.get(0).get(2));
-		Assert.assertEquals("分数", readAll.get(0).get(3));
+		Assertions.assertEquals("姓名", readAll.get(0).get(0));
+		Assertions.assertEquals("性别", readAll.get(0).get(1));
+		Assertions.assertEquals("年龄", readAll.get(0).get(2));
+		Assertions.assertEquals("分数", readAll.get(0).get(3));
 
 		// 第一行
-		Assert.assertEquals("张三", readAll.get(1).get(0));
-		Assert.assertEquals("男", readAll.get(1).get(1));
-		Assert.assertEquals(11L, readAll.get(1).get(2));
-		Assert.assertEquals(33.2D, readAll.get(1).get(3));
+		Assertions.assertEquals("张三", readAll.get(1).get(0));
+		Assertions.assertEquals("男", readAll.get(1).get(1));
+		Assertions.assertEquals(11L, readAll.get(1).get(2));
+		Assertions.assertEquals(33.2D, readAll.get(1).get(3));
 	}
 
 	@Test
@@ -112,11 +112,11 @@ public class ExcelReadTest {
 		List<List<Object>> readAll = reader.read();
 
 		// 标题
-		Assert.assertEquals("班级", readAll.get(0).get(0));
-		Assert.assertEquals("年级", readAll.get(0).get(1));
-		Assert.assertEquals("学校", readAll.get(0).get(2));
-		Assert.assertEquals("入学时间", readAll.get(0).get(3));
-		Assert.assertEquals("更新时间", readAll.get(0).get(4));
+		Assertions.assertEquals("班级", readAll.get(0).get(0));
+		Assertions.assertEquals("年级", readAll.get(0).get(1));
+		Assertions.assertEquals("学校", readAll.get(0).get(2));
+		Assertions.assertEquals("入学时间", readAll.get(0).get(3));
+		Assertions.assertEquals("更新时间", readAll.get(0).get(4));
 	}
 
 	@Test
@@ -124,9 +124,9 @@ public class ExcelReadTest {
 		ExcelReader reader = ExcelUtil.getReader(ResourceUtil.getStream("aaa.xlsx"));
 		List<Map<String, Object>> readAll = reader.readAll();
 
-		Assert.assertEquals("张三", readAll.get(0).get("姓名"));
-		Assert.assertEquals("男", readAll.get(0).get("性别"));
-		Assert.assertEquals(11L, readAll.get(0).get("年龄"));
+		Assertions.assertEquals("张三", readAll.get(0).get("姓名"));
+		Assertions.assertEquals("男", readAll.get(0).get("性别"));
+		Assertions.assertEquals(11L, readAll.get(0).get("年龄"));
 	}
 
 	@Test
@@ -138,14 +138,14 @@ public class ExcelReadTest {
 		reader.addHeaderAlias("鞋码", "shoeSize");
 
 		List<Person> all = reader.readAll(Person.class);
-		Assert.assertEquals("张三", all.get(0).getName());
-		Assert.assertEquals("男", all.get(0).getGender());
-		Assert.assertEquals(Integer.valueOf(11), all.get(0).getAge());
-		Assert.assertEquals(new BigDecimal("41.5"), all.get(0).getShoeSize());
+		Assertions.assertEquals("张三", all.get(0).getName());
+		Assertions.assertEquals("男", all.get(0).getGender());
+		Assertions.assertEquals(Integer.valueOf(11), all.get(0).getAge());
+		Assertions.assertEquals(new BigDecimal("41.5"), all.get(0).getShoeSize());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void excelReadToBeanListTest2() {
 		ExcelReader reader = ExcelUtil.getReader("f:/test/toBean.xlsx");
 		reader.addHeaderAlias("姓名", "name");
@@ -167,7 +167,7 @@ public class ExcelReadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readDoubleTest() {
 		ExcelReader reader = ExcelUtil.getReader("f:/test/doubleTest.xls");
 		final List<List<Object>> read = reader.read();
@@ -181,19 +181,19 @@ public class ExcelReadTest {
 		final ExcelReader reader = ExcelUtil.getReader("merge_test.xlsx");
 		final List<List<Object>> read = reader.read();
 		// 验证合并单元格在两行中都可以取到值
-		Assert.assertEquals(11L, read.get(1).get(2));
-		Assert.assertEquals(11L, read.get(2).get(2));
+		Assertions.assertEquals(11L, read.get(1).get(2));
+		Assertions.assertEquals(11L, read.get(2).get(2));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readCellsTest() {
 		final ExcelReader reader = ExcelUtil.getReader("merge_test.xlsx");
 		reader.read((cell, value)-> Console.log("{}, {} {}", cell.getRowIndex(), cell.getColumnIndex(), value));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readTest() {
 		// 测试合并单元格是否可以正常读到第一个单元格的值
 		final ExcelReader reader = ExcelUtil.getReader("d:/test/人员体检信息表.xlsx");
@@ -210,17 +210,17 @@ public class ExcelReadTest {
 		final List<List<Object>> read = reader.read();
 
 		// 对于任意一个单元格有值的情况下，之前的单元格值按照null处理
-		Assert.assertEquals(1, read.get(1).size());
-		Assert.assertEquals(2, read.get(2).size());
-		Assert.assertEquals(3, read.get(3).size());
+		Assertions.assertEquals(1, read.get(1).size());
+		Assertions.assertEquals(2, read.get(2).size());
+		Assertions.assertEquals(3, read.get(3).size());
 
-		Assert.assertEquals("#", read.get(2).get(0));
-		Assert.assertEquals("#", read.get(3).get(0));
-		Assert.assertEquals("#", read.get(3).get(1));
+		Assertions.assertEquals("#", read.get(2).get(0));
+		Assertions.assertEquals("#", read.get(3).get(0));
+		Assertions.assertEquals("#", read.get(3).get(1));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readEmptyTest(){
 		final ExcelReader reader = ExcelUtil.getReader("d:/test/issue.xlsx");
 		final List<Map<String, Object>> maps = reader.readAll();
@@ -228,7 +228,7 @@ public class ExcelReadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readNullRowTest(){
 		final ExcelReader reader = ExcelUtil.getReader("d:/test/1.-.xls");
 		reader.read((CellHandler) Console::log);
@@ -239,9 +239,9 @@ public class ExcelReadTest {
 		ExcelReader reader = ExcelUtil.getReader(ResourceUtil.getStream("aaa.xlsx"));
 		final List<Object> objects = reader.readColumn(0, 1);
 
-		Assert.assertEquals(3, objects.size());
-		Assert.assertEquals("张三", objects.get(0));
-		Assert.assertEquals("李四", objects.get(1));
-		Assert.assertEquals("", objects.get(2));
+		Assertions.assertEquals(3, objects.size());
+		Assertions.assertEquals("张三", objects.get(0));
+		Assertions.assertEquals("李四", objects.get(1));
+		Assertions.assertEquals("", objects.get(2));
 	}
 }

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelSaxReadTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelSaxReadTest.java
@@ -2,7 +2,6 @@ package cn.hutool.poi.excel;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.convert.Convert;
-import cn.hutool.core.exceptions.ValidateException;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.lang.Console;

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelSaxReadTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelSaxReadTest.java
@@ -2,6 +2,7 @@ package cn.hutool.poi.excel;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.convert.Convert;
+import cn.hutool.core.exceptions.ValidateException;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.core.lang.Console;
@@ -11,9 +12,9 @@ import cn.hutool.poi.excel.sax.Excel03SaxReader;
 import cn.hutool.poi.excel.sax.handler.RowHandler;
 import cn.hutool.poi.exceptions.POIException;
 import org.apache.poi.ss.usermodel.CellStyle;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -65,15 +66,17 @@ public class ExcelSaxReadTest {
 		reader.read("aaa.xls", "sheetName:校园入学");
 	}
 
-	@Test(expected = POIException.class)
+	@Test
 	public void excel03ByNameErrorTest() {
-		// sheet名称不存在则报错
-		Excel03SaxReader reader = new Excel03SaxReader(createRowHandler());
-		reader.read("aaa.xls", "校园入学1");
+		Assertions.assertThrows(POIException.class, () -> {
+			// sheet名称不存在则报错
+			Excel03SaxReader reader = new Excel03SaxReader(createRowHandler());
+			reader.read("aaa.xls", "校园入学1");
+		});
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readBlankLineTest() {
 		ExcelUtil.readBySax("e:/ExcelBlankLine.xlsx", 0, (sheetIndex, rowIndex, rowList) -> {
 			if (StrUtil.isAllEmpty(Convert.toStrArray(rowList))) {
@@ -99,7 +102,7 @@ public class ExcelSaxReadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readBySaxTest2() {
 		ExcelUtil.readBySax("d:/test/456789.xlsx", "0", (sheetIndex, rowIndex, rowList) -> Console.log(rowList));
 	}
@@ -109,13 +112,13 @@ public class ExcelSaxReadTest {
 //			Console.log("[{}] [{}] {}", sheetIndex, rowIndex, rowlist);
 			if (5 != rowIndex && 6 != rowIndex) {
 				// 测试样例中除第五行、第六行都为非空行
-				Assert.assertTrue(CollUtil.isNotEmpty(rowlist));
+				Assertions.assertTrue(CollUtil.isNotEmpty(rowlist));
 			}
 		};
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void handle07CellTest() {
 		ExcelUtil.readBySax("d:/test/test.xlsx", -1, new RowHandler() {
 
@@ -133,7 +136,7 @@ public class ExcelSaxReadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void handle03CellTest() {
 		ExcelUtil.readBySax("d:/test/test.xls", -1, new RowHandler() {
 
@@ -159,7 +162,7 @@ public class ExcelSaxReadTest {
 				rows.add("");
 			}
 		});
-		Assert.assertEquals(50L, rows.get(3));
+		Assertions.assertEquals(50L, rows.get(3));
 	}
 
 	@Test
@@ -169,7 +172,7 @@ public class ExcelSaxReadTest {
 				rows.add(list.get(1)));
 
 		final FormulaCellValue value = (FormulaCellValue) rows.get(3);
-		Assert.assertEquals(50L, value.getResult());
+		Assertions.assertEquals(50L, value.getResult());
 	}
 
 	@Test
@@ -179,11 +182,11 @@ public class ExcelSaxReadTest {
 				(i, i1, list) -> rows.add(StrUtil.toString(list.get(0)))
 		);
 
-		Assert.assertEquals("2020-10-09 00:00:00", rows.get(1));
+		Assertions.assertEquals("2020-10-09 00:00:00", rows.get(1));
 		// 非日期格式不做转换
-		Assert.assertEquals("112233", rows.get(2));
-		Assert.assertEquals("1000.0", rows.get(3));
-		Assert.assertEquals("2012-12-21 00:00:00", rows.get(4));
+		Assertions.assertEquals("112233", rows.get(2));
+		Assertions.assertEquals("1000.0", rows.get(3));
+		Assertions.assertEquals("2012-12-21 00:00:00", rows.get(4));
 	}
 
 	@Test
@@ -193,15 +196,15 @@ public class ExcelSaxReadTest {
 				(i, i1, list) -> rows.add(StrUtil.toString(list.get(0)))
 		);
 
-		Assert.assertEquals("2020-10-09 00:00:00", rows.get(1));
+		Assertions.assertEquals("2020-10-09 00:00:00", rows.get(1));
 		// 非日期格式不做转换
-		Assert.assertEquals("112233", rows.get(2));
-		Assert.assertEquals("1000.0", rows.get(3));
-		Assert.assertEquals("2012-12-21 00:00:00", rows.get(4));
+		Assertions.assertEquals("112233", rows.get(2));
+		Assertions.assertEquals("1000.0", rows.get(3));
+		Assertions.assertEquals("2012-12-21 00:00:00", rows.get(4));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void dateReadXlsxTest2() {
 		ExcelUtil.readBySax("d:/test/custom_date_format2.xlsx", 0,
 				(i, i1, list) -> Console.log(list)
@@ -209,7 +212,7 @@ public class ExcelSaxReadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readBlankTest() {
 		File file = new File("D:/test/b.xlsx");
 
@@ -219,7 +222,7 @@ public class ExcelSaxReadTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readXlsmTest(){
 		ExcelUtil.readBySax("d:/test/WhiteListTemplate.xlsm", -1,
 				(sheetIndex, rowIndex, rowlist) -> Console.log("[{}] [{}] {}", sheetIndex, rowIndex, rowlist));

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelUtilTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelUtilTest.java
@@ -1,51 +1,51 @@
 package cn.hutool.poi.excel;
 
 import cn.hutool.poi.excel.cell.CellLocation;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 public class ExcelUtilTest {
 
 	@Test
 	public void indexToColNameTest() {
-		Assert.assertEquals("A", ExcelUtil.indexToColName(0));
-		Assert.assertEquals("B", ExcelUtil.indexToColName(1));
-		Assert.assertEquals("C", ExcelUtil.indexToColName(2));
+		Assertions.assertEquals("A", ExcelUtil.indexToColName(0));
+		Assertions.assertEquals("B", ExcelUtil.indexToColName(1));
+		Assertions.assertEquals("C", ExcelUtil.indexToColName(2));
 
-		Assert.assertEquals("AA", ExcelUtil.indexToColName(26));
-		Assert.assertEquals("AB", ExcelUtil.indexToColName(27));
-		Assert.assertEquals("AC", ExcelUtil.indexToColName(28));
+		Assertions.assertEquals("AA", ExcelUtil.indexToColName(26));
+		Assertions.assertEquals("AB", ExcelUtil.indexToColName(27));
+		Assertions.assertEquals("AC", ExcelUtil.indexToColName(28));
 
-		Assert.assertEquals("AAA", ExcelUtil.indexToColName(702));
-		Assert.assertEquals("AAB", ExcelUtil.indexToColName(703));
-		Assert.assertEquals("AAC", ExcelUtil.indexToColName(704));
+		Assertions.assertEquals("AAA", ExcelUtil.indexToColName(702));
+		Assertions.assertEquals("AAB", ExcelUtil.indexToColName(703));
+		Assertions.assertEquals("AAC", ExcelUtil.indexToColName(704));
 	}
 
 	@Test
 	public void colNameToIndexTest() {
-		Assert.assertEquals(704, ExcelUtil.colNameToIndex("AAC"));
-		Assert.assertEquals(703, ExcelUtil.colNameToIndex("AAB"));
-		Assert.assertEquals(702, ExcelUtil.colNameToIndex("AAA"));
+		Assertions.assertEquals(704, ExcelUtil.colNameToIndex("AAC"));
+		Assertions.assertEquals(703, ExcelUtil.colNameToIndex("AAB"));
+		Assertions.assertEquals(702, ExcelUtil.colNameToIndex("AAA"));
 
-		Assert.assertEquals(28, ExcelUtil.colNameToIndex("AC"));
-		Assert.assertEquals(27, ExcelUtil.colNameToIndex("AB"));
-		Assert.assertEquals(26, ExcelUtil.colNameToIndex("AA"));
+		Assertions.assertEquals(28, ExcelUtil.colNameToIndex("AC"));
+		Assertions.assertEquals(27, ExcelUtil.colNameToIndex("AB"));
+		Assertions.assertEquals(26, ExcelUtil.colNameToIndex("AA"));
 
-		Assert.assertEquals(2, ExcelUtil.colNameToIndex("C"));
-		Assert.assertEquals(1, ExcelUtil.colNameToIndex("B"));
-		Assert.assertEquals(0, ExcelUtil.colNameToIndex("A"));
+		Assertions.assertEquals(2, ExcelUtil.colNameToIndex("C"));
+		Assertions.assertEquals(1, ExcelUtil.colNameToIndex("B"));
+		Assertions.assertEquals(0, ExcelUtil.colNameToIndex("A"));
 	}
 
 	@Test
 	public void toLocationTest(){
 		final CellLocation a11 = ExcelUtil.toLocation("A11");
-		Assert.assertEquals(0, a11.getX());
-		Assert.assertEquals(10, a11.getY());
+		Assertions.assertEquals(0, a11.getX());
+		Assertions.assertEquals(10, a11.getY());
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void readAndWriteTest(){
 		ExcelReader reader = ExcelUtil.getReader("d:\\test/select.xls");
 		ExcelWriter writer = reader.getWriter();

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
@@ -22,8 +22,8 @@ import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.VerticalAlignment;
 import org.apache.poi.ss.util.CellRangeAddressList;
 import org.apache.poi.xssf.usermodel.XSSFRichTextString;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -58,7 +58,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void testRowOrColumnCellStyle() {
 		List<?> row1 = CollUtil.newArrayList("aaaaa", "bb", "cc", "dd", DateUtil.date(), 3.22676575765);
 		List<?> row2 = CollUtil.newArrayList("aa1", "bb1", "cc1", "dd1", DateUtil.date(), 250.7676);
@@ -102,7 +102,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest2() {
 		List<String> row = CollUtil.newArrayList("姓名", "加班日期", "下班时间", "加班时长", "餐补", "车补次数", "车补", "总计");
 		ExcelWriter overtimeWriter = ExcelUtil.getWriter("e:/excel/single_line.xlsx");
@@ -111,7 +111,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeWithSheetTest() {
 		ExcelWriter writer = ExcelUtil.getWriterWithSheet("表格1");
 
@@ -131,7 +131,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		List<?> row1 = CollUtil.newArrayList("aaaaa", "bb", "cc", "dd", DateUtil.date(), 3.22676575765);
 		List<?> row2 = CollUtil.newArrayList("aa1", "bb1", "cc1", "dd1", DateUtil.date(), 250.7676);
@@ -166,7 +166,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void mergeTest() {
 		List<?> row1 = CollUtil.newArrayList("aa", "bb", "cc", "dd", DateUtil.date(), 3.22676575765);
 		List<?> row2 = CollUtil.newArrayList("aa1", "bb1", "cc1", "dd1", DateUtil.date(), 250.7676);
@@ -196,7 +196,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void mergeTest2() {
 		Map<String, Object> row1 = new LinkedHashMap<>();
 		row1.put("姓名", "张三");
@@ -226,7 +226,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapTest() {
 		Map<String, Object> row1 = new LinkedHashMap<>();
 		row1.put("姓名", "张三");
@@ -263,7 +263,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapTest2() {
 		Map<String, Object> row1 = MapUtil.newHashMap(true);
 		row1.put("姓名", "张三");
@@ -282,7 +282,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapWithStyleTest() {
 		Map<String, Object> row1 = MapUtil.newHashMap(true);
 		row1.put("姓名", "张三");
@@ -309,7 +309,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapAliasTest() {
 		Map<Object, Object> row1 = new LinkedHashMap<>();
 		row1.put("name", "张三");
@@ -344,7 +344,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapOnlyAliasTest() {
 		Map<Object, Object> row1 = new LinkedHashMap<>();
 		row1.put("name", "张三");
@@ -377,7 +377,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapOnlyAliasTest2() {
 		Map<Object, Object> row1 = new LinkedHashMap<>();
 		row1.put("name", "张三");
@@ -407,7 +407,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapOnlyAliasTest3() {
 		Map<Object, Object> row1 = new LinkedHashMap<>();
 		row1.put("name", "张三");
@@ -441,7 +441,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeBeanTest() {
 		cn.hutool.poi.excel.TestBean bean1 = new cn.hutool.poi.excel.TestBean();
 		bean1.setName("张三");
@@ -477,7 +477,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeBeanTest2() {
 		cn.hutool.poi.excel.OrderExcel order1 = new cn.hutool.poi.excel.OrderExcel();
 		order1.setId("1");
@@ -505,7 +505,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeCellValueTest() {
 		ExcelWriter writer = new ExcelWriter("d:/cellValueTest.xls");
 		writer.writeCellValue(3, 5, "aaa");
@@ -514,7 +514,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void addSelectTest() {
 		List<String> row = CollUtil.newArrayList("姓名", "加班日期", "下班时间", "加班时长", "餐补", "车补次数", "车补", "总计");
 		ExcelWriter overtimeWriter = ExcelUtil.getWriter("d:/test/single_line.xlsx");
@@ -524,7 +524,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void addSelectTest2() {
 		ExcelWriter writer = ExcelUtil.getWriter("d:/test/select.xls");
 		writer.writeCellValue(0, 0, "请选择科目");
@@ -542,7 +542,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMultiSheetTest() {
 		List<Map<String, Object>> rows = new LinkedList<>();
 		for (int i = 0; i < 10; i++) {
@@ -577,7 +577,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMultiSheetTest2() {
 		List<Map<String, Object>> rows = new LinkedList<>();
 		final HashMap<String, Object> map = MapUtil.newHashMap();
@@ -601,7 +601,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMultiSheetWithStyleTest() {
 		ExcelWriter writer = ExcelUtil.getWriter("D:\\test\\multiSheetWithStyle.xlsx", "表格1");
 
@@ -632,7 +632,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapsTest() {
 		List<Map<String, Object>> rows = new ArrayList<>();
 
@@ -660,7 +660,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void formatTest() {
 		final ExcelWriter writer = ExcelUtil.getWriter("d:/test/formatTest.xlsx");
 		final CellStyle cellStyle = writer.createCellStyle(0, 0);
@@ -669,7 +669,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeNumberFormatTest() {
 		final ExcelWriter writer = ExcelUtil.getWriter("d:/test/formatTest.xlsx");
 		writer.disableDefaultStyle();
@@ -680,7 +680,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeSecHeadRowTest() {
 		List<?> row1 = CollUtil.newArrayList(1, "aa", "bb", "cc", "dd", "ee");
 		List<?> row2 = CollUtil.newArrayList(2, "aa1", "bb1", "cc1", "dd1", "ee1");
@@ -730,7 +730,7 @@ public class ExcelWriteTest {
 	 * 测试使用BigWriter写出，ExcelWriter修改失败
 	 */
 	@Test
-	@Ignore
+	@Disabled
 	public void editTest() {
 		// 生成文件
 		File file = new File("d:/test/100_.xlsx");
@@ -753,7 +753,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void mergeTest3(){
 		// https://github.com/dromara/hutool/issues/1696
 
@@ -783,7 +783,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void mergeForDateTest(){
 		// https://github.com/dromara/hutool/issues/1911
 
@@ -796,7 +796,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void changeHeaderStyleTest(){
 		final ExcelWriter writer = ExcelUtil.getWriter("d:/test/headerStyle.xlsx");
 		writer.writeHeadRow(ListUtil.of("姓名", "性别", "年龄"));
@@ -808,7 +808,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeFloatTest(){
 		//issue https://gitee.com/dromara/hutool/issues/I43U9G
 		String path = "d:/test/floatTest.xlsx";
@@ -820,7 +820,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void issueI466ZZTest(){
 		// https://gitee.com/dromara/hutool/issues/I466ZZ
 		// 需要输出S_20000314_x5116_0004
@@ -833,7 +833,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeLongTest(){
 		//https://gitee.com/dromara/hutool/issues/I49R6U
 		final ExcelWriter writer = ExcelUtil.getWriter("d:/test/long.xlsx");
@@ -842,7 +842,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeHyperlinkTest(){
 			final ExcelWriter writer = ExcelUtil.getWriter("d:/test/hyperlink.xlsx");
 
@@ -853,7 +853,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void mergeNumberTest(){
 		File tempFile=new File("d:/test/mergeNumber.xlsx");
 		FileUtil.del(tempFile);
@@ -864,7 +864,7 @@ public class ExcelWriteTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeImgTest() {
 		ExcelWriter writer = ExcelUtil.getWriter(true);
 

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/Issue1729Test.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/Issue1729Test.java
@@ -1,8 +1,8 @@
 package cn.hutool.poi.excel;
 
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -16,9 +16,9 @@ public class Issue1729Test {
 	public void readTest() {
 		final ExcelReader reader = ExcelUtil.getReader("UserProjectDO.xlsx");
 		final List<UserProjectDO> read = reader.read(0, 1, UserProjectDO.class);
-		Assert.assertEquals("aa", read.get(0).getProjectName());
-		Assert.assertNull(read.get(0).getEndTrainTime());
-		Assert.assertEquals("2020-02-02", read.get(0).getEndTestTime().toString());
+		Assertions.assertEquals("aa", read.get(0).getProjectName());
+		Assertions.assertNull(read.get(0).getEndTrainTime());
+		Assertions.assertEquals("2020-02-02", read.get(0).getEndTestTime().toString());
 	}
 
 	@Data

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/NumericCellValueTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/NumericCellValueTest.java
@@ -3,7 +3,7 @@ package cn.hutool.poi.excel;
 import cn.hutool.poi.excel.cell.values.NumericCellValue;
 import java.util.Date;
 import org.apache.poi.ss.usermodel.Cell;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NumericCellValueTest {
 

--- a/hutool-poi/src/test/java/cn/hutool/poi/ofd/OfdWriterTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/ofd/OfdWriterTest.java
@@ -1,13 +1,13 @@
 package cn.hutool.poi.ofd;
 
 import cn.hutool.core.io.FileUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class OfdWriterTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest(){
 		final OfdWriter ofdWriter = new OfdWriter(FileUtil.file("d:/test/test.ofd"));
 		ofdWriter.addText(null, "测试文本");

--- a/hutool-poi/src/test/java/cn/hutool/poi/word/WordWriterTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/word/WordWriterTest.java
@@ -5,8 +5,8 @@ import cn.hutool.core.collection.ListUtil;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.awt.Font;
 import java.io.File;
@@ -18,7 +18,7 @@ import java.util.Map;
 public class WordWriterTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTest() {
 		Word07Writer writer = new Word07Writer();
 		writer.addText(new Font("方正小标宋简体", Font.PLAIN, 22), "我是第一部分", "我是第二部分");
@@ -29,7 +29,7 @@ public class WordWriterTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writePicTest() {
 		Word07Writer writer = new Word07Writer();
 		writer.addPicture(new File("d:\\test\\qrcodeCustom.jpg"), 100, 200);
@@ -40,7 +40,7 @@ public class WordWriterTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeTableTest(){
 		final Word07Writer writer = new Word07Writer();
 		Map<String, Object> map = new LinkedHashMap<>();
@@ -54,7 +54,7 @@ public class WordWriterTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void writeMapAsTableTest() {
 		Word07Writer writer = new Word07Writer();
 

--- a/hutool-script/src/test/java/cn/hutool/script/test/NashornDeepTest.java
+++ b/hutool-script/src/test/java/cn/hutool/script/test/NashornDeepTest.java
@@ -2,7 +2,7 @@ package cn.hutool.script.test;
 
 
 import cn.hutool.core.io.resource.ResourceUtil;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
@@ -17,6 +17,6 @@ public class NashornDeepTest {
 		engine.eval(ResourceUtil.readUtf8Str("filter1.js"));
 
 		final Object filter1 = ((Invocable) engine).invokeFunction("filter1", 1, 2);
-		Assert.assertFalse((Boolean) filter1);
+		Assertions.assertFalse((Boolean) filter1);
 	}
 }

--- a/hutool-script/src/test/java/cn/hutool/script/test/ScriptUtilTest.java
+++ b/hutool-script/src/test/java/cn/hutool/script/test/ScriptUtilTest.java
@@ -3,8 +3,8 @@ package cn.hutool.script.test;
 import cn.hutool.core.io.resource.ResourceUtil;
 import cn.hutool.script.ScriptRuntimeException;
 import cn.hutool.script.ScriptUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.script.CompiledScript;
 import javax.script.ScriptEngine;
@@ -12,7 +12,7 @@ import javax.script.ScriptException;
 
 /**
  * 脚本单元测试类
- * 
+ *
  * @author looly
  *
  */
@@ -36,7 +36,7 @@ public class ScriptUtilTest {
 	@Test
 	public void invokeTest() {
 		final Object result = ScriptUtil.invoke(ResourceUtil.readUtf8Str("filter1.js"), "filter1", 2, 1);
-		Assert.assertTrue((Boolean) result);
+		Assertions.assertTrue((Boolean) result);
 	}
 
 	@Test

--- a/hutool-setting/src/test/java/cn/hutool/setting/PropsTest.java
+++ b/hutool-setting/src/test/java/cn/hutool/setting/PropsTest.java
@@ -5,10 +5,10 @@ import cn.hutool.log.LogFactory;
 import cn.hutool.log.dialect.console.ConsoleLogFactory;
 import cn.hutool.setting.dialect.Props;
 import lombok.Data;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
@@ -23,8 +23,8 @@ import java.util.Objects;
  */
 public class PropsTest {
 
-	@Before
-	public void init() {
+	@BeforeAll
+	static void init() {
 		LogFactory.setCurrentLogFactory(ConsoleLogFactory.class);
 	}
 
@@ -33,22 +33,22 @@ public class PropsTest {
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		Props props = new Props("test.properties");
 		String user = props.getProperty("user");
-		Assert.assertEquals(user, "root");
+		Assertions.assertEquals(user, "root");
 
 		String driver = props.getStr("driver");
-		Assert.assertEquals(driver, "com.mysql.jdbc.Driver");
+		Assertions.assertEquals(driver, "com.mysql.jdbc.Driver");
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void propTestForAbsPAth() {
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		Props props = new Props("d:/test.properties");
 		String user = props.getProperty("user");
-		Assert.assertEquals(user, "root");
+		Assertions.assertEquals(user, "root");
 
 		String driver = props.getStr("driver");
-		Assert.assertEquals(driver, "com.mysql.jdbc.Driver");
+		Assertions.assertEquals(driver, "com.mysql.jdbc.Driver");
 	}
 
 	@Test
@@ -56,19 +56,19 @@ public class PropsTest {
 		Props props = Props.getProp("to_bean_test.properties");
 
 		ConfigProperties cfg = props.toBean(ConfigProperties.class, "mail");
-		Assert.assertEquals("mailer@mail.com", cfg.getHost());
-		Assert.assertEquals(9000, cfg.getPort());
-		Assert.assertEquals("mailer@mail.com", cfg.getFrom());
+		Assertions.assertEquals("mailer@mail.com", cfg.getHost());
+		Assertions.assertEquals(9000, cfg.getPort());
+		Assertions.assertEquals("mailer@mail.com", cfg.getFrom());
 
-		Assert.assertEquals("john", cfg.getCredentials().getUsername());
-		Assert.assertEquals("password", cfg.getCredentials().getPassword());
-		Assert.assertEquals("SHA1", cfg.getCredentials().getAuthMethod());
+		Assertions.assertEquals("john", cfg.getCredentials().getUsername());
+		Assertions.assertEquals("password", cfg.getCredentials().getPassword());
+		Assertions.assertEquals("SHA1", cfg.getCredentials().getAuthMethod());
 
-		Assert.assertEquals("true", cfg.getAdditionalHeaders().get("redelivery"));
-		Assert.assertEquals("true", cfg.getAdditionalHeaders().get("secure"));
+		Assertions.assertEquals("true", cfg.getAdditionalHeaders().get("redelivery"));
+		Assertions.assertEquals("true", cfg.getAdditionalHeaders().get("secure"));
 
-		Assert.assertEquals("admin@mail.com", cfg.getDefaultRecipients().get(0));
-		Assert.assertEquals("owner@mail.com", cfg.getDefaultRecipients().get(1));
+		Assertions.assertEquals("admin@mail.com", cfg.getDefaultRecipients().get(0));
+		Assertions.assertEquals("owner@mail.com", cfg.getDefaultRecipients().get(1));
 	}
 
 	@Test
@@ -82,11 +82,11 @@ public class PropsTest {
 		configProp.setProperty("version", 3);
 		SystemConfig systemConfig = configProp.toBean(SystemConfig.class);
 
-		Assert.assertEquals(DateUtil.parse("2020-01-01"), systemConfig.getCreateTime());
-		Assert.assertEquals(true, systemConfig.getIsInit());
-		Assert.assertEquals("1", systemConfig.getStairPlan());
-		Assert.assertEquals(new Integer(2), systemConfig.getStageNum());
-		Assert.assertEquals("3", systemConfig.getVersion());
+		Assertions.assertEquals(DateUtil.parse("2020-01-01"), systemConfig.getCreateTime());
+		Assertions.assertEquals(true, systemConfig.getIsInit());
+		Assertions.assertEquals("1", systemConfig.getStairPlan());
+		Assertions.assertEquals(new Integer(2), systemConfig.getStageNum());
+		Assertions.assertEquals("3", systemConfig.getVersion());
 	}
 
 	@Data

--- a/hutool-setting/src/test/java/cn/hutool/setting/PropsTest.java
+++ b/hutool-setting/src/test/java/cn/hutool/setting/PropsTest.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 public class PropsTest {
 
 	@BeforeAll
-	static void init() {
+	public static void init() {
 		LogFactory.setCurrentLogFactory(ConsoleLogFactory.class);
 	}
 

--- a/hutool-setting/src/test/java/cn/hutool/setting/PropsUtilTest.java
+++ b/hutool-setting/src/test/java/cn/hutool/setting/PropsUtilTest.java
@@ -1,8 +1,8 @@
 package cn.hutool.setting;
 
 import cn.hutool.setting.dialect.PropsUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
 
@@ -11,12 +11,12 @@ public class PropsUtilTest {
 	@Test
 	public void getTest() {
 		String driver = PropsUtil.get("test").getStr("driver");
-		Assert.assertEquals("com.mysql.jdbc.Driver", driver);
+		Assertions.assertEquals("com.mysql.jdbc.Driver", driver);
 	}
 
 	@Test
 	public void getFirstFoundTest() {
 		String driver = Objects.requireNonNull(PropsUtil.getFirstFound("test2", "test")).getStr("driver");
-		Assert.assertEquals("com.mysql.jdbc.Driver", driver);
+		Assertions.assertEquals("com.mysql.jdbc.Driver", driver);
 	}
 }

--- a/hutool-setting/src/test/java/cn/hutool/setting/SettingTest.java
+++ b/hutool-setting/src/test/java/cn/hutool/setting/SettingTest.java
@@ -1,9 +1,9 @@
 package cn.hutool.setting;
 
 import cn.hutool.core.lang.Console;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * Setting单元测试
@@ -18,23 +18,23 @@ public class SettingTest {
 		Setting setting = new Setting("test.setting", true);
 
 		String driver = setting.getByGroup("driver", "demo");
-		Assert.assertEquals("com.mysql.jdbc.Driver", driver);
+		Assertions.assertEquals("com.mysql.jdbc.Driver", driver);
 
 		//本分组变量替换
 		String user = setting.getByGroup("user", "demo");
-		Assert.assertEquals("rootcom.mysql.jdbc.Driver", user);
+		Assertions.assertEquals("rootcom.mysql.jdbc.Driver", user);
 
 		//跨分组变量替换
 		String user2 = setting.getByGroup("user2", "demo");
-		Assert.assertEquals("rootcom.mysql.jdbc.Driver", user2);
+		Assertions.assertEquals("rootcom.mysql.jdbc.Driver", user2);
 
 		//默认值测试
 		String value = setting.getStr("keyNotExist", "defaultTest");
-		Assert.assertEquals("defaultTest", value);
+		Assertions.assertEquals("defaultTest", value);
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void settingTestForAbsPath() {
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		Setting setting = new Setting("d:\\excel-plugin\\other.setting", true);
@@ -50,10 +50,10 @@ public class SettingTest {
 		setting.setByGroup("user", "group3", "root3");
 		setting.set("user", "root4");
 
-		Assert.assertEquals("root", setting.getByGroup("user", "group1"));
-		Assert.assertEquals("root2", setting.getByGroup("user", "group2"));
-		Assert.assertEquals("root3", setting.getByGroup("user", "group3"));
-		Assert.assertEquals("root4", setting.get("user"));
+		Assertions.assertEquals("root", setting.getByGroup("user", "group1"));
+		Assertions.assertEquals("root2", setting.getByGroup("user", "group2"));
+		Assertions.assertEquals("root3", setting.getByGroup("user", "group3"));
+		Assertions.assertEquals("root4", setting.get("user"));
 	}
 
 	/**

--- a/hutool-setting/src/test/java/cn/hutool/setting/SettingUtilTest.java
+++ b/hutool-setting/src/test/java/cn/hutool/setting/SettingUtilTest.java
@@ -1,20 +1,20 @@
 package cn.hutool.setting;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SettingUtilTest {
 
 	@Test
 	public void getTest() {
 		String driver = SettingUtil.get("test").get("demo", "driver");
-		Assert.assertEquals("com.mysql.jdbc.Driver", driver);
+		Assertions.assertEquals("com.mysql.jdbc.Driver", driver);
 	}
 
 	@Test
 	public void getTest2() {
 		String driver = SettingUtil.get("example/example").get("demo", "key");
-		Assert.assertEquals("value", driver);
+		Assertions.assertEquals("value", driver);
 	}
 
 	@Test
@@ -22,6 +22,6 @@ public class SettingUtilTest {
 		//noinspection ConstantConditions
 		String driver = SettingUtil.getFirstFound("test2", "test")
 				.get("demo", "driver");
-		Assert.assertEquals("com.mysql.jdbc.Driver", driver);
+		Assertions.assertEquals("com.mysql.jdbc.Driver", driver);
 	}
 }

--- a/hutool-setting/src/test/java/cn/hutool/setting/yaml/YamlUtilTest.java
+++ b/hutool-setting/src/test/java/cn/hutool/setting/yaml/YamlUtilTest.java
@@ -3,9 +3,9 @@ package cn.hutool.setting.yaml;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Dict;
 import cn.hutool.core.util.CharsetUtil;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -15,15 +15,15 @@ public class YamlUtilTest {
 	public void loadByPathTest() {
 		final Dict result = YamlUtil.loadByPath("test.yaml");
 
-		Assert.assertEquals("John", result.getStr("firstName"));
+		Assertions.assertEquals("John", result.getStr("firstName"));
 
 		final List<Integer> numbers = result.getByPath("contactDetails.number");
-		Assert.assertEquals(123456789, (int) numbers.get(0));
-		Assert.assertEquals(456786868, (int) numbers.get(1));
+		Assertions.assertEquals(123456789, (int) numbers.get(0));
+		Assertions.assertEquals(456786868, (int) numbers.get(1));
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void dumpTest() {
 		final Dict dict = Dict.create()
 				.set("name", "hutool")

--- a/hutool-system/src/test/java/cn/hutool/system/OshiPrintTest.java
+++ b/hutool-system/src/test/java/cn/hutool/system/OshiPrintTest.java
@@ -2,14 +2,14 @@ package cn.hutool.system;
 
 import cn.hutool.core.lang.Console;
 import cn.hutool.system.oshi.OshiUtil;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore
+@Disabled
 public class OshiPrintTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void printCpuInfo(){
 		Console.log(OshiUtil.getCpuInfo());
 	}

--- a/hutool-system/src/test/java/cn/hutool/system/OshiTest.java
+++ b/hutool-system/src/test/java/cn/hutool/system/OshiTest.java
@@ -2,8 +2,8 @@ package cn.hutool.system;
 
 import cn.hutool.system.oshi.CpuInfo;
 import cn.hutool.system.oshi.OshiUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import oshi.software.os.OSProcess;
 
 /**
@@ -14,18 +14,18 @@ public class OshiTest {
 	@Test
 	public void getMemoryTest() {
 		long total = OshiUtil.getMemory().getTotal();
-		Assert.assertTrue(total > 0);
+		Assertions.assertTrue(total > 0);
 	}
 
 	@Test
 	public void getCupInfo() {
 		CpuInfo cpuInfo = OshiUtil.getCpuInfo();
-		Assert.assertNotNull(cpuInfo);
+		Assertions.assertNotNull(cpuInfo);
 	}
 
 	@Test
 	public void getCurrentProcessTest() {
 		final OSProcess currentProcess = OshiUtil.getCurrentProcess();
-		Assert.assertEquals("java", currentProcess.getName());
+		Assertions.assertEquals("java", currentProcess.getName());
 	}
 }

--- a/hutool-system/src/test/java/cn/hutool/system/SystemUtilTest.java
+++ b/hutool-system/src/test/java/cn/hutool/system/SystemUtilTest.java
@@ -1,15 +1,15 @@
 package cn.hutool.system;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
 public class SystemUtilTest {
 
 	@Test
-	@Ignore
+	@Disabled
 	public void dumpTest() {
 		SystemUtil.dumpSystemInfo();
 	}
@@ -17,37 +17,37 @@ public class SystemUtilTest {
 	@Test
 	public void getCurrentPidTest() {
 		long pid = SystemUtil.getCurrentPID();
-		Assert.assertTrue(pid > 0);
+		Assertions.assertTrue(pid > 0);
 	}
 
 	@Test
 	public void getJavaInfoTest() {
 		JavaInfo javaInfo = SystemUtil.getJavaInfo();
-		Assert.assertNotNull(javaInfo);
+		Assertions.assertNotNull(javaInfo);
 	}
 
 	@Test
 	public void getJavaRuntimeInfoTest() {
 		JavaRuntimeInfo info = SystemUtil.getJavaRuntimeInfo();
-		Assert.assertNotNull(info);
+		Assertions.assertNotNull(info);
 	}
 
 	@Test
 	public void getOsInfoTest() {
 		OsInfo osInfo = SystemUtil.getOsInfo();
-		Assert.assertNotNull(osInfo);
+		Assertions.assertNotNull(osInfo);
 	}
 
 	@Test
 	public void getHostInfo() {
 		HostInfo hostInfo = SystemUtil.getHostInfo();
-		Assert.assertNotNull(hostInfo);
+		Assertions.assertNotNull(hostInfo);
 	}
 
 	@Test
 	public void getUserInfoTest(){
 		// https://gitee.com/dromara/hutool/issues/I3NM39
 		final UserInfo userInfo = SystemUtil.getUserInfo();
-		Assert.assertTrue(userInfo.getTempDir().endsWith(File.separator));
+		Assertions.assertTrue(userInfo.getTempDir().endsWith(File.separator));
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -43,16 +43,32 @@
 
 		<!-- versions -->
 		<compile.version>8</compile.version>
-		<junit.version>4.13.2</junit.version>
+		<junit.version>5.8.2</junit.version>
 		<lombok.version>1.18.22</lombok.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<!-- 全局单元测试 -->
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -97,6 +113,7 @@
 				<configuration>
 					<source>${compile.version}</source>
 					<target>${compile.version}</target>
+					<parameters>true</parameters>
 				</configuration>
 			</plugin>
 			<!-- Javadoc -->
@@ -113,7 +130,16 @@
 					</execution>
 				</executions>
 			</plugin>
-
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.22.2</version>
+				<configuration>
+					<systemPropertyVariables>
+						<user.timezone>Asia/Shanghai</user.timezone>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.1.1</version>
+				<configuration>
+					<failOnError>false</failOnError>
+					<failOnWarnings>false</failOnWarnings>
+				</configuration>
 				<executions>
 					<execution>
 						<phase>package</phase>


### PR DESCRIPTION
### `Junit4` 替换为 `Junit5`

1. `@org.junit.Test` -> `@org.junit.jupiter.api.Test`
2. `org.junit.Assert` -> `org.junit.jupiter.api.Assertions`
3. `@Ignore` -> `@Disabled`
4. `@Before` -> `@BeforeEach`
5. `@BeforeClass` -> `@BeforeAll`
6. `@Test(expected = XxxException.class)` -> `Assertions.assertThrows(XxxException.class, () -> {  ...  })`

---

### `Junit5` 拥有更多新特性（当前PR并未使用这些特性）

1. `@DisabledOnJre`: 指定在某些版本的JDK时，不执行测试。
2. `@EnabledOnJre`: 指定在某些版本的JDK时，才执行测试。
3. ...等等