### PR TITLE
fix Calculator.conversion EmptyStackException bug

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/math/Calculator.java
+++ b/hutool-core/src/main/java/cn/hutool/core/math/Calculator.java
@@ -191,7 +191,7 @@ public class Calculator {
 				}
 			}
 		}
-		if (arr[0] == '~' || (arr.length > 1 && arr[1] == '(')) {
+		if (arr[0] == '~' && (arr.length > 1 && arr[1] == '(')) {
 			arr[0] = '-';
 			return "0" + new String(arr);
 		} else {

--- a/hutool-core/src/test/java/cn/hutool/core/math/CalculatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/CalculatorTest.java
@@ -31,10 +31,15 @@ public class CalculatorTest {
 	}
 
 	@Test
-	@Ignore
 	public void conversationTest5(){
 		// https://github.com/dromara/hutool/issues/1984
 		final double conversion = Calculator.conversion("((1/1) / (1/1) -1) * 100");
-		Assert.assertEquals((88D * 66 / 23) % 26, conversion, 2);
+		Assert.assertEquals(0, conversion, 2);
+	}
+
+	@Test
+	public void conversationTest6() {
+		final double conversion = Calculator.conversion("-((2.12-2) * 100)");
+		Assert.assertEquals(-1D * (2.12 - 2) * 100, conversion, 2);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 已提交代码至'v5-dev'分支
2. 没有更改代码风格
3. 已添加新的单元测试

### 修改描述

1. [bug修复] 关于Calculator.conversion() 方法在((1/1) / (1/1) -1) * 100样例中出现EmptyStackException的bug