### PR TITLE
Fix: 修复 zip 被识别成 jar 和 apk 被识别成 jar 或 zip 的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
@@ -182,6 +182,8 @@ public class FileTypeUtil {
 				typeName = "war";
 			} else if ("ofd".equalsIgnoreCase(extName)) {
 				typeName = "ofd";
+			} else if ("apk".equalsIgnoreCase(extName)) {
+				typeName = "apk";
 			}
 		} else if ("jar".equals(typeName)) {
 			// wps编辑过的.xlsx文件与.jar的开头相同,通过扩展名判断
@@ -196,6 +198,8 @@ public class FileTypeUtil {
 				typeName = "pptx";
 			} else if ("zip".equalsIgnoreCase(extName)) {
 				typeName = "zip";
+			} else if ("apk".equalsIgnoreCase(extName)) {
+				typeName = "apk";
 			}
 		}
 		return typeName;

--- a/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileTypeUtil.java
@@ -194,6 +194,8 @@ public class FileTypeUtil {
 			} else if ("pptx".equalsIgnoreCase(extName)) {
 				// issue#I5A0GO
 				typeName = "pptx";
+			} else if ("zip".equalsIgnoreCase(extName)) {
+				typeName = "zip";
 			}
 		}
 		return typeName;


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复后缀为 zip 的文件被识别成 jar 的问题
2. [bug修复] 修复后缀为 apk 的文件被识别成 jar 或 zip 的问题