### PR TITLE
feat(core:DateUtil): add `rangeFunc` and `rangeConsume`

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -20,14 +20,10 @@ import java.time.LocalDateTime;
 import java.time.Year;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * 时间工具类
@@ -1883,6 +1879,54 @@ public class DateUtil extends CalendarUtil {
 	 */
 	public static DateRange range(Date start, Date end, final DateField unit) {
 		return new DateRange(start, end, unit);
+	}
+
+	/**
+	 * 按日期范围遍历，执行 function
+	 *
+	 * @param start 起始日期时间（包括）
+	 * @param end   结束日期时间
+	 * @param unit  步进单位
+	 * @param func  每次遍历要执行的 function
+	 * @param <T>
+	 * @return
+	 */
+	public static <T> List<T> rangeFunc(Date start, Date end, final DateField unit, Function<Date, T> func) {
+		if (start == null || end == null || start.after(end)) {
+			return Collections.emptyList();
+		} else {
+			ArrayList<T> list = new ArrayList<>();
+			DateRange dateRange = range(start, end, unit);
+			while (dateRange.hasNext()) {
+				DateTime next = dateRange.next();
+				Date date = next.toJdkDate();
+				T result = func.apply(date);
+				list.add(result);
+			}
+			return list;
+		}
+	}
+
+	/**
+	 * 按日期范围遍历，执行 consumer
+	 *
+	 * @param start    起始日期时间（包括）
+	 * @param end      结束日期时间
+	 * @param unit     步进单位
+	 * @param consumer 每次遍历要执行的 consumer
+	 * @return
+	 */
+	public static void rangeConsume(Date start, Date end, final DateField unit, Consumer<Date> consumer) {
+		if (start == null || end == null || start.after(end)) {
+			return;
+		} else {
+			DateRange dateRange = range(start, end, unit);
+			while (dateRange.hasNext()) {
+				DateTime next = dateRange.next();
+				Date date = next.toJdkDate();
+				consumer.accept(date);
+			}
+		}
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/lang/RangeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/RangeTest.java
@@ -37,6 +37,32 @@ public class RangeTest {
 	}
 
 	@Test
+	public void dateRangeFuncTest() {
+		DateTime start = DateUtil.parse("2021-01-01");
+		DateTime end = DateUtil.parse("2021-01-03");
+
+		List<Integer> dayOfMonthList = DateUtil.rangeFunc(start, end, DateField.DAY_OF_YEAR, a -> DateTime.of(a).dayOfMonth());
+		Assert.assertArrayEquals(dayOfMonthList.toArray(new Integer[]{}), new Integer[]{1, 2, 3});
+
+		List<Integer> dayOfMonthList2 = DateUtil.rangeFunc(null, null, DateField.DAY_OF_YEAR, a -> DateTime.of(a).dayOfMonth());
+		Assert.assertArrayEquals(dayOfMonthList2.toArray(new Integer[]{}), new Integer[]{});
+	}
+
+	@Test
+	public void dateRangeConsumeTest() {
+		DateTime start = DateUtil.parse("2021-01-01");
+		DateTime end = DateUtil.parse("2021-01-03");
+
+		StringBuilder sb = new StringBuilder();
+		DateUtil.rangeConsume(start, end, DateField.DAY_OF_YEAR, a -> sb.append(DateTime.of(a).dayOfMonth()).append("#"));
+		Assert.assertEquals(sb.toString(), "1#2#3#");
+
+		StringBuilder sb2 = new StringBuilder();
+		DateUtil.rangeConsume(null, null, DateField.DAY_OF_YEAR, a -> sb.append(DateTime.of(a).dayOfMonth()).append("#"));
+		Assert.assertEquals(sb2.toString(), "");
+	}
+
+	@Test
 	public void dateRangeTest2() {
 		DateTime start = DateUtil.parse("2021-01-31");
 		DateTime end = DateUtil.parse("2021-03-31");


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

[新特性] add `rangeFunc` and `rangeConsume` in DateUtil

caller just want to loop execute some process within a date range, do not need to iterate manually.

follow the [Principle of Least Knowledge](https://zh.wikipedia.org/wiki/%E6%9C%80%E5%B0%8F%E6%9D%83%E9%99%90%E5%8E%9F%E5%88%99), 
`cn.hutool.core.date.DateRange` do not need to expose to caller code,
which can reduce user's mind cost and avoid potential risks like modification to `DateRange`.

