### PR TITLE
1.[bug修复] 解决调用ZipUtil.listFileNames方法后zip文件一直被占用无法删除/再次上传该zip文件的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/ZipUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ZipUtil.java
@@ -978,6 +978,11 @@ public class ZipUtil {
 			}
 		}
 
+		try {
+			zipFile.close();
+		} catch (IOException e) {
+			// 静默关闭
+		}
 		return fileNames;
 	}
 


### PR DESCRIPTION
1.[bug修复] 解决调用ZipUtil.listFileNames方法后zip文件一直被占用无法删除/再次上传该zip文件的问题。