### PR TITLE
fixup! 文件名参数提取失败，并新增提取方法

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpResponse.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpResponse.java
@@ -626,7 +626,7 @@ public class HttpResponse extends HttpBase<HttpResponse> implements Closeable {
 	 *
 	 * @return 文件名，empty表示无
 	 */
-	private String getFileNameFromDisposition() {
+	public String getFileNameFromDisposition() {
 		return getFileNameFromDisposition("filename");
 	}
 
@@ -636,7 +636,7 @@ public class HttpResponse extends HttpBase<HttpResponse> implements Closeable {
 	 *
 	 * @return 文件名，empty表示无
 	 */
-	private String getFileNameFromDisposition(String paramName) {
+	public String getFileNameFromDisposition(String paramName) {
 		String fileName = null;
 		final String disposition = header(Header.CONTENT_DISPOSITION);
 		if (StrUtil.isNotBlank(disposition)) {

--- a/hutool-http/src/main/java/cn/hutool/http/HttpResponse.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpResponse.java
@@ -622,15 +622,25 @@ public class HttpResponse extends HttpBase<HttpResponse> implements Closeable {
 	}
 
 	/**
-	 * 从Content-Disposition头中获取文件名
+	 * 从Content-Disposition头中获取文件名，默认为 filename
 	 *
 	 * @return 文件名，empty表示无
 	 */
 	private String getFileNameFromDisposition() {
+		return getFileNameFromDisposition("filename");
+	}
+
+	/**
+	 * 从Content-Disposition头中获取文件名
+	 * @param paramName 文件参数名
+	 *
+	 * @return 文件名，empty表示无
+	 */
+	private String getFileNameFromDisposition(String paramName) {
 		String fileName = null;
 		final String disposition = header(Header.CONTENT_DISPOSITION);
 		if (StrUtil.isNotBlank(disposition)) {
-			fileName = ReUtil.get("filename=\"(.*?)\"", disposition, 1);
+			fileName = ReUtil.get(paramName+"=\"(.*?)\"", disposition, 1);
 			if (StrUtil.isBlank(fileName)) {
 				fileName = StrUtil.subAfter(disposition, "filename=", true);
 			}


### PR DESCRIPTION
#### 说明

提交分支v5-master

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] `HttpResponse` 无法提取自定义文件参数名。
2. [新特性]  新增 getFileNameFromDisposition 方法，可自定义读取文件名。

`cn.hutool.http.HttpResponse#getFileNameFromDisposition`


### 提交前自测
