### PR TITLE
增加创建线程池工具类方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/thread/rejected/RejectedExecutionHandlerUtility.java
+++ b/hutool-core/src/main/java/cn/hutool/core/thread/rejected/RejectedExecutionHandlerUtility.java
@@ -1,0 +1,32 @@
+package cn.hutool.core.thread.rejected;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 线程池拒绝策略工具类
+ *
+ * @author luozongle
+ */
+public class RejectedExecutionHandlerUtility {
+
+	/**
+	 * 当任务队列过长时处于阻塞状态，直到添加到队列中
+	 * 如果阻塞过程中被中断，就会抛出{@link InterruptedException}异常
+	 */
+    public static class BlockPolicy implements RejectedExecutionHandler {
+
+        public BlockPolicy() {
+        }
+
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor e) {
+            try {
+                e.getQueue().put(r);
+            } catch (InterruptedException ex) {
+                throw new RejectedExecutionException("Task " + r + " rejected from " + e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. 增加创建线程池可以指定线程名字的方法
2. 有时候在线程池内访问第三方接口，只希望固定并发数去访问，并且不希望丢弃任务，所以增加了一个阻塞的拒绝策略，队列满的时候会处于阻塞状态(例如刷库的场景)