### PR TITLE
扩展LocalDateTimeUtil.isIn方法使用场景

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
@@ -451,83 +451,6 @@ public class LocalDateTimeUtil {
 		return Period.between(startTimeInclude, endTimeExclude);
 	}
 
-
-	/**
-	 * 判断指定时间time是否在开始时间startTime和结束时间endTime范围内。
-	 * <p>
-	 * 通过isIncludeStart, isIncludeEnd参数控制时间范围区间是否为开区间
-	 * <p>
-	 * 例如：传入参数：isIncludeStart=true, isIncludeEnd=false
-	 * <p>
-	 * 则本方法会判断 time ∈ (start, end] 是否成立
-	 *
-	 * @param time           被比较的时间
-	 * @param start          开始时间, 应小于等于结束时间
-	 * @param end            结束时间，应大于等于开始时间
-	 * @param isIncludeStart 时间范围是否包含开始时间
-	 * @param isIncludeEnd   时间范围是否包含结束时间
-	 * @return true-在范围内，false-不在范围内
-	 * @author FengBaoheng
-	 * @since 5.8.6
-	 */
-	public static boolean isBetween(LocalDateTime time, LocalDateTime start, LocalDateTime end,
-									boolean isIncludeStart, boolean isIncludeEnd) {
-		if (time == null || start == null || end == null) {
-			throw new IllegalArgumentException("时间参数不可为null");
-		}
-
-		if(end.isBefore(start)){
-			throw new IllegalArgumentException("结束时间应大于等于开始时间");
-		}
-
-		// 先判断是否满足 time ∈ (start, end)
-		boolean isBetween = time.isAfter(start) && time.isBefore(end);
-
-		// 若不满足，则再判断是否在时间范围的边界上
-		if (!isBetween && isIncludeStart) {
-			isBetween = time.equals(start);
-		}
-
-		if (!isBetween && isIncludeEnd) {
-			isBetween = time.equals(end);
-		}
-
-		return isBetween;
-	}
-
-	/**
-	 * 判断指定时间time是否在开始时间startTime和结束时间endTime范围内。
-	 * <p>
-	 * 也即判断 time ∈ [startTime, endTime] 是否成立
-	 *
-	 * @param time      被比较的时间
-	 * @param startTime 开始时间, 应小于等于结束时间
-	 * @param endTime   结束时间，应大于等于开始时间
-	 * @return true-在范围内，false-不在范围内
-	 * @author FengBaoheng
-	 * @since 5.8.6
-	 */
-	public static boolean isBetween(LocalDateTime time, LocalDateTime startTime, LocalDateTime endTime) {
-		return isBetween(time, startTime, endTime, true, true);
-	}
-
-
-	/**
-	 * 判断当前时间（默认时区）是否在开始时间startTime和结束时间endTime范围内。
-	 * <p>
-	 * 也即判断 当前时间 ∈ [startTime, endTime] 是否成立
-	 *
-	 * @param startTime 开始时间, 应小于等于结束时间
-	 * @param endTime   结束时间，应大于等于开始时间
-	 * @return true-在范围内，false-不在范围内
-	 * @author FengBaoheng
-	 * @since 5.8.6
-	 */
-	public static boolean isBetween(LocalDateTime startTime, LocalDateTime endTime) {
-		return isBetween(LocalDateTimeUtil.now(), startTime, endTime);
-	}
-
-
 	/**
 	 * 修改为一天的开始时间，例如：2020-02-02 00:00:00,000
 	 *
@@ -676,6 +599,20 @@ public class LocalDateTimeUtil {
 	}
 
 	/**
+	 * 判断当前时间（默认时区）是否在指定范围内<br>
+	 * 起始时间和结束时间可以互换
+	 *
+	 * @param beginDate 起始时间（包含）
+	 * @param endDate   结束时间（包含）
+	 * @return 是否在范围内
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static boolean isIn(ChronoLocalDateTime<?> beginDate, ChronoLocalDateTime<?> endDate) {
+		return TemporalAccessorUtil.isIn(LocalDateTimeUtil.now(), beginDate, endDate);
+	}
+
+	/**
 	 * 当前日期是否在日期指定范围内<br>
 	 * 起始日期和结束日期可以互换
 	 *
@@ -685,7 +622,26 @@ public class LocalDateTimeUtil {
 	 * @return 是否在范围内
 	 * @since 5.8.5
 	 */
-	public static boolean isIn(ChronoLocalDateTime<?> date, ChronoLocalDateTime<?> beginDate, ChronoLocalDateTime<?> endDate){
+	public static boolean isIn(ChronoLocalDateTime<?> date, ChronoLocalDateTime<?> beginDate, ChronoLocalDateTime<?> endDate) {
 		return TemporalAccessorUtil.isIn(date, beginDate, endDate);
+	}
+
+	/**
+	 * 判断当前时间（默认时区）是否在指定范围内<br>
+	 * 起始时间和结束时间可以互换<br>
+	 * 通过includeBegin, includeEnd参数控制时间范围区间是否为开区间，例如：传入参数：includeBegin=true, includeEnd=false，
+	 * 则本方法会判断 date ∈ (beginDate, endDate] 是否成立
+	 *
+	 * @param beginDate    起始时间（包含）
+	 * @param endDate      结束时间（包含）
+	 * @param includeBegin 时间范围是否包含起始时间
+	 * @param includeEnd   时间范围是否包含结束时间
+	 * @return 是否在范围内
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static boolean isIn(ChronoLocalDateTime<?> date, ChronoLocalDateTime<?> beginDate,
+							   ChronoLocalDateTime<?> endDate, boolean includeBegin, boolean includeEnd) {
+		return TemporalAccessorUtil.isIn(date, beginDate, endDate, includeBegin, includeEnd);
 	}
 }

--- a/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
@@ -451,6 +451,75 @@ public class LocalDateTimeUtil {
 		return Period.between(startTimeInclude, endTimeExclude);
 	}
 
+
+	/**
+	 * 判断指定时间time是否在开始时间startTime和结束时间endTime范围内。
+	 * <p>
+	 * 通过isIncludeStart, isIncludeEnd参数控制时间范围区间是否为开区间
+	 * <p>
+	 * 例如：传入参数：isIncludeStart=true, isIncludeEnd=false
+	 * <p>
+	 * 则本方法会判断 time ∈ (start, end] 是否成立
+	 *
+	 * @param time           被比较的时间
+	 * @param start      开始时间, 应小于等于结束时间
+	 * @param end        结束时间，应大于等于开始时间
+	 * @param isIncludeStart 时间范围是否包含开始时间
+	 * @param isIncludeEnd   时间范围是否包含结束时间
+	 * @return true-在范围内，false-不在范围内
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static boolean isBetween(LocalDateTime time, LocalDateTime start, LocalDateTime end,
+									boolean isIncludeStart, boolean isIncludeEnd) {
+		// 先判断是否满足 time ∈ (start, end)
+		boolean isBetween = time.isAfter(start) && time.isBefore(end);
+
+		// 若不满足，则再判断是否在时间范围的边界上
+		if (!isBetween && isIncludeStart) {
+			isBetween = time.equals(start);
+		}
+
+		if (!isBetween && isIncludeEnd) {
+			isBetween = time.equals(end);
+		}
+
+		return isBetween;
+	}
+
+	/**
+	 * 判断指定时间time是否在开始时间startTime和结束时间endTime范围内。
+	 * <p>
+	 * 也即判断 time ∈ [startTime, endTime] 是否成立
+	 *
+	 * @param time      被比较的时间
+	 * @param startTime 开始时间, 应小于等于结束时间
+	 * @param endTime   结束时间，应大于等于开始时间
+	 * @return true-在范围内，false-不在范围内
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static boolean isBetween(LocalDateTime time, LocalDateTime startTime, LocalDateTime endTime) {
+		return isBetween(time, startTime, endTime, true, true);
+	}
+
+
+	/**
+	 * 判断当前时间（默认时区）是否在开始时间startTime和结束时间endTime范围内。
+	 * <p>
+	 * 也即判断 当前时间 ∈ [startTime, endTime] 是否成立
+	 *
+	 * @param startTime 开始时间, 应小于等于结束时间
+	 * @param endTime   结束时间，应大于等于开始时间
+	 * @return true-在范围内，false-不在范围内
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static boolean isBetween(LocalDateTime startTime, LocalDateTime endTime) {
+		return isBetween(LocalDateTimeUtil.now(), startTime, endTime);
+	}
+
+
 	/**
 	 * 修改为一天的开始时间，例如：2020-02-02 00:00:00,000
 	 *

--- a/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
@@ -462,8 +462,8 @@ public class LocalDateTimeUtil {
 	 * 则本方法会判断 time ∈ (start, end] 是否成立
 	 *
 	 * @param time           被比较的时间
-	 * @param start      开始时间, 应小于等于结束时间
-	 * @param end        结束时间，应大于等于开始时间
+	 * @param start          开始时间, 应小于等于结束时间
+	 * @param end            结束时间，应大于等于开始时间
 	 * @param isIncludeStart 时间范围是否包含开始时间
 	 * @param isIncludeEnd   时间范围是否包含结束时间
 	 * @return true-在范围内，false-不在范围内
@@ -472,6 +472,14 @@ public class LocalDateTimeUtil {
 	 */
 	public static boolean isBetween(LocalDateTime time, LocalDateTime start, LocalDateTime end,
 									boolean isIncludeStart, boolean isIncludeEnd) {
+		if (time == null || start == null || end == null) {
+			throw new IllegalArgumentException("时间参数不可为null");
+		}
+
+		if(end.isBefore(start)){
+			throw new IllegalArgumentException("结束时间应大于等于开始时间");
+		}
+
 		// 先判断是否满足 time ∈ (start, end)
 		boolean isBetween = time.isAfter(start) && time.isBefore(end);
 

--- a/hutool-core/src/main/java/cn/hutool/core/date/TemporalAccessorUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/TemporalAccessorUtil.java
@@ -180,11 +180,49 @@ public class TemporalAccessorUtil extends TemporalUtil{
 	 * @return 是否在范围内
 	 * @since 5.8.5
 	 */
-	public static boolean isIn(TemporalAccessor date, TemporalAccessor beginDate, TemporalAccessor endDate){
+	public static boolean isIn(TemporalAccessor date, TemporalAccessor beginDate, TemporalAccessor endDate) {
+		return isIn(date, beginDate, endDate, true, true);
+	}
+
+	/**
+	 * 当前日期是否在日期指定范围内<br>
+	 * 起始日期和结束日期可以互换<br>
+	 * 通过includeBegin, includeEnd参数控制日期范围区间是否为开区间，例如：传入参数：includeBegin=true, includeEnd=false，
+	 * 则本方法会判断 date ∈ (beginDate, endDate] 是否成立
+	 *
+	 * @param date         被检查的日期
+	 * @param beginDate    起始日期
+	 * @param endDate      结束日期
+	 * @param includeBegin 时间范围是否包含起始日期
+	 * @param includeEnd   时间范围是否包含结束日期
+	 * @return 是否在范围内
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static boolean isIn(TemporalAccessor date, TemporalAccessor beginDate, TemporalAccessor endDate,
+							   boolean includeBegin, boolean includeEnd) {
+		if (date == null || beginDate == null || endDate == null) {
+			throw new IllegalArgumentException("参数不可为null");
+		}
+
 		final long thisMills = toEpochMilli(date);
 		final long beginMills = toEpochMilli(beginDate);
 		final long endMills = toEpochMilli(endDate);
+		final long rangeMin = Math.min(beginMills, endMills);
+		final long rangeMax = Math.max(beginMills, endMills);
 
-		return thisMills >= Math.min(beginMills, endMills) && thisMills <= Math.max(beginMills, endMills);
+		// 先判断是否满足 date ∈ (beginDate, endDate)
+		boolean isIn = rangeMin < thisMills && thisMills < rangeMax;
+
+		// 若不满足，则再判断是否在时间范围的边界上
+		if (!isIn && includeBegin) {
+			isIn = thisMills == rangeMin;
+		}
+
+		if (!isIn && includeEnd) {
+			isIn = thisMills == rangeMax;
+		}
+
+		return isIn;
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -164,6 +164,12 @@ public class LocalDateTimeUtilTest {
 		Assert.assertFalse(LocalDateTimeUtil.isBetween(start, start, end, false, false));
 		Assert.assertTrue(LocalDateTimeUtil.isBetween(end, start, end, false, true));
 		Assert.assertFalse(LocalDateTimeUtil.isBetween(end, start, end, false, false));
+
+		// 异常入参
+		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(null, start, end, false, false));
+		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(start, null, end, false, false));
+		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(start, start, null, false, false));
+		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(start, end, start, false, false));
 	}
 
 	@Test

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -168,6 +168,11 @@ public class LocalDateTimeUtilTest {
 		// begin、end互换
 		Assert.assertTrue(LocalDateTimeUtil.isIn(begin, end, begin, true, true));
 
+		// 比较当前时间范围
+		LocalDateTime now = LocalDateTime.now();
+		Assert.assertTrue(LocalDateTimeUtil.isIn(now.minusHours(1L), now.plusHours(1L)));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(now.minusHours(1L), now.minusHours(2L)));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(now.plusHours(1L), now.plusHours(2L)));
 
 		// 异常入参
 		Assert.assertThrows(IllegalArgumentException.class, () -> LocalDateTimeUtil.isIn(null, begin, end, false, false));

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -140,6 +140,33 @@ public class LocalDateTimeUtilTest {
 	}
 
 	@Test
+	public void isBetween() {
+		// 时间范围 8点-9点
+		LocalDateTime start = LocalDateTime.parse("2019-02-02T08:00:00");
+		LocalDateTime end = LocalDateTime.parse("2019-02-02T09:00:00");
+
+		// 不在时间范围内 用例
+		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T06:00:00"), start, end));
+		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T13:00:00"), start, end));
+		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-01T08:00:00"), start, end));
+		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-03T09:00:00"), start, end));
+
+		// 在时间范围内 用例
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:00:00"), start, end));
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:00:01"), start, end));
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:11:00"), start, end));
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:22:00"), start, end));
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:59:59"), start, end));
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T09:00:00"), start, end));
+
+		// 测试边界条件
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(start, start, end, true, false));
+		Assert.assertFalse(LocalDateTimeUtil.isBetween(start, start, end, false, false));
+		Assert.assertTrue(LocalDateTimeUtil.isBetween(end, start, end, false, true));
+		Assert.assertFalse(LocalDateTimeUtil.isBetween(end, start, end, false, false));
+	}
+
+	@Test
 	public void beginOfDayTest() {
 		final LocalDateTime localDateTime = LocalDateTimeUtil.parse("2020-01-23T12:23:56");
 		final LocalDateTime beginOfDay = LocalDateTimeUtil.beginOfDay(localDateTime);

--- a/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/LocalDateTimeUtilTest.java
@@ -140,36 +140,39 @@ public class LocalDateTimeUtilTest {
 	}
 
 	@Test
-	public void isBetween() {
+	public void isIn() {
 		// 时间范围 8点-9点
-		LocalDateTime start = LocalDateTime.parse("2019-02-02T08:00:00");
+		LocalDateTime begin = LocalDateTime.parse("2019-02-02T08:00:00");
 		LocalDateTime end = LocalDateTime.parse("2019-02-02T09:00:00");
 
 		// 不在时间范围内 用例
-		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T06:00:00"), start, end));
-		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T13:00:00"), start, end));
-		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-01T08:00:00"), start, end));
-		Assert.assertFalse(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-03T09:00:00"), start, end));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T06:00:00"), begin, end));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T13:00:00"), begin, end));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-01T08:00:00"), begin, end));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-03T09:00:00"), begin, end));
 
 		// 在时间范围内 用例
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:00:00"), start, end));
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:00:01"), start, end));
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:11:00"), start, end));
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:22:00"), start, end));
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T08:59:59"), start, end));
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(LocalDateTime.parse("2019-02-02T09:00:00"), start, end));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T08:00:00"), begin, end));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T08:00:01"), begin, end));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T08:11:00"), begin, end));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T08:22:00"), begin, end));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T08:59:59"), begin, end));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(LocalDateTime.parse("2019-02-02T09:00:00"), begin, end));
 
 		// 测试边界条件
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(start, start, end, true, false));
-		Assert.assertFalse(LocalDateTimeUtil.isBetween(start, start, end, false, false));
-		Assert.assertTrue(LocalDateTimeUtil.isBetween(end, start, end, false, true));
-		Assert.assertFalse(LocalDateTimeUtil.isBetween(end, start, end, false, false));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(begin, begin, end, true, false));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(begin, begin, end, false, false));
+		Assert.assertTrue(LocalDateTimeUtil.isIn(end, begin, end, false, true));
+		Assert.assertFalse(LocalDateTimeUtil.isIn(end, begin, end, false, false));
+
+		// begin、end互换
+		Assert.assertTrue(LocalDateTimeUtil.isIn(begin, end, begin, true, true));
+
 
 		// 异常入参
-		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(null, start, end, false, false));
-		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(start, null, end, false, false));
-		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(start, start, null, false, false));
-		Assert.assertThrows(IllegalArgumentException.class, ()->LocalDateTimeUtil.isBetween(start, end, start, false, false));
+		Assert.assertThrows(IllegalArgumentException.class, () -> LocalDateTimeUtil.isIn(null, begin, end, false, false));
+		Assert.assertThrows(IllegalArgumentException.class, () -> LocalDateTimeUtil.isIn(begin, null, end, false, false));
+		Assert.assertThrows(IllegalArgumentException.class, () -> LocalDateTimeUtil.isIn(begin, begin, null, false, false));
 	}
 
 	@Test


### PR DESCRIPTION
### 修改描述
[新特性] 为LocalDateTimeUtil.isIn(date, beginDate,endDate)重载了2种新方法。 
重载1：isIn(beginDate,endDate) 判断**当前时间**是否在时间范围内。
重载2：isIn(date, beginDate, endDate, includeBegin, includeEnd), 末尾新增的两个boolean类型变量可决定时间范围区间的开、闭性。扩展了使用场景。

具体用法也可参考相应的单元测试用例