### PR TITLE
Ftp方法isDir和exist修复及改进

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
@@ -100,13 +100,15 @@ public abstract class AbstractFtp implements Closeable {
 		// 目录验证
 		if (isDir(path)) {
 			return true;
-		} else {
-			if (CharUtil.isFileSeparator(path.charAt(path.length() - 1))) {
-				return false;
-			}
+		}
+		if (CharUtil.isFileSeparator(path.charAt(path.length() - 1))) {
+			return false;
+		}
+		final String fileName = FileUtil.getName(path);
+		if (".".equals(fileName) || "..".equals(fileName)) {
+			return false;
 		}
 		// 文件验证
-		final String fileName = FileUtil.getName(path);
 		final String dir = StrUtil.removeSuffix(path, fileName);
 		final List<String> names;
 		try {

--- a/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
@@ -2,6 +2,7 @@ package cn.hutool.extra.ftp;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.io.FileUtil;
+import cn.hutool.core.util.CharUtil;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.StrUtil;
 
@@ -96,6 +97,15 @@ public abstract class AbstractFtp implements Closeable {
 	 * @return 是否存在
 	 */
 	public boolean exist(String path) {
+		// 目录验证
+		if (isDir(path)) {
+			return true;
+		} else {
+			if (CharUtil.isFileSeparator(path.charAt(path.length() - 1))) {
+				return false;
+			}
+		}
+		// 文件验证
 		final String fileName = FileUtil.getName(path);
 		final String dir = StrUtil.removeSuffix(path, fileName);
 		final List<String> names;

--- a/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
@@ -97,6 +97,9 @@ public abstract class AbstractFtp implements Closeable {
 	 * @return 是否存在
 	 */
 	public boolean exist(String path) {
+		if (StrUtil.isBlank(path)) {
+			return false;
+		}
 		// 目录验证
 		if (isDir(path)) {
 			return true;

--- a/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
@@ -112,7 +112,7 @@ public abstract class AbstractFtp implements Closeable {
 			return false;
 		}
 		// 文件验证
-		final String dir = StrUtil.removeSuffix(path, fileName);
+		final String dir = StrUtil.emptyToDefault(StrUtil.removeSuffix(path, fileName), ".");
 		final List<String> names;
 		try {
 			names = ls(dir);

--- a/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ftp/AbstractFtp.java
@@ -73,7 +73,12 @@ public abstract class AbstractFtp implements Closeable {
 	 * @since 5.7.5
 	 */
 	public boolean isDir(String dir) {
-		return cd(dir);
+		final String workDir = pwd();
+		try {
+			return cd(dir);
+		} finally {
+			cd(workDir);
+		}
 	}
 
 	/**

--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -106,6 +106,12 @@ public class FtpTest {
 	public void existSftpTest() throws Exception {
 		try (Sftp ftp = new Sftp("127.0.0.1", 22, "test", "test")) {
 			Console.log(ftp.pwd());
+			Console.log(ftp.exist(null));
+			Console.log(ftp.exist(""));
+			Console.log(ftp.exist("."));
+			Console.log(ftp.exist(".."));
+			Console.log(ftp.exist("/"));
+			Console.log(ftp.exist("a"));
 			Console.log(ftp.exist("/home/test"));
 			Console.log(ftp.exist("/home/test/"));
 			Console.log(ftp.exist("/home/test//////"));
@@ -122,11 +128,13 @@ public class FtpTest {
 	@Ignore
 	public void existFtpTest() throws Exception {
 		try (Ftp ftp = new Ftp("127.0.0.1", 21)) {
+			Console.log(ftp.pwd());
 			Console.log(ftp.exist(null));
 			Console.log(ftp.exist(""));
 			Console.log(ftp.exist("."));
 			Console.log(ftp.exist(".."));
 			Console.log(ftp.exist("/"));
+			Console.log(ftp.exist("a"));
 			Console.log(ftp.exist("/test"));
 			Console.log(ftp.exist("/test/"));
 			Console.log(ftp.exist("/test//////"));

--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -90,4 +90,14 @@ public class FtpTest {
 					FileUtil.file("d:/test/download/" + name));
 		}
 	}
+
+	@Test
+	@Ignore
+	public void isDirTest() throws Exception {
+		try (Ftp ftp = new Ftp("127.0.0.1", 21)) {
+			Console.log(ftp.pwd());
+			ftp.isDir("/test");
+			Console.log(ftp.pwd());
+		}
+	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -122,6 +122,11 @@ public class FtpTest {
 	@Ignore
 	public void existFtpTest() throws Exception {
 		try (Ftp ftp = new Ftp("127.0.0.1", 21)) {
+			Console.log(ftp.exist(null));
+			Console.log(ftp.exist(""));
+			Console.log(ftp.exist("."));
+			Console.log(ftp.exist(".."));
+			Console.log(ftp.exist("/"));
 			Console.log(ftp.exist("/test"));
 			Console.log(ftp.exist("/test/"));
 			Console.log(ftp.exist("/test//////"));
@@ -132,9 +137,7 @@ public class FtpTest {
 			Console.log(ftp.exist("///////////"));
 			Console.log(ftp.exist("./"));
 			Console.log(ftp.exist("./file1"));
-			Console.log(ftp.exist("."));
 			Console.log(ftp.exist("./2/3/4/.."));
-			Console.log(ftp.ls("./2/3/4/.."));
 			Console.log(ftp.pwd());
 		}
 	}

--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -100,4 +100,37 @@ public class FtpTest {
 			Console.log(ftp.pwd());
 		}
 	}
+
+	@Test
+	@Ignore
+	public void existSftpTest() throws Exception {
+		try (Sftp ftp = new Sftp("127.0.0.1", 22, "test", "test")) {
+			Console.log(ftp.pwd());
+			Console.log(ftp.exist("/home/test"));
+			Console.log(ftp.exist("/home/test/"));
+			Console.log(ftp.exist("/home/test//////"));
+			Console.log(ftp.exist("/home/test/file1"));
+			Console.log(ftp.exist("/home/test/file1/"));
+			Console.log(ftp.exist("///////////"));
+			Console.log(ftp.exist("./"));
+			Console.log(ftp.exist("./file1"));
+			Console.log(ftp.pwd());
+		}
+	}
+
+	@Test
+	@Ignore
+	public void existFtpTest() throws Exception {
+		try (Ftp ftp = new Ftp("127.0.0.1", 21)) {
+			Console.log(ftp.exist("/test/"));
+			Console.log(ftp.exist("/test/"));
+			Console.log(ftp.exist("/test//////"));
+			Console.log(ftp.exist("/file1"));
+			Console.log(ftp.exist("/file1/"));
+			Console.log(ftp.exist("///////////"));
+			Console.log(ftp.exist("./"));
+			Console.log(ftp.exist("./file1"));
+			Console.log(ftp.pwd());
+		}
+	}
 }

--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -122,14 +122,19 @@ public class FtpTest {
 	@Ignore
 	public void existFtpTest() throws Exception {
 		try (Ftp ftp = new Ftp("127.0.0.1", 21)) {
-			Console.log(ftp.exist("/test/"));
+			Console.log(ftp.exist("/test"));
 			Console.log(ftp.exist("/test/"));
 			Console.log(ftp.exist("/test//////"));
+			Console.log(ftp.exist("/test/.."));
+			Console.log(ftp.exist("/test/."));
 			Console.log(ftp.exist("/file1"));
 			Console.log(ftp.exist("/file1/"));
 			Console.log(ftp.exist("///////////"));
 			Console.log(ftp.exist("./"));
 			Console.log(ftp.exist("./file1"));
+			Console.log(ftp.exist("."));
+			Console.log(ftp.exist("./2/3/4/.."));
+			Console.log(ftp.ls("./2/3/4/.."));
 			Console.log(ftp.pwd());
 		}
 	}


### PR DESCRIPTION
#### 说明

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复了Ftp.isDir方法会修改pwd工作目录的问题
2. [bug修复] 修复了Ftp.exist方法判断以分割符结尾路径时判断错误的问题