### PR TITLE
解决Snowflake每毫秒生成4096个ID后就需要自选等待的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/Snowflake.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Snowflake.java
@@ -218,7 +218,16 @@ public class Snowflake implements Serializable {
 		if (timestamp == this.lastTimestamp) {
 			final long sequence = (this.sequence + 1) & SEQUENCE_MASK;
 			if (sequence == 0) {
-				timestamp = tilNextMillis(lastTimestamp);
+				/**
+				 * 1 timeOffset 默认是0,目前的做法是每毫秒生成4096个id以后就自旋等待到下一毫秒，在生成Id
+				 * 2 可以通过 timeOffset 来指定最多向未来多少毫秒以内的时间借用生成的id，从而解决1毫秒生成4096个id以后需要自旋等待的问题
+				 * 3 比如我们指定 timeOffset=10000，就可用最多借用未来10000毫秒的id，应对突发瞬时需求，最大一毫秒允许生成的id数变成4096*10000
+				 */
+                if( timeOffset == 0 ){
+                    timestamp = this.tilNextMillis(this.lastTimestamp);
+                }else{
+                    timestamp = ++timestamp;
+                }
 			}
 			this.sequence = sequence;
 		} else {

--- a/hutool-core/src/main/java/cn/hutool/core/lang/Snowflake.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Snowflake.java
@@ -226,7 +226,7 @@ public class Snowflake implements Serializable {
                 if( timeOffset == 0 ){
                     timestamp = this.tilNextMillis(this.lastTimestamp);
                 }else{
-                    timestamp = ++timestamp;
+                   timestamp++;
                 }
 			}
 			this.sequence = sequence;


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)


1. [新特性] 解决Snowflake每毫秒生成4096个ID后就需要自选等待的问题
2. [原理1] timeOffset 我的理解是时间偏移，也可以是ID生成器向后面提前生成ID的时间偏移量毫秒数
3. [原理2] 以前每毫秒生成4096个ID以后需要自旋等待，我觉得可以通过timeOffset  设置向后面多少个毫秒借他们的ID
4.  [原理2] 结果就是，瞬间可以生成的ID数量大大提高了，但是这些ID不是凭空出现的，而是向未来时间窗口借的
5. [目前情况] 指定了 timeOffset>100的情况下，生成409600个id需要100毫秒
6. [改动后情况]:指定了 timeOffset>100的情况下，生成409600个id需要10毫秒