### PR TITLE
增加使用模型写Excel文件时支持从java模型注解解析表头信息（中文表头、顺序、是否忽略某个字段）

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/annotation/HeadTitle.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/annotation/HeadTitle.java
@@ -1,0 +1,31 @@
+package cn.hutool.poi.excel.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Excel 字段注解<br>
+ * 该注解可用于通过模型对象导出数据到Excel时可通过注解模型字段进行导出标题、顺序、以及是否忽略该字段的控制
+ *
+ * @author dningcheng
+ * @since 5.8.6
+ */
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HeadTitle {
+	/**
+	 * 标题
+	 */
+	String title() default "";
+	/**
+	 * 顺序
+	 */
+	int index() default  1;
+	/**
+	 * 是否忽略
+	 */
+	boolean ignore() default false;
+
+}

--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/model/Title.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/model/Title.java
@@ -1,0 +1,47 @@
+package cn.hutool.poi.excel.model;
+
+/**
+ * Excel的模型标题封装类
+ *
+ * @author dningcheng
+ * @since 5.8.6
+ */
+public class Title {
+
+	private Integer index;
+	private String field;
+	private String title;
+
+	public Title() {
+	}
+
+	public Title(Integer index, String field, String title) {
+		this.index = index;
+		this.field = field;
+		this.title = title;
+	}
+
+	public Integer getIndex() {
+		return index;
+	}
+
+	public void setIndex(Integer index) {
+		this.index = index;
+	}
+
+	public String getField() {
+		return field;
+	}
+
+	public void setField(String field) {
+		this.field = field;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+}

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
@@ -28,15 +28,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * 写出Excel单元测试
@@ -885,4 +877,36 @@ public class ExcelWriteTest {
 		final String disposition = writer.getDisposition("测试A12.xlsx", CharsetUtil.CHARSET_UTF_8);
 		Assert.assertEquals("attachment; filename=\"%E6%B5%8B%E8%AF%95A12.xlsx\"", disposition);
 	}
+
+	/**
+	 * 测试注解模型属性后的写excel中 顺序、别名、忽略 特性是否生效
+	 *
+	 * @Author dningcheng
+	 **/
+	@Test
+	@Ignore
+	public static void writeModelAnnotationTest(){
+
+		String path = "/Users/ellie/Desktop/writeModel.xlsx";
+		FileUtil.del(path);
+
+		final ExcelWriter writer = ExcelUtil.getWriter(path);
+
+		List<TestAnnoBean> dataList = new ArrayList<>();
+		dataList.add(TestAnnoBean.builder()
+				.age(28)
+				.name("张三")
+				.score(100D)
+				.examDate(new Date())
+				.isPass(true).build());
+		dataList.add(TestAnnoBean.builder()
+				.age(24)
+				.name("李四")
+				.score(15D)
+				.examDate(new Date())
+				.isPass(false).build());
+		writer.write(dataList);
+		writer.close();
+	}
+
 }

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/TestAnnoBean.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/TestAnnoBean.java
@@ -1,0 +1,32 @@
+package cn.hutool.poi.excel;
+
+import cn.hutool.poi.excel.annotation.HeadTitle;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TestAnnoBean {
+
+	@HeadTitle(title = "人员姓名",index = 1)
+	private String name;
+
+	@HeadTitle(title = "人员年龄",index = 1,ignore = true)
+	private int age;
+
+	@HeadTitle(title = "人员成绩",index = 2)
+	private double score;
+
+	private boolean isPass;
+
+	@HeadTitle(ignore = true)
+	private Date examDate;
+
+	private String address;
+}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  增加使用java模型写excel时可通过注解指定生成的excel表头信息(别名、顺序、是否忽略某个字段),因为这个特性在几个其他三方excel工具类库早已存在而且好用,咱们能够支持更好! 
 测试用例参照: cn.hutool.poi.excel.ExcelWriteTest#writeModelAnnotationTest