### PR TITLE
feat: cache相关增加Duration类型的timeout参数，方便构造各种时间单位

### DIFF
--- a/hutool-cache/src/main/java/cn/hutool/cache/Cache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/Cache.java
@@ -4,7 +4,9 @@ import cn.hutool.cache.impl.CacheObj;
 import cn.hutool.core.lang.func.Func0;
 
 import java.io.Serializable;
+import java.time.Duration;
 import java.util.Iterator;
+import java.util.Objects;
 
 /**
  * 缓存接口
@@ -47,6 +49,19 @@ public interface Cache<K, V> extends Iterable<V>, Serializable {
 	 * @param timeout 失效时长，单位毫秒
 	 */
 	void put(K key, V object, long timeout);
+
+	/**
+	 * 将对象加入到缓存，使用指定失效时长<br>
+	 * 如果缓存空间满了，{@link #prune()} 将被调用以获得空间来存放新对象
+	 *
+	 * @param key     键
+	 * @param object  缓存的对象
+	 * @param timeout 失效时长
+	 */
+	default void put(K key, V object, Duration timeout) {
+		Objects.requireNonNull(timeout, "timeout cannot be null");
+		this.put(key, object, timeout.toMillis());
+	}
 
 	/**
 	 * 从缓存中获得对象，当对象不在缓存中或已经过期返回{@code null}

--- a/hutool-cache/src/main/java/cn/hutool/cache/file/LFUFileCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/file/LFUFileCache.java
@@ -1,6 +1,7 @@
 package cn.hutool.cache.file;
 
 import java.io.File;
+import java.time.Duration;
 
 import cn.hutool.cache.Cache;
 import cn.hutool.cache.impl.LFUCache;
@@ -41,6 +42,16 @@ public class LFUFileCache extends AbstractFileCache{
 	 */
 	public LFUFileCache(int capacity, int maxFileSize, long timeout) {
 		super(capacity, maxFileSize, timeout);
+	}
+
+	/**
+	 * 构造
+	 * @param capacity 缓存容量
+	 * @param maxFileSize 文件最大大小
+	 * @param timeout 默认超时时间
+	 */
+	public LFUFileCache(int capacity, int maxFileSize, Duration timeout) {
+		this(capacity, maxFileSize, timeout.toMillis());
 	}
 
 	@Override

--- a/hutool-cache/src/main/java/cn/hutool/cache/file/LRUFileCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/file/LRUFileCache.java
@@ -1,6 +1,7 @@
 package cn.hutool.cache.file;
 
 import java.io.File;
+import java.time.Duration;
 
 import cn.hutool.cache.Cache;
 import cn.hutool.cache.impl.LRUCache;
@@ -41,6 +42,16 @@ public class LRUFileCache extends AbstractFileCache{
 	 */
 	public LRUFileCache(int capacity, int maxFileSize, long timeout) {
 		super(capacity, maxFileSize, timeout);
+	}
+
+	/**
+	 * 构造
+	 * @param capacity 缓存容量
+	 * @param maxFileSize 文件最大大小
+	 * @param timeout 默认超时时间
+	 */
+	public LRUFileCache(int capacity, int maxFileSize, Duration timeout) {
+		this(capacity, maxFileSize, timeout.toMillis());
 	}
 
 	@Override

--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/FIFOCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/FIFOCache.java
@@ -1,5 +1,6 @@
 package cn.hutool.cache.impl;
 
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 
@@ -38,6 +39,16 @@ public class FIFOCache<K, V> extends StampedCache<K, V> {
 		this.capacity = capacity;
 		this.timeout = timeout;
 		cacheMap = new LinkedHashMap<>(capacity + 1, 1.0f, false);
+	}
+
+	/**
+	 * 构造
+	 *
+	 * @param capacity 容量
+	 * @param timeout  过期时长
+	 */
+	public FIFOCache(int capacity, Duration timeout) {
+		this(capacity, timeout.toMillis());
 	}
 
 	/**

--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/LFUCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/LFUCache.java
@@ -1,5 +1,6 @@
 package cn.hutool.cache.impl;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -41,6 +42,16 @@ public class LFUCache<K, V> extends StampedCache<K, V> {
 		this.capacity = capacity;
 		this.timeout = timeout;
 		cacheMap = new HashMap<>(capacity + 1, 1.0f);
+	}
+
+	/**
+	 * 构造
+	 *
+	 * @param capacity 容量
+	 * @param timeout 过期时长
+	 */
+	public LFUCache(int capacity, Duration timeout) {
+		this(capacity, timeout.toMillis());
 	}
 
 	// ---------------------------------------------------------------- prune

--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/LRUCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/LRUCache.java
@@ -2,6 +2,7 @@ package cn.hutool.cache.impl;
 
 import cn.hutool.core.map.FixedLinkedHashMap;
 
+import java.time.Duration;
 import java.util.Iterator;
 
 /**
@@ -43,6 +44,15 @@ public class LRUCache<K, V> extends ReentrantCache<K, V> {
 
 		//链表key按照访问顺序排序，调用get方法后，会将这次访问的元素移至头部
 		cacheMap = new FixedLinkedHashMap<>(capacity);
+	}
+
+	/**
+	 * 构造
+	 * @param capacity 容量
+	 * @param timeout 默认超时时间
+	 */
+	public LRUCache(int capacity, Duration timeout) {
+		this(capacity, timeout.toMillis());
 	}
 
 	// ---------------------------------------------------------------- prune

--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/TimedCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/TimedCache.java
@@ -3,6 +3,7 @@ package cn.hutool.cache.impl;
 import cn.hutool.cache.GlobalPruneTimer;
 import cn.hutool.core.lang.mutable.Mutable;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -35,6 +36,15 @@ public class TimedCache<K, V> extends StampedCache<K, V> {
 	/**
 	 * 构造
 	 *
+	 * @param timeout 超时（过期）时长
+	 */
+	public TimedCache(Duration timeout) {
+		this(timeout.toMillis(), new HashMap<>());
+	}
+
+	/**
+	 * 构造
+	 *
 	 * @param timeout 过期时长
 	 * @param map 存储缓存对象的map
 	 */
@@ -42,6 +52,16 @@ public class TimedCache<K, V> extends StampedCache<K, V> {
 		this.capacity = 0;
 		this.timeout = timeout;
 		this.cacheMap = map;
+	}
+
+	/**
+	 * 构造
+	 *
+	 * @param timeout 过期时长
+	 * @param map 存储缓存对象的map
+	 */
+	public TimedCache(Duration timeout, Map<Mutable<K>, CacheObj<K, V>> map) {
+		this(timeout.toMillis(), map);
 	}
 
 	// ---------------------------------------------------------------- prune

--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/WeakCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/WeakCache.java
@@ -6,6 +6,7 @@ import cn.hutool.core.lang.mutable.Mutable;
 import cn.hutool.core.map.WeakConcurrentMap;
 
 import java.lang.ref.Reference;
+import java.time.Duration;
 
 /**
  * 弱引用缓存<br>
@@ -27,6 +28,14 @@ public class WeakCache<K, V> extends TimedCache<K, V>{
 	 * @param timeout 超时时常，单位毫秒，-1或0表示无限制
 	 */
 	public WeakCache(long timeout) {
+		super(timeout, new WeakConcurrentMap<>());
+	}
+
+	/**
+	 * 构造
+	 * @param timeout 超时时常
+	 */
+	public WeakCache(Duration timeout) {
 		super(timeout, new WeakConcurrentMap<>());
 	}
 


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)


1. [新特性]  cache模块timeout参数增加Duration类型，方便构造各种时间单位

例如：
```
		Cache<String,String> cache = new FIFOCache<>(10, Duration.ofMinutes(5));
		cache.put("a", "b", Duration.ofHours(1));
		cache.put("b", "b", Duration.ofSeconds(10));
```