### PR TITLE
修复 `CsvParser` 行号有误 的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvParser.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvParser.java
@@ -264,7 +264,7 @@ public final class CsvParser extends ComputeIter<CsvRow> implements Closeable, S
 					inQuotes = false;
 				} else {
 					// 字段内容中新行
-					if (isLineEnd(c)) {
+					if (isLineEnd(c, preChar)) {
 						inQuotesLineCount++;
 					}
 				}
@@ -350,11 +350,13 @@ public final class CsvParser extends ComputeIter<CsvRow> implements Closeable, S
 
 	/**
 	 * 是否行结束符
-	 * @param c 符号
+	 *
+	 * @param c       符号
+	 * @param preChar 前一个字符
 	 * @return 是否结束
 	 * @since 5.7.4
 	 */
-	private boolean isLineEnd(char c){
+	private boolean isLineEnd(char c, int preChar) {
 		return (c == CharUtil.CR || c == CharUtil.LF) && preChar != CharUtil.CR;
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
@@ -133,7 +133,7 @@ public class CsvReaderTest {
 		Assert.assertEquals("a,b,c,d", CollUtil.join(data.getRow(0), ","));
 
 		Assert.assertEquals(4, data.getRow(2).getOriginalLineNumber());
-		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(2), ","));
+		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(2), ",").replace("\r", ""));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
 		Assert.assertEquals(6, data.getRow(3).getOriginalLineNumber());
@@ -150,7 +150,7 @@ public class CsvReaderTest {
 		Assert.assertEquals("1,2,3,4", CollUtil.join(data.getRow(0), ","));
 
 		Assert.assertEquals(4, data.getRow(1).getOriginalLineNumber());
-		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(1), ","));
+		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(1), ",").replace("\r", ""));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
 		Assert.assertEquals(6, data.getRow(2).getOriginalLineNumber());
@@ -164,7 +164,7 @@ public class CsvReaderTest {
 		CsvData data = reader.read(ResourceUtil.getReader("test_lines.csv", CharsetUtil.CHARSET_UTF_8));
 
 		Assert.assertEquals(4, data.getRow(0).getOriginalLineNumber());
-		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(0), ","));
+		Assert.assertEquals("q,w,e,r,我是一段\n带换行的内容", CollUtil.join(data.getRow(0), ",").replace("\r", ""));
 
 		// 文件中第3行数据，对应原始行号是6（从0开始）
 		Assert.assertEquals(6, data.getRow(1).getOriginalLineNumber());


### PR DESCRIPTION
修复 `CsvParser`问题：当上一行特殊分隔符为 `\r`，当前行数据中存在双引号，且双引号内含有 `\r` 或 `\n` 时，此时 `inQuotesLineCount` 不会自增1，导致后面所有行的行号 `originalLineNumber` 有误。