### PR TITLE
fix: issues #2243 HttpRequest.toString() 导致的 getUrl() 编码异常

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
@@ -1080,7 +1080,7 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 	@Override
 	public String toString() {
 		StringBuilder sb = StrUtil.builder();
-		sb.append("Request Url: ").append(this.url.setCharset(this.charset)).append(StrUtil.CRLF);
+		sb.append("Request Url: ").append(this.url).append(StrUtil.CRLF);
 		sb.append(super.toString());
 		return sb.toString();
 	}

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -208,4 +208,12 @@ public class HttpRequestTest {
 				.form(params).toString();
 		Console.log(result);
 	}
+
+	@Test
+	public void issue2243Test() {
+		String sourceUrl = "https://rtcpns.cn-north-1.myhuaweicloud.com:443/rest/provision/caas/privatenumber/v1.0?privateNum=%2B8616512884988";
+		HttpRequest request = HttpRequest.of(sourceUrl, null).method(Method.GET);
+		request.toString();
+		assert request.getUrl().equals(sourceUrl);
+	}
 }


### PR DESCRIPTION
#### 说明

1. [bug修复] 修正 HttpRequest.of 在 charset 设置不编码后，调用 toString 导致 url 被编码的异常，详见