### PR TITLE
方法名与方法不符合，NetUtil.ipv6ToBitInteger，建议是ipv6ToBigInteger

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/img/BackgroundRemoval.java
+++ b/hutool-core/src/main/java/cn/hutool/core/img/BackgroundRemoval.java
@@ -299,7 +299,8 @@ public class BackgroundRemoval {
 			}
 		}
 
-		Map<String, Integer> map = new HashMap<>(list.size());
+		int initialCapacity = (int) (list.size() / 0.75) + 1;
+		Map<String, Integer> map = new HashMap<>(initialCapacity);
 		for (String string : list) {
 			Integer integer = map.get(string);
 			if (integer == null) {

--- a/hutool-core/src/main/java/cn/hutool/core/net/NetUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/NetUtil.java
@@ -90,7 +90,7 @@ public class NetUtil {
 	 * @return 大整数, 如发生异常返回 null
 	 * @since 5.5.7
 	 */
-	public static BigInteger ipv6ToBitInteger(String IPv6Str) {
+	public static BigInteger ipv6ToBigInteger(String IPv6Str) {
 		try {
 			InetAddress address = InetAddress.getByName(IPv6Str);
 			if (address instanceof Inet6Address) {

--- a/hutool-dfa/src/main/java/cn/hutool/dfa/Test.java
+++ b/hutool-dfa/src/main/java/cn/hutool/dfa/Test.java
@@ -1,0 +1,8 @@
+package cn.hutool.dfa;
+
+public class Test {
+	public static void main(String[] args) {
+		int initialCapacity = (int) (0 / 0.75) + 1;
+		System.out.println(initialCapacity);
+	}
+}

--- a/hutool-dfa/src/main/java/cn/hutool/dfa/Test.java
+++ b/hutool-dfa/src/main/java/cn/hutool/dfa/Test.java
@@ -1,8 +1,0 @@
-package cn.hutool.dfa;
-
-public class Test {
-	public static void main(String[] args) {
-		int initialCapacity = (int) (0 / 0.75) + 1;
-		System.out.println(initialCapacity);
-	}
-}


### PR DESCRIPTION
1、方法名与方法不符合，
原先是NetUtil.ipv6ToBitInteger，建议是ipv6ToBigInteger

2、自定义缓存key生成策略时，目前HashMap容量设置为集合的大小，按照JDK, 临界点在 size * 0.75 时会触发扩容，目前来看必然会进行扩容，这样性能会受到影响，可以将初始化大小修改成 (size / 0.75) + 1 去计算