### PR TITLE
fix: flaky tests in hutool-json(#2709)

### DIFF
--- a/hutool-json/src/test/java/cn/hutool/json/Issues1881Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issues1881Test.java
@@ -2,6 +2,7 @@ package cn.hutool.json;
 
 import lombok.Data;
 import lombok.experimental.Accessors;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,6 +32,10 @@ public class Issues1881Test {
 		holderContactVOList.add(new ThingsHolderContactVO().setId(1L).setName("1"));
 		holderContactVOList.add(new ThingsHolderContactVO().setId(2L).setName("2"));
 
-		Assert.assertEquals("[{\"id\":1,\"name\":\"1\"},{\"id\":2,\"name\":\"2\"}]", JSONUtil.parseArray(holderContactVOList).toString());
+		Assert.assertThat(JSONUtil.parseArray(holderContactVOList).toString(),
+				CoreMatchers.anyOf(CoreMatchers.is("[{\"id\":1,\"name\":\"1\"},{\"id\":2,\"name\":\"2\"}]"),
+						CoreMatchers.is("[{\"id\":1,\"name\":\"1\"},{\"name\":\"2\",\"id\":2}]"),
+						CoreMatchers.is("[{\"name\":\"1\",\"id\":1},{\"id\":2,\"name\":\"2\"}]"),
+						CoreMatchers.is("[{\"name\":\"1\",\"id\":1},{\"name\":\"2\",\"id\":2}]")));
 	}
 }

--- a/hutool-json/src/test/java/cn/hutool/json/TransientTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/TransientTest.java
@@ -1,6 +1,7 @@
 package cn.hutool.json;
 
 import lombok.Data;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -21,7 +22,7 @@ public class TransientTest {
 		//noinspection MismatchedQueryAndUpdateOfCollection
 		final JSONObject jsonObject = new JSONObject(detailBill,
 				JSONConfig.create().setTransientSupport(false));
-		Assert.assertEquals("{\"id\":\"3243\",\"bizNo\":\"bizNo\"}", jsonObject.toString());
+		Assert.assertThat(jsonObject.toString(), CoreMatchers.anyOf(CoreMatchers.is("{\"id\":\"3243\",\"bizNo\":\"bizNo\"}"), CoreMatchers.is("{\"bizNo\":\"bizNo\",\"id\":\"3243\"}")));
 	}
 
 	@Test


### PR DESCRIPTION
将对象转换为 JSON 时，元素的顺序是未定义的。测试应该能够处理所有这些情况，否则它们有时可能会失败。