### PR TITLE
添加泛型元素求和的方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -1,5 +1,6 @@
 package cn.hutool.core.util;
 
+import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.exceptions.UtilException;
 import cn.hutool.core.lang.Assert;
 import cn.hutool.core.math.Calculator;
@@ -13,6 +14,7 @@ import java.text.ParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * 数字工具类<br>
@@ -190,6 +192,27 @@ public class NumberUtil {
 			}
 		}
 		return result;
+	}
+
+	/**
+	 * 提供精确的加法运算<br>
+	 * 如果传入多个值为null或者空，则返回0
+	 *
+	 * @param items       元素列表，为null的忽略
+	 * @param valueGetter 元素的数值字段获取函数
+	 * @param <T>         元素类型
+	 * @param <V>         数值类型
+	 * @return 和
+	 * @author FengBaoheng
+	 * @since 5.8.6
+	 */
+	public static <T, V extends Number> BigDecimal add(Collection<T> items, Function<? super T, ? extends V> valueGetter) {
+		if (CollUtil.isEmpty(items) || valueGetter == null) {
+			return BigDecimal.ZERO;
+		}
+
+		Number[] values = CollUtil.map(items, valueGetter, true).toArray(new Number[0]);
+		return add(values);
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -1,13 +1,16 @@
 package cn.hutool.core.util;
 
+import cn.hutool.core.collection.ListUtil;
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.lang.Console;
+import lombok.Getter;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -46,6 +49,52 @@ public class NumberUtilTest {
 	public void addTest4() {
 		final BigDecimal result = NumberUtil.add(new BigDecimal("133"), new BigDecimal("331"));
 		Assert.assertEquals(new BigDecimal("464"), result);
+	}
+
+	/**
+	 * 测试泛型元素求和
+	 */
+	@Test
+	public void addTest5() {
+		// 父类
+		@Getter
+		class Person {
+			private final Integer age;
+
+			public Person(Integer age) {
+				this.age = age;
+			}
+		}
+
+		// 学生子类
+		@Getter
+		class Student extends Person {
+			private final BigDecimal score;
+
+			public Student(Integer age, BigDecimal score) {
+				super(age);
+				this.score = score;
+			}
+		}
+
+		Student s1 = new Student(10, new BigDecimal("100"));
+		Student s2 = new Student(9, new BigDecimal("60.5"));
+		Student s3 = new Student(11, null);
+		Student s4 = new Student(null, new BigDecimal("90.5"));
+		Student s5 = new Student(null, null);
+		List<Student> students = ListUtil.of(s1, s2, s3, s4, s5, null);
+
+		BigDecimal sumAge = NumberUtil.add(students, Person::getAge);
+		Assert.assertEquals(new BigDecimal("30"), sumAge);
+
+		BigDecimal sumScore = NumberUtil.add(students, Student::getScore);
+		Assert.assertEquals(new BigDecimal("251.0"), sumScore);
+
+		Assert.assertEquals(BigDecimal.ZERO, NumberUtil.add(students, null));
+
+		Assert.assertEquals(BigDecimal.ZERO, NumberUtil.add(ListUtil.empty(), Student::getScore));
+
+		Assert.assertEquals(BigDecimal.ZERO, NumberUtil.add(null, Student::getScore));
 	}
 
 	@Test


### PR DESCRIPTION
### 修改描述
1. [新特性]  NumberUtil中新增了泛型列表求和方法add()

### 目的
在业务代码中，对复杂Bean中的某几个统计字段进行求和时发现，总是会先提取字段值，再调用求和方法。
为了简化这种代码，希望扩展hutool中NumberUtil类的add方法，使用泛型入参简化上述逻辑。
示例场景可见单元测试

### 其他扩展
sub mul 可同步进行修改

