### PR TITLE
fix: 修复 BeanUtil#copyProperties 源对象与目标对象都是 Map 时设置忽略属性无效问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/copier/CopyOptions.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/copier/CopyOptions.java
@@ -12,6 +12,8 @@ import cn.hutool.core.util.ReflectUtil;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -68,6 +70,11 @@ public class CopyOptions implements Serializable {
 	 * 是否覆盖目标值，如果不覆盖，会先读取目标对象的值，非{@code null}则写，否则忽略。如果覆盖，则不判断直接写
 	 */
 	protected boolean override = true;
+
+	/**
+	 * 源对象和目标对象都是 {@code Map} 时, 需要忽略的源对象 {@code Map} key
+	 */
+	private Set<Object> ignoreKeySet;
 
 	/**
 	 * 自定义类型转换器，默认使用全局万能转换器转换
@@ -181,6 +188,7 @@ public class CopyOptions implements Serializable {
 	 * @return CopyOptions
 	 */
 	public CopyOptions setIgnoreProperties(String... ignoreProperties) {
+		this.setIgnoreKeySet(ignoreProperties);
 		return setPropertiesFilter((field, o) -> false == ArrayUtil.contains(ignoreProperties, field.getName()));
 	}
 
@@ -218,6 +226,16 @@ public class CopyOptions implements Serializable {
 	 */
 	public CopyOptions ignoreError() {
 		return setIgnoreError(true);
+	}
+
+	/**
+	 * 设置忽略源 {@link Map} key set
+	 * @param ignoreProperties 忽略的key
+	 * @return CopyOptions
+	 */
+	public CopyOptions setIgnoreKeySet(String... ignoreProperties) {
+		this.ignoreKeySet = new HashSet<>(Arrays.asList(ignoreProperties));
+		return this;
 	}
 
 	/**
@@ -362,5 +380,15 @@ public class CopyOptions implements Serializable {
 	 */
 	protected boolean testPropertyFilter(Field field, Object value) {
 		return null == this.propertiesFilter || this.propertiesFilter.test(field, value);
+	}
+
+	/**
+	 * 测试是否保留key, {@code true} 不保留， {@code false} 保留
+	 *
+	 * @param key {@link Map} key
+	 * @return 是否保留
+	 */
+	protected boolean testMapKeyFilter(Object key) {
+		return this.ignoreKeySet.contains(key);
 	}
 }

--- a/hutool-core/src/main/java/cn/hutool/core/bean/copier/MapToMapCopier.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/copier/MapToMapCopier.java
@@ -54,6 +54,12 @@ public class MapToMapCopier extends AbsCopier<Map, Map> {
 				return;
 			}
 
+			// 忽略不需要拷贝的 key,
+			if (true == copyOptions.testMapKeyFilter(sKey)) {
+				return;
+			}
+
+
 			// 获取目标值真实类型并转换源值
 			final Type[] typeArguments = TypeUtil.getTypeArguments(this.targetType);
 			if (null != typeArguments) {

--- a/hutool-core/src/test/java/cn/hutool/core/bean/Issue2697Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/Issue2697Test.java
@@ -1,0 +1,24 @@
+package cn.hutool.core.bean;
+
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * https://github.com/dromara/hutool/issues/2697
+ */
+public class Issue2697Test {
+
+	@Test
+	public void mapToMapTest(){
+		Map<String, String> mapA = new HashMap<>(16);
+		mapA.put("12", "21");
+		mapA.put("121", "21");
+		mapA.put("122", "21");
+		Map<String, String> mapB = new HashMap<>(16);
+		BeanUtil.copyProperties(mapA, mapB, "12");
+		System.out.println(mapB);
+	}
+}


### PR DESCRIPTION
closes #2697

#### 说明

1. 已 PR 到 v5-dev
2. 代码风格已保持一致
3. src/test/java下已添加 Issue2697Test 测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复 BeanUtil#copyProperties 设置忽略属性无效 #2697，CopyOptions 增加 ignoreKeySet 属性存放需要忽略的 Map key 

