### PR TITLE
处理完整中文域名异常问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -42,7 +42,14 @@ public class PunyCode {
 			if (result.length() != 0) {
 				result.append(CharUtil.DOT);
 			}
-			result.append(encode(str, true));
+			boolean encode = false;
+			for (int i=0;i<str.length();i++) {
+				if (!isBasic(str.charAt(i))) {
+					encode = true;
+					break;
+				}
+			}
+			result.append(encode ? encode(str, true) : str);
 		}
 
 		return result.toString();
@@ -152,13 +159,14 @@ public class PunyCode {
 	 */
 	public static String decodeDomain(String domain) throws UtilException {
 		Assert.notNull(domain, "domain must not be null!");
+		domain = domain.toLowerCase();
 		final List<String> split = StrUtil.split(domain, CharUtil.DOT);
 		final StringBuilder result = new StringBuilder(domain.length() / 4 + 1);
 		for (final String str : split) {
 			if (result.length() != 0) {
 				result.append(CharUtil.DOT);
 			}
-			result.append(decode(str));
+			result.append(str.startsWith(PUNY_CODE_PREFIX) ? decode(str) : str);
 		}
 
 		return result.toString();


### PR DESCRIPTION
#### 说明
上次调整处理完整中文域名问题，在你合并之后有bug了。上次issues为：https://github.com/dromara/hutool/pull/2543
重新调整了一下。bug描述如下：
1、 完整中文域名“赵新虎.中国”，转化为punycode正常为“xn--efvz93e52e.xn--fiqs8s”。可是中文域名“赵新虎.com”转化punycode则异常，正常为“xn--efvz93e52e.com”，但实际转化为“xn--efvz93e52e.xn--com-”。
2、 关于解码bug如下：
“xn--efvz93e52e.xn--fiqs8s”解码正常“赵新虎.中国”。“xn--efvz93e52e.com”解码异常为“赵新虎.㯘”。并且punycde为大写时报错了。报错为：
`Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException
	at java.lang.System.arraycopy(Native Method)
	at java.lang.AbstractStringBuilder.insert(AbstractStringBuilder.java:1215)
	at java.lang.StringBuilder.insert(StringBuilder.java:338)
	at cn.hutool.core.codec.PunyCode.decode(PunyCode.java:227)
	at cn.hutool.core.codec.PunyCode.decodeDomain(PunyCode.java:161)
	at com.longming.normal.TestMain.main(TestMain.java:52)`


### 修改描述(包括说明bug修复或者添加新特性)
修复后能解决以上问题。