### PR TITLE
bug修复 2447 JSONUtil.toBean 当时间戳为Integer时 时间转换有误

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/impl/TemporalAccessorConverter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/impl/TemporalAccessorConverter.java
@@ -94,6 +94,8 @@ public class TemporalAccessorConverter extends AbstractConverter<TemporalAccesso
 	protected TemporalAccessor convertInternal(Object value) {
 		if (value instanceof Long) {
 			return parseFromLong((Long) value);
+		} else if (value instanceof Integer) {
+			return parseFromLong((long) (Integer) value);
 		} else if (value instanceof TemporalAccessor) {
 			return parseFromTemporalAccessor((TemporalAccessor) value);
 		} else if (value instanceof Date) {

--- a/hutool-json/src/test/java/cn/hutool/json/Issue2447Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue2447Test.java
@@ -1,0 +1,36 @@
+package cn.hutool.json;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+public class Issue2447Test {
+
+	@Test
+	public void addInteger() {
+		Time time = new Time();
+		time.setTime(LocalDateTime.of(1970, 1, 2, 10, 0, 1, 0));
+		String timeStr = JSONUtil.toJsonStr(time);
+		Assert.assertEquals(timeStr, "{\"time\":93601000}");
+		Assert.assertEquals(JSONUtil.toBean(timeStr, Time.class).getTime(), time.getTime());
+	}
+
+	static class Time {
+		private LocalDateTime time;
+
+		public LocalDateTime getTime() {
+			return time;
+		}
+
+		public void setTime(LocalDateTime time) {
+			this.time = time;
+		}
+
+		@Override
+		public String toString() {
+			return time.toString();
+		}
+	}
+
+}


### PR DESCRIPTION

1. [bug修复] 2447 JSONUtil.toBean 当时间戳为Integer时 时间转换有误
https://github.com/dromara/hutool/issues/2447