### PR TITLE
修复NumberUtil.equals重载方法缺少long类型时候,自动转换为float精度丢失,出现问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -1835,6 +1835,18 @@ public class NumberUtil {
 
 	/**
 	 * 比较大小，值相等 返回true<br>
+	 * 此方法修复传入long型数据由于没有本类型重载方法,导致数据精度丢失
+	 * @param num1 数字1
+	 * @param num2 数字2
+	 * @return 是否相等
+	 * @since 5.7.19
+	 */
+	public static boolean equals(long num1, long num2) {
+		return num1 == num2;
+	}
+
+	/**
+	 * 比较大小，值相等 返回true<br>
 	 * 此方法通过调用{@link BigDecimal#compareTo(BigDecimal)}方法来判断是否相等<br>
 	 * 此方法判断值相等时忽略精度的，即0.00 == 0
 	 *


### PR DESCRIPTION

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] [https://gitee.com/dromara/hutool/issues/I4P6YN#note_8146495](url)
java规定的转换是
`char->int->long->float->double`
由于NumberUtil.equals 没有long型重载,所以默认为`NumberUtil.equals(float num1,float num2)`
long转float 可能会有精度丢失
```java
        System.out.println((float) 20220103L);
        System.out.println((float) 20220104L);

        2.0220104E7
        2.0220104E7

```
