### PR TITLE
更新了 Ftp.existFile(String path) 的方法描述

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/ftp/Ftp.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ftp/Ftp.java
@@ -418,7 +418,7 @@ public class Ftp extends AbstractFtp {
 	}
 
 	/**
-	 * 判断ftp服务器文件是否存在
+	 * 判断ftp服务器目录内是否还有子元素（目录或文件）
 	 *
 	 * @param path 文件路径
 	 * @return 是否存在


### PR DESCRIPTION
该方法应该是“判断ftp服务器目录内是否还有子元素（目录或文件）”而不是“判断ftp服务器文件是否存在”，旧的方法描述具有误导性，让人误以为这个方法是判断指定的path是否存在

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……