### PR TITLE
增加： 当条件匹配到true的情况下，执行Lambda函数代码(可替换某些情况下的if else,简洁化代码)

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/func/LambdaUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/func/LambdaUtil.java
@@ -9,6 +9,7 @@ import cn.hutool.core.util.StrUtil;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandleInfo;
 import java.lang.invoke.SerializedLambda;
+import java.util.Objects;
 
 /**
  * Lambda相关工具类
@@ -205,4 +206,52 @@ public class LambdaUtil {
 		return cache.computeIfAbsent(func.getClass().getName(), (key) -> ReflectUtil.invoke(func, "writeReplace"));
 	}
 	//endregion
+
+
+	/**
+	 * 当条件为true时,执行无参函数里面的代码
+	 *
+	 * @param isCall  是否执行func参数的代码，若为true则执行func参数的代码
+	 * @param func  函数(无参,not null)
+	 */
+	public static void callVoidFunc(boolean isCall, VoidFunc0 func) {
+		Objects.requireNonNull(func,"func can not be null");
+		if (!isCall) {
+			 return  ;
+		}
+		func.callWithRuntimeException();
+	}
+
+	/**
+	 * 当条件为true时,执行无参函数里面的代码，返回相应的值
+	 *
+	 * @param isCall  是否执行func参数的代码，若为true则执行func参数的代码
+	 * @param func  函数(无参,not null)
+	 * @param <R>  Lambda 返回值类型
+	 */
+	public static <R> R callVoidReturnFunc(boolean isCall, Func0<R> func) {
+		Objects.requireNonNull(func,"func can not be null");
+		if (!isCall) {
+			return  null;
+		}
+		return func.callWithRuntimeException();
+	}
+
+	/**
+	 * 当条件为true时,执行有参函数里面的代码,并返回相应的值
+	 *
+	 * @param isCall  是否执行func参数的代码，若为true则执行func参数的代码
+	 * @param parameter  参数
+	 * @param func  函数(有参,not null)
+	 * @param <P>  Lambda 参数值类型
+	 * @param <R>  Lambda 返回值类型
+	 */
+	public static <P,R> R callParameterReturnFunc(boolean isCall,P parameter, Func1<P,R> func) {
+		Objects.requireNonNull(func,"func can not be null");
+		if (!isCall) {
+			 return  null;
+		}
+		return func.callWithRuntimeException(parameter);
+	}
+
 }


### PR DESCRIPTION
### 说明

已增加unit test

[新特性]  LambdaUtil增加三个方法，用来动态匹配条件为true时，执行Lambda函数. 可用于减少大量的if else语句判断和嵌套多层的判断，对项目代码能够以简洁的方式维护. 

当增加多一个if 判断，只需对map增加多一个put即可，无需增加额外的类和if判断，如下: 

```
		Integer params = 1;
		//将无参函数的执行代码put到Map中，并设置类型为LocalDate的返回值
		Map<Integer, Func0 <LocalDate> > funcMap = new HashMap<>();
		funcMap.put(1, () ->  LocalDate.of(2022,7,26) );
		funcMap.put(2, () -> LocalDate.of(2021,7,26));
		funcMap.put(3, () -> LocalDate.of(2020,7,26));

		//forEach匹配要执行的函数,并获取正确的LocalDate 返回值
		Optional < LocalDate> resultOptional = funcMap.entrySet().stream().
				filter(entry -> Objects.equals(entry.getKey(), params)).
				map(entry-> LambdaUtil.callVoidReturnFunc(true, entry.getValue())).findAny();

		LocalDate result =  resultOptional.orElse(null);
		Assert.assertEquals(2022, result.getYear());
```