### PR TITLE
fix：参数化类型的相等判断修改

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/ParameterizedTypeImpl.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/ParameterizedTypeImpl.java
@@ -3,6 +3,8 @@ package cn.hutool.core.lang;
 import java.io.Serializable;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Objects;
 
 import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.StrUtil;
@@ -98,5 +100,28 @@ public class ParameterizedTypeImpl implements ParameterizedType, Serializable {
 			}
 		}
 		return buf;
+	}
+
+	public boolean equals(Object obj) {
+		if (obj instanceof ParameterizedType) {
+			ParameterizedType parameterizedType = (ParameterizedType) obj;
+			if (this == parameterizedType) {
+				return true;
+			} else {
+				Type typeOwnerType = parameterizedType.getOwnerType();
+				Type typeRawType = parameterizedType.getRawType();
+				return Objects.equals(this.ownerType, typeOwnerType)
+					&& Objects.equals(this.rawType, typeRawType)
+					&& Arrays.equals(this.actualTypeArguments, parameterizedType.getActualTypeArguments());
+			}
+		} else {
+			return false;
+		}
+	}
+
+	public int hashCode() {
+		return Arrays.hashCode(this.actualTypeArguments)
+			^ Objects.hashCode(this.ownerType)
+			^ Objects.hashCode(this.rawType);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ParameterizedTypeImplTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ParameterizedTypeImplTest.java
@@ -1,0 +1,20 @@
+package cn.hutool.core.lang;
+
+import cn.hutool.core.event.DefaultContextTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+
+public class ParameterizedTypeImplTest {
+
+	@Test
+	public void testEquals() {
+		ParameterizedType parameterizedType1 = new ParameterizedTypeImpl(new Class[]{Integer.class}, List.class, null);
+		ParameterizedType parameterizedType2 = new ParameterizedTypeImpl(new Class[]{Integer.class}, List.class, null);
+		ParameterizedType parameterizedType3 = new ParameterizedTypeImpl(new Class[]{String.class}, List.class, null);
+		Assert.assertEquals(parameterizedType1,parameterizedType2);
+		Assert.assertNotEquals(parameterizedType3,parameterizedType2);
+	}
+}


### PR DESCRIPTION
为参数化类型实现类添加equals和hashcode方法

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] ：参数化类型的相等判断修改。为支持泛型的cn.hutool.core.lang.ParameterizedTypeImpl类实现equals和hashcode方法，这样在判断两个参数化类型是否相等时就会去判断类的声明类型和泛型列表。
