### PR TITLE
CharSequenceUtil.nullToDefault等方法支持传方法引用

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * {@link CharSequence} 相关工具类封装
@@ -296,6 +297,17 @@ public class CharSequenceUtil {
 	}
 
 	/**
+	 * 如果字符串是 {@code null}，则返回指定默认字符串，否则返回字符串本身。
+	 *
+	 * @param str        			要转换的字符串
+	 * @param defaultStrSupplier	默认字符串提供者
+	 * @return 字符串本身或指定的默认字符串
+	 */
+	public static String nullToDefault(CharSequence str, Supplier<String> defaultStrSupplier) {
+		return (str == null) ? defaultStrSupplier.get() : str.toString();
+	}
+
+	/**
 	 * 如果字符串是{@code null}或者&quot;&quot;，则返回指定默认字符串，否则返回字符串本身。
 	 *
 	 * <pre>
@@ -315,6 +327,17 @@ public class CharSequenceUtil {
 	}
 
 	/**
+	 * 如果字符串是{@code null}或者&quot;&quot;，则返回指定默认字符串，否则返回字符串本身。
+	 *
+	 * @param str        			要转换的字符串
+	 * @param defaultStrSupplier	默认字符串提供者
+	 * @return 字符串本身或指定的默认字符串
+	 */
+	public static String emptyToDefault(CharSequence str, Supplier<String> defaultStrSupplier) {
+		return isEmpty(str) ? defaultStrSupplier.get() : str.toString();
+	}
+
+	/**
 	 * 如果字符串是{@code null}或者&quot;&quot;或者空白，则返回指定默认字符串，否则返回字符串本身。
 	 *
 	 * <pre>
@@ -331,6 +354,17 @@ public class CharSequenceUtil {
 	 */
 	public static String blankToDefault(CharSequence str, String defaultStr) {
 		return isBlank(str) ? defaultStr : str.toString();
+	}
+
+	/**
+	 * 如果字符串是{@code null}或者&quot;&quot;或者空白，则返回指定默认字符串，否则返回字符串本身。
+	 *
+	 * @param str					要转换的字符串
+	 * @param defaultStrSupplier	默认字符串提供者
+	 * @return 字符串本身或指定的默认字符串
+	 */
+	public static String blankToDefault(CharSequence str, Supplier<String> defaultStrSupplier) {
+		return isBlank(str) ? defaultStrSupplier.get() : str.toString();
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
@@ -160,4 +160,33 @@ public class CharSequenceUtilTest {
 		a = null;
 		Assert.assertNull(CharSequenceUtil.trimToNull(a));
 	}
+
+	@Test
+	public void nullToDefaultTest() {
+		Assert.assertEquals(CharSequenceUtil.nullToDefault(null, this::defaultStrSupplier), "Hutool NO.1");
+		Assert.assertEquals(CharSequenceUtil.nullToDefault("", this::defaultStrSupplier), "");
+		Assert.assertEquals(CharSequenceUtil.nullToDefault(" ", this::defaultStrSupplier), " ");
+		Assert.assertEquals(CharSequenceUtil.nullToDefault("a", this::defaultStrSupplier), "a");
+	}
+
+	@Test
+	public void emptyToDefaultTest() {
+		Assert.assertEquals(CharSequenceUtil.emptyToDefault(null, this::defaultStrSupplier), "Hutool NO.1");
+		Assert.assertEquals(CharSequenceUtil.emptyToDefault("", this::defaultStrSupplier), "Hutool NO.1");
+		Assert.assertEquals(CharSequenceUtil.emptyToDefault(" ", this::defaultStrSupplier), " ");
+		Assert.assertEquals(CharSequenceUtil.emptyToDefault("a", this::defaultStrSupplier), "a");
+	}
+
+	@Test
+	public void blankToDefaultTest() {
+		Assert.assertEquals(CharSequenceUtil.blankToDefault(null, this::defaultStrSupplier), "Hutool NO.1");
+		Assert.assertEquals(CharSequenceUtil.blankToDefault("", this::defaultStrSupplier), "Hutool NO.1");
+		Assert.assertEquals(CharSequenceUtil.blankToDefault(" ", this::defaultStrSupplier), "Hutool NO.1");
+		Assert.assertEquals(CharSequenceUtil.blankToDefault("a", this::defaultStrSupplier), "a");
+	}
+
+	private String defaultStrSupplier() {
+		System.out.println("我被执行了");
+		return "Hutool NO.1";
+	}
 }


### PR DESCRIPTION
### 修改描述

1. [新特性] 
CharSequenceUtil.nullToDefault、emptyToDefault、blankToDefault方法，默认字符串支持传方法引用；

> 如下所示，经常会有多个字符串取值的场景；如果str1不为空，新方法不需要再执行CharSequenceUtil.blankToDefault(str2, str3)；
* 原方法： 
```
String result = CharSequenceUtil.blankToDefault(str1, CharSequenceUtil.blankToDefault(str2, str3));
```
* 新方法： 
```
String result = CharSequenceUtil.blankToDefault(str1, () -> CharSequenceUtil.blankToDefault(str2, str3));
```