### PR TITLE
针对punycode进行优化方法名称

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -44,24 +44,13 @@ public class PunyCode {
 				}
 			}
 			if (encode) {
-				outStringBuilder.append(PunyCode.encode(string, true));
+				outStringBuilder.append(encode(string, true));
 			} else {
 				outStringBuilder.append(string);
 			}
 			outStringBuilder.append(".");
 		}
 		return outStringBuilder.substring(0, outStringBuilder.length() - 1);
-	}
-
-	/**
-	 * 将内容编码为PunyCode
-	 *
-	 * @param input 字符串
-	 * @return PunyCode字符串
-	 * @throws UtilException 计算异常
-	 */
-	public static String encode(CharSequence input) throws UtilException {
-		return encode(input, false);
 	}
 
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -139,13 +139,13 @@ public class PunyCode {
 
 	/**
 	 * 解码punycode域名
-	 * @param domain
+	 * @param punycode
 	 * @return
 	 * @throws UtilException
 	 */
-	public static String decode(String domain) throws UtilException{
-		Assert.notNull(domain, "domain must not be null!");
-		String[] split = domain.split("\\.");
+	public static String decode(String punycode) throws UtilException{
+		Assert.notNull(punycode, "punycode must not be null!");
+		String[] split = punycode.split("\\.");
 		StringBuilder outStringBuilder = new StringBuilder();
 		for (String string: split) {
 			if (string.startsWith(PUNY_CODE_PREFIX)) {

--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -30,7 +30,7 @@ public class PunyCode {
 	 * @return
 	 * @throws UtilException
 	 */
-	public static String encodeDomain(String domain) throws UtilException{
+	public static String encode(String domain) throws UtilException{
 		Assert.notNull(domain, "domain must not be null!");
 		String[] split = domain.split("\\.");
 		StringBuilder outStringBuilder = new StringBuilder();
@@ -44,7 +44,7 @@ public class PunyCode {
 				}
 			}
 			if (encode) {
-				outStringBuilder.append(encode(string, true));
+				outStringBuilder.append(encodeSingle(string, true));
 			} else {
 				outStringBuilder.append(string);
 			}
@@ -61,7 +61,7 @@ public class PunyCode {
 	 * @return PunyCode字符串
 	 * @throws UtilException 计算异常
 	 */
-	public static String encode(CharSequence input, boolean withPrefix) throws UtilException {
+	public static String encodeSingle(CharSequence input, boolean withPrefix) throws UtilException {
 		Assert.notNull(input, "input must not be null!");
 		int n = INITIAL_N;
 		int delta = 0;
@@ -143,13 +143,13 @@ public class PunyCode {
 	 * @return
 	 * @throws UtilException
 	 */
-	public static String decodeDomain(String domain) throws UtilException{
+	public static String decode(String domain) throws UtilException{
 		Assert.notNull(domain, "domain must not be null!");
 		String[] split = domain.split("\\.");
 		StringBuilder outStringBuilder = new StringBuilder();
 		for (String string: split) {
 			if (string.startsWith(PUNY_CODE_PREFIX)) {
-				outStringBuilder.append(decode(string));
+				outStringBuilder.append(decodeSingle(string));
 			} else {
 				outStringBuilder.append(string);
 			}
@@ -165,7 +165,7 @@ public class PunyCode {
 	 * @return 字符串
 	 * @throws UtilException 计算异常
 	 */
-	public static String decode(String input) throws UtilException {
+	public static String decodeSingle(String input) throws UtilException {
 		Assert.notNull(input, "input must not be null!");
 		input = StrUtil.removePrefixIgnoreCase(input, PUNY_CODE_PREFIX);
 

--- a/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
@@ -19,8 +19,8 @@ public class PunyCodeTest {
 	@Test
 	public void encodeEncodeDomainTest(){
 		String domain = "赵新虎.中国";
-		String strPunyCode = PunyCode.encode(domain);
-		String decode = PunyCode.decode(strPunyCode);
+		String encode = PunyCode.encode(domain);
+		String decode = PunyCode.decode(encode);
 		Assert.assertEquals(decode, domain);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/codec/PunyCodeTest.java
@@ -19,8 +19,8 @@ public class PunyCodeTest {
 	@Test
 	public void encodeEncodeDomainTest(){
 		String domain = "赵新虎.中国";
-		String strPunyCode = PunyCode.encodeDomain(domain);
-		String decode = PunyCode.decodeDomain(strPunyCode);
+		String strPunyCode = PunyCode.encode(domain);
+		String decode = PunyCode.decode(strPunyCode);
 		Assert.assertEquals(decode, domain);
 	}
 }


### PR DESCRIPTION
#### 针对punycode进行优化方法名称

针对punycode进行优化方法名称，用来使用域名转码解码的相关操作。并且删除了部分历史方法（因为其对域名操作不适用问题），并且调整了方法参数名称和所传值不对应问题

### 修改描述(包括说明bug修复或者添加新特性)

针对之前调整punycod建议(https://github.com/dromara/hutool/pull/2543)的优化