### PR TITLE
当获取不到mac地址时,随机返回一个dataCenterId,降低无参构造的雪花算法在独立的JVM环境碰撞概率

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/IdUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/IdUtil.java
@@ -219,6 +219,8 @@ public class IdUtil {
 			id = ((0x000000FF & (long) mac[mac.length - 2])
 					| (0x0000FF00 & (((long) mac[mac.length - 1]) << 8))) >> 6;
 			id = id % (maxDatacenterId + 1);
+		} else {
+			id = (long) (Math.random() * (maxDatacenterId + 1));
 		}
 
 		return id;

--- a/hutool-core/src/test/java/cn/hutool/core/lang/SnowflakeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/SnowflakeTest.java
@@ -28,6 +28,13 @@ public class SnowflakeTest {
 	}
 
 	@Test
+	public void snowflakeTest2(){
+		Snowflake idWorker = new Snowflake();
+		long nextId = idWorker.nextId();
+		Assert.assertTrue(nextId > 0);
+	}
+
+	@Test
 	public void snowflakeTest(){
 		HashSet<Long> hashSet = new HashSet<>();
 


### PR DESCRIPTION
1. [性能优化] 当获取不到mac地址时,随机返回一个dataCenterId,降低无参构造的雪花算法在独立的JVM环境碰撞概率
