### PR TITLE
新增包装字符串提取方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
@@ -1,5 +1,7 @@
 package cn.hutool.core.util;
 
+import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.lang.Assert;
 import cn.hutool.core.text.CharSequenceUtil;
 import cn.hutool.core.text.StrBuilder;
 import cn.hutool.core.text.StrFormatter;
@@ -10,7 +12,9 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * 字符串工具类
@@ -467,5 +471,52 @@ public class StrUtil extends CharSequenceUtil implements StrPool {
 	 */
 	public static String format(CharSequence template, Map<?, ?> map, boolean ignoreNull) {
 		return StrFormatter.format(template, map, ignoreNull);
+	}
+
+	/**
+	 * 在文本中提取被包装的字符串
+	 *
+	 * @param text   被提取的文本
+	 * @param prefix 前缀
+	 * @param suffix 后缀
+	 * @return 提取字符串列表
+	 */
+	public static List<String> extractWrapStr(String text, String prefix, String suffix) {
+		List<String> list = CollUtil.newArrayList();
+		extractWrapStr(text, prefix, suffix, list::add);
+
+		return list;
+	}
+
+	/**
+	 * 在文本中提取被包装的字符串
+	 * 并将被提取到的字符串进行消费
+	 * 提取字符串中包含空字符以及重复字符串，这里暂时不做处理
+	 *
+	 * @param text     被提取的文本
+	 * @param prefix   前缀
+	 * @param suffix   后缀
+	 * @param consumer 提取字符串消费者
+	 */
+	public static void extractWrapStr(String text, String prefix, String suffix, Consumer<String> consumer) {
+		Assert.notEmpty(text, "text to check must be not empty!");
+		Assert.notEmpty(prefix, "prefix to check must be not empty!");
+		Assert.notEmpty(suffix, "suffix to check must be not empty!");
+		// 去除一些特殊的情况
+		if (text.length() <= prefix.length()
+				|| text.length() <= suffix.length()
+				|| text.length() < prefix.length() + suffix.length()) {
+			return;
+		}
+		int formIndex = 0;
+		int prefixIndex = text.indexOf(prefix, formIndex);
+		int suffixIndex = text.indexOf(suffix, prefixIndex);
+		while (prefixIndex != -1 && suffixIndex > prefixIndex) {
+			consumer.accept(text.substring(prefixIndex + prefix.length(), suffixIndex));
+
+			formIndex = suffixIndex + suffix.length();
+			prefixIndex = text.indexOf(prefix, formIndex);
+			suffixIndex = text.indexOf(suffix, prefixIndex);
+		}
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
@@ -4,6 +4,7 @@ import cn.hutool.core.lang.Dict;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -610,5 +611,22 @@ public class StrUtilTest {
 	public void isNumericTest() {
 		String a = "2142342422423423";
 		Assert.assertTrue(StrUtil.isNumeric(a));
+	}
+
+	@Test
+	public void extractWrapStrTest() {
+		String content = "{A}{B}{C}{D}";
+		List<String> list = StrUtil.extractWrapStr(content, "{", "}");
+		List<String> asList = Arrays.asList("A", "B", "C", "D");
+		for (int i = 0; i < asList.size(); i++) {
+			Assert.assertEquals(list.get(i), asList.get(i));
+		}
+
+		String content2 = "{}{}{}{}";
+		List<String> list2 = StrUtil.extractWrapStr(content2, "{", "}");
+		List<String> asList2 = Arrays.asList("", "", "", "");
+		for (int i = 0; i < asList2.size(); i++) {
+			Assert.assertEquals(list2.get(i), asList2.get(i));
+		}
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  新增提取文本中用指定 `prefix` `suffix` 包装起来的字符串

目前该方法只实现了一种包装提取，如果有多个包装需要提取，可以考虑使用正则实现;