### PR TITLE
添加了设置从绝对路径加载数据库配置文件的功能（特殊情况使用，比如写Minecraft插件的时候）

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/DbUtil.java
+++ b/hutool-db/src/main/java/cn/hutool/db/DbUtil.java
@@ -4,6 +4,7 @@ import cn.hutool.core.convert.Convert;
 import cn.hutool.core.io.IoUtil;
 import cn.hutool.db.dialect.Dialect;
 import cn.hutool.db.dialect.DialectFactory;
+import cn.hutool.db.ds.AbstractDSFactory;
 import cn.hutool.db.ds.DSFactory;
 import cn.hutool.db.sql.SqlLog;
 import cn.hutool.log.Log;
@@ -110,7 +111,7 @@ public final class DbUtil {
 	 */
 	public static void close(Object... objsToClose) {
 		for (Object obj : objsToClose) {
-			if(null != obj){
+			if (null != obj) {
 				if (obj instanceof AutoCloseable) {
 					IoUtil.close((AutoCloseable) obj);
 				} else {
@@ -175,7 +176,7 @@ public final class DbUtil {
 	 * @param setting 配置项
 	 * @since 5.7.2
 	 */
-	public static void removeShowSqlParams(Setting setting){
+	public static void removeShowSqlParams(Setting setting) {
 		setting.remove(SqlLog.KEY_SHOW_SQL);
 		setting.remove(SqlLog.KEY_FORMAT_SQL);
 		setting.remove(SqlLog.KEY_SHOW_PARAMS);
@@ -236,5 +237,15 @@ public final class DbUtil {
 	 */
 	public static void setReturnGeneratedKeyGlobal(boolean returnGeneratedKey) {
 		GlobalDbConfig.setReturnGeneratedKey(returnGeneratedKey);
+	}
+
+	/**
+	 * 设置从绝对路径加载数据库配置文件
+	 * （特殊情况使用，比如写Minecraft插件的时候）
+	 *
+	 * @param absolutePath 配置文件的绝对路径
+	 */
+	public static void setCustomizeDbSettingPath(String absolutePath) {
+		AbstractDSFactory.CUSTOMIZE_DB_SETTING_PATH = absolutePath;
 	}
 }

--- a/hutool-db/src/main/java/cn/hutool/db/ds/AbstractDSFactory.java
+++ b/hutool-db/src/main/java/cn/hutool/db/ds/AbstractDSFactory.java
@@ -20,33 +20,51 @@ import java.util.concurrent.ConcurrentHashMap;
  * 数据源是与配置文件中的分组相关的，每个分组的数据源相互独立，也就是每个分组的数据源是单例存在的。
  *
  * @author looly
- *
  */
 public abstract class AbstractDSFactory extends DSFactory {
 	private static final long serialVersionUID = -6407302276272379881L;
 
-	/** 数据库配置文件可选路径1 */
+	/**
+	 * 数据库配置文件可选路径1
+	 */
 	private static final String DEFAULT_DB_SETTING_PATH = "config/db.setting";
-	/** 数据库配置文件可选路径2 */
+	/**
+	 * 数据库配置文件可选路径2
+	 */
 	private static final String DEFAULT_DB_SETTING_PATH2 = "db.setting";
+	/**
+	 * 自定义数据库配置文件路径（绝对路径，特殊情况使用，比如写Minecraft插件的时候）
+	 */
+	public static String CUSTOMIZE_DB_SETTING_PATH = null;
 
-	/** 数据库连接配置文件 */
+	/**
+	 * 数据库连接配置文件
+	 */
 	private final Setting setting;
-	/** 数据源池 */
+	/**
+	 * 数据源池
+	 */
 	private final Map<String, DataSourceWrapper> dsMap;
 
 	/**
 	 * 构造
 	 *
-	 * @param dataSourceName 数据源名称
+	 * @param dataSourceName  数据源名称
 	 * @param dataSourceClass 数据库连接池实现类，用于检测所提供的DataSource类是否存在，当传入的DataSource类不存在时抛出ClassNotFoundException<br>
-	 *            此参数的作用是在detectDSFactory方法自动检测所用连接池时，如果实现类不存在，调用此方法会自动抛出异常，从而切换到下一种连接池的检测。
-	 * @param setting 数据库连接配置
+	 *                        此参数的作用是在detectDSFactory方法自动检测所用连接池时，如果实现类不存在，调用此方法会自动抛出异常，从而切换到下一种连接池的检测。
+	 * @param setting         数据库连接配置
 	 */
 	public AbstractDSFactory(String dataSourceName, Class<? extends DataSource> dataSourceClass, Setting setting) {
 		super(dataSourceName);
 		//此参数的作用是在detectDSFactory方法自动检测所用连接池时，如果实现类不存在，调用此方法会自动抛出异常，从而切换到下一种连接池的检测。
 		Assert.notNull(dataSourceClass);
+		if (CUSTOMIZE_DB_SETTING_PATH != null) {
+			try {
+				setting = new Setting(CUSTOMIZE_DB_SETTING_PATH, false);
+			} catch (NoResourceException e3) {
+				throw new NoResourceException("Customize db setting file [{}] not found !", CUSTOMIZE_DB_SETTING_PATH);
+			}
+		}
 		if (null == setting) {
 			try {
 				setting = new Setting(DEFAULT_DB_SETTING_PATH, true);
@@ -56,6 +74,13 @@ public abstract class AbstractDSFactory extends DSFactory {
 					setting = new Setting(DEFAULT_DB_SETTING_PATH2, true);
 				} catch (NoResourceException e2) {
 					throw new NoResourceException("Default db setting [{}] or [{}] in classpath not found !", DEFAULT_DB_SETTING_PATH, DEFAULT_DB_SETTING_PATH2);
+				}
+			}
+			if (CUSTOMIZE_DB_SETTING_PATH != null) {
+				try {
+					setting = new Setting(CUSTOMIZE_DB_SETTING_PATH, false);
+				} catch (NoResourceException e3) {
+					throw new NoResourceException("Customize db setting file [{}] not found !", CUSTOMIZE_DB_SETTING_PATH);
 				}
 			}
 		}
@@ -135,10 +160,10 @@ public abstract class AbstractDSFactory extends DSFactory {
 	/**
 	 * 创建新的{@link DataSource}<br>
 	 *
-	 * @param jdbcUrl JDBC连接字符串
-	 * @param driver 数据库驱动类名
-	 * @param user 用户名
-	 * @param pass 密码
+	 * @param jdbcUrl     JDBC连接字符串
+	 * @param driver      数据库驱动类名
+	 * @param user        用户名
+	 * @param pass        密码
 	 * @param poolSetting 分组下的连接池配置文件
 	 * @return {@link DataSource}
 	 */


### PR DESCRIPTION
### 修改描述

1. [bug修复/特性] 添加了设置从绝对路径加载数据库配置文件的功能（特殊情况使用，比如写Minecraft插件的时候）

> 在写Minecraft插件的时候，因为一些奇奇怪怪的原因导致无法正常从classpath加载db.setting文件，导致hutool的数据库模块无法正常使用，故添加了此方法来手动加载配置文件。