### PR TITLE
修改在匹配到多个group时只取第一个group，而不继续匹配的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/ReUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ReUtil.java
@@ -212,7 +212,7 @@ public class ReUtil {
 
 		ArrayList<String> result = new ArrayList<>();
 		final Matcher matcher = pattern.matcher(content);
-		if (matcher.find()) {
+		while (matcher.find()) {
 			final int startGroup = withGroup0 ? 0 : 1;
 			final int groupCount = matcher.groupCount();
 			for (int i = startGroup; i <= groupCount; i++) {


### PR DESCRIPTION
在我们做匹配的时候，其实往往不是只要第一个结果，如果当一个表达式，在一个content中有多处匹配的话，是都需要获取的，所以这里该用while，而不是使用if，这样会导致他只获取第一个匹配内容的时候，就返回了，而不会继续匹配。