### PR TITLE
V5 dev

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -25,6 +25,35 @@ public class PunyCode {
 	public static final String PUNY_CODE_PREFIX = "xn--";
 
 	/**
+	 * punycode转码域名
+	 * @param domain
+	 * @return
+	 * @throws UtilException
+	 */
+	private static String encodeDomain(String domain) throws UtilException{
+		Assert.notNull(domain, "domain must not be null!");
+		String[] split = domain.split("\\.");
+		StringBuilder outStringBuilder = new StringBuilder();
+		for (String string: split) {
+			boolean encode = false;
+			for (int index=0; index<string.length(); index++) {
+				char c = string.charAt(index);
+				if (!isBasic(c)) {
+					encode = true;
+					break;
+				}
+			}
+			if (encode) {
+				outStringBuilder.append(PunyCode.encode(string, true));
+			} else {
+				outStringBuilder.append(string);
+			}
+			outStringBuilder.append(".");
+		}
+		return outStringBuilder.substring(0, outStringBuilder.length() - 1);
+	}
+
+	/**
 	 * 将内容编码为PunyCode
 	 *
 	 * @param input 字符串
@@ -117,6 +146,27 @@ public class PunyCode {
 			output.insert(0, PUNY_CODE_PREFIX);
 		}
 		return output.toString();
+	}
+
+	/**
+	 * 解码punycode域名
+	 * @param domain
+	 * @return
+	 * @throws UtilException
+	 */
+	private static String decodeDomain(String domain) throws UtilException{
+		Assert.notNull(domain, "domain must not be null!");
+		String[] split = domain.split("\\.");
+		StringBuilder outStringBuilder = new StringBuilder();
+		for (String string: split) {
+			if (string.startsWith(PUNY_CODE_PREFIX)) {
+				outStringBuilder.append(decode(string));
+			} else {
+				outStringBuilder.append(string);
+			}
+			outStringBuilder.append(".");
+		}
+		return outStringBuilder.substring(0, outStringBuilder.length() - 1);
 	}
 
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -30,7 +30,7 @@ public class PunyCode {
 	 * @return
 	 * @throws UtilException
 	 */
-	private static String encodeDomain(String domain) throws UtilException{
+	public static String encodeDomain(String domain) throws UtilException{
 		Assert.notNull(domain, "domain must not be null!");
 		String[] split = domain.split("\\.");
 		StringBuilder outStringBuilder = new StringBuilder();
@@ -154,7 +154,7 @@ public class PunyCode {
 	 * @return
 	 * @throws UtilException
 	 */
-	private static String decodeDomain(String domain) throws UtilException{
+	public static String decodeDomain(String domain) throws UtilException{
 		Assert.notNull(domain, "domain must not be null!");
 		String[] split = domain.split("\\.");
 		StringBuilder outStringBuilder = new StringBuilder();

--- a/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
@@ -15,4 +15,12 @@ public class PunyCodeTest {
 		decode = PunyCode.decode("xn--Hutool-ux9js33tgln");
 		Assert.assertEquals(text, decode);
 	}
+
+	@Test
+	public void encodeEncodeDomainTest(){
+		String domain = "赵新虎.中国";
+		String strPunyCode = PunyCode.encodeDomain(domain);
+		String decode = PunyCode.decodeDomain(strPunyCode);
+		Assert.assertEquals(decode, domain);
+	}
 }


### PR DESCRIPTION
#### 说明

针对当前punycode处理完整域名异常问题。当前punycode处理字符正常，但是处理完整域名是不符合punycode要求的。
如：“赵新虎”转码后为“xn--efvz93e52e”，这个是正常的。但是完整域名“赵新虎.中国”转码后为“xn--.-lq6ay5z8yp4o2b37i”，真实完整域名转码为punycode为“xn--efvz93e52e.xn--fiqs8s”，域名中间的“.”是需要特殊处理的。

### 修改描述(包括说明bug修复或者添加新特性)

1、 针对完整域名处理punycode的不准确性进行了补充。

2、 另外有一个建议：punycode本身就是针对域名来处理的，所以确实需要特殊处理。即原始的encode和decode方法是否可以使用encodeDomain和decodeDomain进行替换？