### PR TITLE
修复 murmur3 32 实现错误

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/hash/MurmurHash.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/hash/MurmurHash.java
@@ -95,11 +95,11 @@ public class MurmurHash implements Serializable{
 		int k1 = 0;
 		switch (length - idx) {
 		case 3:
-			k1 ^= data[idx + 2] << 16;
+			k1 ^= (data[idx + 2] & 0xff) << 16;
 		case 2:
-			k1 ^= data[idx + 1] << 8;
+			k1 ^= (data[idx + 1] & 0xff) << 8;
 		case 1:
-			k1 ^= data[idx];
+			k1 ^= (data[idx] & 0xff);
 
 			// mix functions
 			k1 *= C1_32;

--- a/hutool-core/src/test/java/cn/hutool/core/lang/hash/MurMurHashTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/hash/MurMurHashTest.java
@@ -9,15 +9,15 @@ public class MurMurHashTest {
 	@Test
 	public void hash32Test() {
 		int hv = MurmurHash.hash32(StrUtil.utf8Bytes("你"));
-		Assert.assertEquals(222142701, hv);
+		Assert.assertEquals(-1898877446, hv);
 
 		hv = MurmurHash.hash32(StrUtil.utf8Bytes("你好"));
-		Assert.assertEquals(1188098267, hv);
+		Assert.assertEquals(337357348, hv);
 
 		hv = MurmurHash.hash32(StrUtil.utf8Bytes("见到你很高兴"));
-		Assert.assertEquals(-1898490321, hv);
+		Assert.assertEquals(1101306141, hv);
 		hv = MurmurHash.hash32(StrUtil.utf8Bytes("我们将通过生成一个大的文件的方式来检验各种方法的执行效率因为这种方式在结束的时候需要执行文件"));
-		Assert.assertEquals(-1713131054, hv);
+		Assert.assertEquals(-785444229, hv);
 	}
 
 	@Test


### PR DESCRIPTION
修复 murmur3 32 在尾部计算未对齐部分数据时未做无符号转换导致在包含中文或部分字符串时与标准实现计算不相符

e.g.
![image](https://user-images.githubusercontent.com/90960002/190973542-3b375d16-9a8e-45cc-9106-cba4328b1fa5.png)
![image](https://user-images.githubusercontent.com/90960002/190973644-95a128f1-6376-4b74-916b-a5c70cdaae31.png)
![image](https://user-images.githubusercontent.com/90960002/190973705-c87b3d05-41d0-417f-882a-d8557ad2fac5.png)
