### PR TITLE
Regex for reserved filenames in Windows platform

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
@@ -3311,6 +3311,19 @@ public class FileUtil extends PathUtil {
 	}
 
 	/**
+	 * 文件名中是在Windows中的保留文件名，包括：
+	 * (CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
+	 * LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9)
+	 *
+	 * @param fileName 文件名（必须不包括路径，否则路径符将被替换）
+	 * @return 是否是Windows保留文件名
+	 * @since 5.8.3.M1
+	 */
+	public static boolean matchInvalidFilename(String fileName) {
+		return FileNameUtil.matchInvalidFilename(fileName);
+	}
+
+	/**
 	 * 计算文件CRC32校验码
 	 *
 	 * @param file 文件，不能为目录

--- a/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
@@ -43,6 +43,11 @@ public class FileNameUtil {
 	private static final Pattern FILE_NAME_INVALID_PATTERN_WIN = Pattern.compile("[\\\\/:*?\"<>|]");
 
 	/**
+	 * Windows下文件名中的无效名称
+	 */
+	private static final Pattern FILE_NAME_INVALID_FILENAME_WIN = Pattern.compile("^(CON|PRM|AUX|NUL|COM[0-9]|LPT[0-9])$");
+
+	/**
 	 * 特殊后缀
 	 */
 	private static final CharSequence[] SPECIAL_SUFFIX = {"tar.bz2", "tar.Z", "tar.gz", "tar.xz"};
@@ -260,6 +265,19 @@ public class FileNameUtil {
 	 */
 	public static boolean containsInvalid(String fileName) {
 		return (false == StrUtil.isBlank(fileName)) && ReUtil.contains(FILE_NAME_INVALID_PATTERN_WIN, fileName);
+	}
+
+	/**
+	 * 文件名中是在Windows中的保留文件名，包括：
+	 * (CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
+	 * LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9)
+	 *
+	 * @param fileName 文件名（必须不包括路径，否则路径符将被替换）
+	 * @return 是否是Windows保留文件名
+	 * @since 5.8.3.M1
+	 */
+	public static boolean matchInvalidFilename(String fileName) {
+		return (!StrUtil.isBlank(fileName)) && ReUtil.isMatch(FILE_NAME_INVALID_FILENAME_WIN, fileName.trim());
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/io/file/FileNameUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/file/FileNameUtilTest.java
@@ -1,0 +1,32 @@
+package cn.hutool.core.io.file;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileNameUtilTest {
+
+	@Test
+	public void test(){
+		String filename = "CON";
+		Assert.assertTrue(FileNameUtil.matchInvalidFilename(filename));
+
+		String filename2 = "CON9";
+		Assert.assertFalse(FileNameUtil.matchInvalidFilename(filename2));
+
+		String filename3 = "LPT8";
+		Assert.assertTrue(FileNameUtil.matchInvalidFilename(filename3));
+
+		String filename4 = "LPT8   ";
+		Assert.assertTrue(FileNameUtil.matchInvalidFilename(filename4));
+
+		String filename5 = "LPT88";
+		Assert.assertFalse(FileNameUtil.matchInvalidFilename(filename5));
+
+		String filename6 = "con";
+		Assert.assertFalse(FileNameUtil.matchInvalidFilename(filename6));
+
+		String filename7 = "abcde";
+		Assert.assertFalse(FileNameUtil.matchInvalidFilename(filename7));
+	}
+
+}


### PR DESCRIPTION
#### 说明

- [x] 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
- [x] 请确认没有更改代码风格（如tab缩进）
- [x] 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 新特性
在`FileNameUtil`中新增对Windows保留文件名称的正则判断工具，并添加单元测试。