### PR TITLE
remove duplicated code for `SpringUtil.publishEvent`

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
@@ -259,13 +259,13 @@ public class SpringUtil implements BeanFactoryPostProcessor, ApplicationContextA
 	/**
 	 * 发布事件
 	 *
+	 * Note: 从 Spring 4.2 起，{@link org.springframework.context.ApplicationEventPublisher#publishEvent} 新增了对 Object 的重载方法，保留此方法为了兼容之前版本。
+	 *
 	 * @param event 待发布的事件，事件必须是{@link ApplicationEvent}的子类
 	 * @since 5.7.12
 	 */
 	public static void publishEvent(ApplicationEvent event) {
-		if (null != applicationContext) {
-			applicationContext.publishEvent(event);
-		}
+		publishEvent((Object) event);
 	}
 
 	/**

--- a/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
@@ -264,6 +264,7 @@ public class SpringUtil implements BeanFactoryPostProcessor, ApplicationContextA
 	 * @param event 待发布的事件，事件必须是{@link ApplicationEvent}的子类
 	 * @since 5.7.12
 	 */
+	@Deprecated
 	public static void publishEvent(ApplicationEvent event) {
 		publishEvent((Object) event);
 	}

--- a/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
@@ -258,19 +258,6 @@ public class SpringUtil implements BeanFactoryPostProcessor, ApplicationContextA
 
 	/**
 	 * 发布事件
-	 *
-	 * Note: 从 Spring 4.2 起，{@link org.springframework.context.ApplicationEventPublisher#publishEvent} 新增了对 Object 的重载方法，保留此方法为了兼容之前版本。
-	 *
-	 * @param event 待发布的事件，事件必须是{@link ApplicationEvent}的子类
-	 * @since 5.7.12
-	 */
-	@Deprecated
-	public static void publishEvent(ApplicationEvent event) {
-		publishEvent((Object) event);
-	}
-
-	/**
-	 * 发布事件
 	 * Spring 4.2+ 版本事件可以不再是{@link ApplicationEvent}的子类
 	 *
 	 * @param event 待发布的事件

--- a/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/spring/SpringUtil.java
@@ -258,7 +258,10 @@ public class SpringUtil implements BeanFactoryPostProcessor, ApplicationContextA
 
 	/**
 	 * 发布事件
-	 * Spring 4.2+ 版本事件可以不再是{@link ApplicationEvent}的子类
+	 *
+	 * <p>
+	 * 此方法会做非空检查，从 Spring 4.2 起，发布事件参数支持 Object 类型
+	 * </p>
 	 *
 	 * @param event 待发布的事件
 	 * @since 5.7.21


### PR DESCRIPTION
从 Spring 4.2起，`publishEvent`方法支持Object，工具类之前针对参数必须为`ApplicationEvent`的方法可以移除了，并且因为新方法是 `Object` 的，当然也包含了 `ApplicationEvent`，所以可以直接把旧的方法移除了。

![image](https://user-images.githubusercontent.com/92196261/154324068-e0c24dff-c6ab-47c3-9a9d-06bf3fa24b54.png)
