### PR TITLE
修复SecureUtil类中HMAC算法加密器创建方法传入的key参数为空时抛异常问题

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/SecureUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/SecureUtil.java
@@ -3,7 +3,9 @@ package cn.hutool.crypto;
 import cn.hutool.core.codec.Base64;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Validator;
+import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.HexUtil;
+import cn.hutool.core.util.ObjectUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.asymmetric.AsymmetricAlgorithm;
 import cn.hutool.crypto.asymmetric.RSA;
@@ -633,7 +635,7 @@ public class SecureUtil {
 	 * @since 3.3.0
 	 */
 	public static HMac hmac(HmacAlgorithm algorithm, String key) {
-		return new HMac(algorithm, StrUtil.utf8Bytes(key));
+		return new HMac(algorithm, StrUtil.isNotEmpty(key)? StrUtil.utf8Bytes(key): null);
 	}
 
 	/**
@@ -645,6 +647,9 @@ public class SecureUtil {
 	 * @since 3.0.3
 	 */
 	public static HMac hmac(HmacAlgorithm algorithm, byte[] key) {
+		if (ArrayUtil.isEmpty(key)) {
+			key = generateKey(algorithm.getValue()).getEncoded();
+		}
 		return new HMac(algorithm, key);
 	}
 
@@ -657,6 +662,9 @@ public class SecureUtil {
 	 * @since 3.0.3
 	 */
 	public static HMac hmac(HmacAlgorithm algorithm, SecretKey key) {
+		if (ObjectUtil.isNull(key)) {
+			key = generateKey(algorithm.getValue());
+		}
 		return new HMac(algorithm, key);
 	}
 
@@ -671,7 +679,7 @@ public class SecureUtil {
 	 * @since 3.3.0
 	 */
 	public static HMac hmacMd5(String key) {
-		return hmacMd5(StrUtil.utf8Bytes(key));
+		return hmacMd5(StrUtil.isNotEmpty(key)? StrUtil.utf8Bytes(key): null);
 	}
 
 	/**
@@ -684,6 +692,9 @@ public class SecureUtil {
 	 * @return {@link HMac}
 	 */
 	public static HMac hmacMd5(byte[] key) {
+		if (ArrayUtil.isEmpty(key)) {
+			key = generateKey(HmacAlgorithm.HmacMD5.getValue()).getEncoded();
+		}
 		return new HMac(HmacAlgorithm.HmacMD5, key);
 	}
 
@@ -710,7 +721,7 @@ public class SecureUtil {
 	 * @since 3.3.0
 	 */
 	public static HMac hmacSha1(String key) {
-		return hmacSha1(StrUtil.utf8Bytes(key));
+		return hmacSha1(StrUtil.isNotEmpty(key)? StrUtil.utf8Bytes(key): null);
 	}
 
 	/**
@@ -723,6 +734,9 @@ public class SecureUtil {
 	 * @return {@link HMac}
 	 */
 	public static HMac hmacSha1(byte[] key) {
+		if (ArrayUtil.isEmpty(key)) {
+			key = generateKey(HmacAlgorithm.HmacMD5.getValue()).getEncoded();
+		}
 		return new HMac(HmacAlgorithm.HmacSHA1, key);
 	}
 
@@ -749,7 +763,7 @@ public class SecureUtil {
 	 * @since 5.6.0
 	 */
 	public static HMac hmacSha256(String key) {
-		return hmacSha256(StrUtil.utf8Bytes(key));
+		return hmacSha256(StrUtil.isNotEmpty(key)? StrUtil.utf8Bytes(key): null);
 	}
 
 	/**
@@ -763,6 +777,9 @@ public class SecureUtil {
 	 * @since 5.6.0
 	 */
 	public static HMac hmacSha256(byte[] key) {
+		if (ArrayUtil.isEmpty(key)) {
+			key = generateKey(HmacAlgorithm.HmacMD5.getValue()).getEncoded();
+		}
 		return new HMac(HmacAlgorithm.HmacSHA256, key);
 	}
 


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] #2519
