### PR TITLE
修正测试用例

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/collection/ListUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/ListUtilTest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class ListUtilTest {
 
 	@Test
-	public void splitTest(){
+	public void splitTest() {
 		List<List<Object>> lists = ListUtil.split(null, 3);
 		Assert.assertEquals(ListUtil.empty(), lists);
 
@@ -60,7 +60,7 @@ public class ListUtilTest {
 	}
 
 	@Test
-	public void splitAvgTest(){
+	public void splitAvgTest() {
 		List<List<Object>> lists = ListUtil.splitAvg(null, 3);
 		Assert.assertEquals(ListUtil.empty(), lists);
 
@@ -80,13 +80,13 @@ public class ListUtilTest {
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void splitAvgNotZero(){
+	public void splitAvgNotZero() {
 		// limit不能小于等于0
 		ListUtil.splitAvg(Arrays.asList(1, 2, 3, 4), 0);
 	}
 
 	@Test
-	public void editTest(){
+	public void editTest() {
 		List<String> a = ListUtil.toLinkedList("1", "2", "3");
 		final List<String> filter = (List<String>) CollUtil.edit(a, str -> "edit" + str);
 		Assert.assertEquals("edit1", filter.get(0));
@@ -104,7 +104,7 @@ public class ListUtilTest {
 	}
 
 	@Test
-	public void pageTest(){
+	public void pageTest() {
 		List<Integer> a = ListUtil.toLinkedList(1, 2, 3,4,5);
 
 		PageUtil.setFirstPageNo(1);
@@ -167,10 +167,13 @@ public class ListUtilTest {
 		Assert.assertArrayEquals(new int[]{}, pageListData.get(0).stream().mapToInt(Integer::valueOf).toArray());
 		Assert.assertArrayEquals(new int[]{3, 4}, pageListData.get(1).stream().mapToInt(Integer::valueOf).toArray());
 		Assert.assertArrayEquals(new int[]{5}, pageListData.get(2).stream().mapToInt(Integer::valueOf).toArray());
+
+		// 恢复默认值，避免影响其他测试用例
+		PageUtil.setFirstPageNo(0);
 	}
 
 	@Test
-	public void subTest(){
+	public void subTest() {
 		final List<Integer> of = ListUtil.of(1, 2, 3, 4);
 		final List<Integer> sub = ListUtil.sub(of, 2, 4);
 		sub.remove(0);
@@ -181,10 +184,10 @@ public class ListUtilTest {
 	}
 
 	@Test
-	public void sortByPropertyTest(){
+	public void sortByPropertyTest() {
 		@Data
 		@AllArgsConstructor
-		class TestBean{
+		class TestBean {
 			private int order;
 			private String name;
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -202,19 +202,19 @@ public class LocalDateTimeUtilTest {
 	public void weekOfYearTest(){
 		LocalDate date1 = LocalDate.of(2021, 12, 31);
 		final int weekOfYear1 = LocalDateTimeUtil.weekOfYear(date1);
-		Assert.assertEquals(weekOfYear1, 52);
+		Assert.assertEquals(52, weekOfYear1);
 
 		final int weekOfYear2 = LocalDateTimeUtil.weekOfYear(date1.atStartOfDay());
-		Assert.assertEquals(weekOfYear2, 52);
+		Assert.assertEquals(52, weekOfYear2);
 	}
 
 	@Test
 	public void weekOfYearTest2(){
 		LocalDate date1 = LocalDate.of(2022, 1, 31);
 		final int weekOfYear1 = LocalDateTimeUtil.weekOfYear(date1);
-		Assert.assertEquals(weekOfYear1, 5);
+		Assert.assertEquals(5, weekOfYear1);
 
 		final int weekOfYear2 = LocalDateTimeUtil.weekOfYear(date1.atStartOfDay());
-		Assert.assertEquals(weekOfYear2, 5);
+		Assert.assertEquals(5, weekOfYear2);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -212,9 +212,9 @@ public class LocalDateTimeUtilTest {
 	public void weekOfYearTest2(){
 		LocalDate date1 = LocalDate.of(2022, 1, 31);
 		final int weekOfYear1 = LocalDateTimeUtil.weekOfYear(date1);
-		Assert.assertEquals(weekOfYear1, 52);
+		Assert.assertEquals(weekOfYear1, 5);
 
 		final int weekOfYear2 = LocalDateTimeUtil.weekOfYear(date1.atStartOfDay());
-		Assert.assertEquals(weekOfYear2, 52);
+		Assert.assertEquals(weekOfYear2, 5);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvWriterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvWriterTest.java
@@ -2,6 +2,7 @@ package cn.hutool.core.text.csv;
 
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.util.CharsetUtil;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class CsvWriterTest {

--- a/hutool-core/src/test/java/cn/hutool/core/util/PageUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/PageUtilTest.java
@@ -5,32 +5,31 @@ import org.junit.Test;
 
 /**
  * 分页单元测试
- * @author Looly
  *
+ * @author Looly
  */
 public class PageUtilTest {
-	
+
 	@Test
-	public void transToStartEndTest(){
-		PageUtil.setFirstPageNo(0);
+	public void transToStartEndTest() {
 		int[] startEnd1 = PageUtil.transToStartEnd(0, 10);
 		Assert.assertEquals(0, startEnd1[0]);
 		Assert.assertEquals(10, startEnd1[1]);
-		
+
 		int[] startEnd2 = PageUtil.transToStartEnd(1, 10);
 		Assert.assertEquals(10, startEnd2[0]);
 		Assert.assertEquals(20, startEnd2[1]);
 	}
-	
+
 	@Test
-	public void totalPage(){
+	public void totalPage() {
 		int totalPage = PageUtil.totalPage(20, 3);
 		Assert.assertEquals(7, totalPage);
 	}
-	
+
 	@Test
 	public void rainbowTest() {
 		int[] rainbow = PageUtil.rainbow(5, 20, 6);
-		Assert.assertArrayEquals(new int[] {3, 4, 5, 6, 7, 8}, rainbow);
+		Assert.assertArrayEquals(new int[]{3, 4, 5, 6, 7, 8}, rainbow);
 	}
 }


### PR DESCRIPTION
1、缺少 `import org.junit.Ignore;`。
2、`weekOfYear` 测试用例有误，且预期值和实际值参数传反了。
3、`ListUtilTest.pageTest()` 测试后，因 `PageUtil.firstPageNo` 值变成 `2` 导致其他测试用例运行失败。