### PR TITLE
fix：修复CollUtil里面关于可变参数传null造成的crash问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/CollUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/CollUtil.java
@@ -108,6 +108,9 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link ArrayList}
 	 */
 	public static <T> Collection<T> union(Collection<T> coll1, Collection<T> coll2) {
+		if (isEmpty(coll1) && isEmpty(coll2)) {
+			return new ArrayList<>();
+		}
 		if (isEmpty(coll1)) {
 			return new ArrayList<>(coll2);
 		} else if (isEmpty(coll2)) {
@@ -145,6 +148,9 @@ public class CollUtil {
 	public static <T> Collection<T> union(Collection<T> coll1, Collection<T> coll2, Collection<T>... otherColls) {
 		Collection<T> union = union(coll1, coll2);
 		for (Collection<T> coll : otherColls) {
+			if (isEmpty(coll)) {
+				continue;
+			}
 			union = union(union, coll);
 		}
 		return union;
@@ -177,6 +183,9 @@ public class CollUtil {
 
 		if (ArrayUtil.isNotEmpty(otherColls)) {
 			for (Collection<T> otherColl : otherColls) {
+				if (isEmpty(otherColl)) {
+					continue;
+				}
 				result.addAll(otherColl);
 			}
 		}
@@ -211,6 +220,9 @@ public class CollUtil {
 
 		if (ArrayUtil.isNotEmpty(otherColls)) {
 			for (Collection<T> otherColl : otherColls) {
+				if (isEmpty(otherColl)) {
+					continue;
+				}
 				result.addAll(otherColl);
 			}
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
@@ -10,21 +10,7 @@ import lombok.Data;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 
 /**
  * 集合工具类单元测试
@@ -906,6 +892,55 @@ public class CollUtilTest {
 		Assert.assertEquals(2, distinct.size());
 		Assert.assertEquals("aa", distinct.get(0).getName());
 		Assert.assertEquals("bb", distinct.get(1).getName());
+	}
+
+	@Test
+	public void unionNullTest() {
+		List<String> list1 = new ArrayList<>();
+		List<String> list2 = null;
+		List<String> list3 = null;
+		Collection<String> union = CollUtil.union(list1, list2, list3);
+		Assert.assertNotNull(union);
+	}
+
+	@Test
+	public void unionDistinctNullTest() {
+		List<String> list1 = new ArrayList<>();
+		List<String> list2 = null;
+		List<String> list3 = null;
+		Set<String> set = CollUtil.unionDistinct(list1, list2, list3);
+		Assert.assertNotNull(set);
+	}
+
+	@Test
+	public void unionAllNullTest() {
+		List<String> list1 = new ArrayList<>();
+		List<String> list2 = null;
+		List<String> list3 = null;
+		List<String> list = CollUtil.unionAll(list1, list2, list3);
+		Assert.assertNotNull(list);
+	}
+
+	@Test
+	public void intersectionNullTest() {
+		List<String> list1 = new ArrayList<>();
+		list1.add("aa");
+		List<String> list2 = new ArrayList<>();
+		list2.add("aa");
+		List<String> list3 = null;
+		Collection<String> collection = CollUtil.intersection(list1, list2, list3);
+		Assert.assertNotNull(collection);
+	}
+
+	@Test
+	public void intersectionDistinctNullTest() {
+		List<String> list1 = new ArrayList<>();
+		list1.add("aa");
+		List<String> list2 = null;
+		// list2.add("aa");
+		List<String> list3 = null;
+		Collection<String> collection = CollUtil.intersectionDistinct(list1, list2, list3);
+		Assert.assertNotNull(collection);
 	}
 
 	@Data


### PR DESCRIPTION
1. [bug修复] 修复[#2426](https://github.com/dromara/hutool/issues/2426)缺陷