### PR TITLE
修复：当使用 TableMap 构造 UrlQuery 对象时，出现部分参数丢失的问题（解决 issue#2671@Github）

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/net/url/UrlQuery.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/url/UrlQuery.java
@@ -156,7 +156,16 @@ public class UrlQuery {
 	 */
 	public UrlQuery addAll(Map<? extends CharSequence, ?> queryMap) {
 		if (MapUtil.isNotEmpty(queryMap)) {
-			queryMap.forEach(this::add);
+			if (queryMap instanceof TableMap) {
+				// TableMap 允许重复的 key，需要单独处理
+				@SuppressWarnings("unchecked")
+				TableMap<? extends CharSequence, ?> tableMap = ((TableMap<? extends CharSequence, ?>) queryMap);
+				for (Map.Entry<? extends CharSequence, ?> entry : tableMap) {
+					add(entry.getKey(), entry.getValue());
+				}
+			} else {
+				queryMap.forEach(this::add);
+			}
 		}
 		return this;
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/net/UrlQueryTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/UrlQueryTest.java
@@ -1,6 +1,7 @@
 package cn.hutool.core.net;
 
 import cn.hutool.core.map.MapUtil;
+import cn.hutool.core.map.TableMap;
 import cn.hutool.core.net.url.UrlBuilder;
 import cn.hutool.core.net.url.UrlQuery;
 import cn.hutool.core.util.CharsetUtil;
@@ -143,5 +144,19 @@ public class UrlQueryTest {
 		String queryStr = "signature=%2Br1ekUCGjXiu50Y%2Bk0MO4ovulK8%3D";
 		final UrlQuery query = UrlQuery.of(queryStr, null);
 		Assert.assertEquals(queryStr, query.toString());
+	}
+
+	@Test
+	public void buildUsingTableMapTest() {
+		// https://github.com/dromara/hutool/issues/2671
+		TableMap<String, String> value = new TableMap<>();
+		value.put("keys", "01");
+		value.put("keys", "02");
+		value.put("keys", "03");
+		value.put("keys", "01");
+		value.put("keys", "01");
+
+		String result = UrlQuery.of(value, true).build(StandardCharsets.UTF_8);
+		Assert.assertEquals("keys=01&keys=02&keys=03&keys=01&keys=01", result);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 当用 TableMap 构造 UrlQuery 对象时，会在 TableMap 包含重复键值对时只保留一个的问题

 #2671 本提交用于修复此问题，此问题还有另外一种修复方案，即重写 TableMap 从 Map 接口继承的 forEach 方法，但个人感觉 TableMap 本身还存在一些其他问题（实现了 Map 接口，却违背了 Map 接口本身的定义，以及一些默认方法没有重写），故这次选择修改 UrlQuery。


### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
3. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过