### PR TITLE
添加判断给定两个对象公共字段值是否相等的方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanUtil.java
@@ -23,13 +23,7 @@ import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -970,5 +964,42 @@ public class BeanUtil {
 		} else {
 			throw new IllegalArgumentException("Invalid Getter or Setter name: " + getterOrSetterName);
 		}
+	}
+
+	/**
+	 * 判断source与target的所有公共字段的值是否相同
+	 * @param source 待检测对象1
+	 * @param target 待检测对象2
+	 * @param ignoreProperties 不需要检测的字段
+	 * @return 判断结果，如果为true则证明所有字段的值都相同
+	 */
+	public static boolean isCommonFieldsEqual(Object source, Object target, String...ignoreProperties) {
+
+		if (null == source && null == target) {
+			return true;
+		}
+		if (null == source || null == target) {
+			return false;
+		}
+
+		Map<String, Object> sourceFieldsMap = BeanUtil.beanToMap(source);
+		Map<String, Object> targetFieldsMap = BeanUtil.beanToMap(target);
+
+		Set<String> sourceFields = sourceFieldsMap.keySet();
+		sourceFields.removeAll(Arrays.asList(ignoreProperties));
+
+		for (String field : sourceFields) {
+			Object sourceValue = sourceFieldsMap.get(field);
+			Object targetValue = targetFieldsMap.get(field);
+
+			if (null == sourceValue && null == targetValue) {
+				continue;
+			}
+			if (!sourceValue.equals(targetValue)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
@@ -11,10 +11,7 @@ import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.StrUtil;
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.Accessors;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -839,5 +836,53 @@ public class BeanUtilTest {
 			}
 		}, copyOptions);
 		Assert.assertEquals("123", pojo.getName());
+	}
+
+	@Data
+	@EqualsAndHashCode
+	private static class TestUserEntity {
+		private String username;
+		private String name;
+		private Integer age;
+		private Integer sex;
+		private String mobile;
+		private Date createTime;
+	}
+
+	@Data
+	@EqualsAndHashCode
+	private static class TestUserDTO {
+		private String name;
+		private Integer age;
+		private Integer sex;
+		private String mobile;
+	}
+	@Test
+	public void isCommonFieldsEqualTest() {
+		TestUserEntity userEntity = new TestUserEntity();
+		TestUserDTO userDTO = new TestUserDTO();
+
+		userDTO.setAge(20);
+		userDTO.setName("takaki");
+		userDTO.setSex(1);
+		userDTO.setMobile("17812312023");
+
+		BeanUtil.copyProperties(userDTO, userEntity);
+
+		System.out.println("相同字段值测试" + BeanUtil.isCommonFieldsEqual(userDTO, userEntity));
+
+		userEntity.setAge(13);
+		System.out.println("修改age字段值后测试" + BeanUtil.isCommonFieldsEqual(userDTO, userEntity));
+		System.out.println("忽略age字段后测试" + BeanUtil.isCommonFieldsEqual(userDTO, userEntity, "age"));
+
+		System.out.println("全null值测试" + BeanUtil.isCommonFieldsEqual(null, null));
+		System.out.println("部分null值测试1" + BeanUtil.isCommonFieldsEqual(null, userEntity));
+		System.out.println("部分null值测试2" + BeanUtil.isCommonFieldsEqual(userEntity, null));
+
+		userEntity.setSex(0);
+		System.out.println(
+				"修改age、sex字段修改后并忽略测试"
+						+ BeanUtil.isCommonFieldsEqual(userDTO, userEntity, "age", "sex")
+		);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)
[新特性]
在BeanUtil中添加了一个判断给定两个对象公共字段值是否相等的方法。
在实际项目中可以有效减少对数据库的操作。