### PR TITLE
1.[bug修复] key为弱引用 value为强引用 会导致key无法被回收 弱引用失效

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/intern/WeakInterner.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/intern/WeakInterner.java
@@ -2,6 +2,8 @@ package cn.hutool.core.lang.intern;
 
 import cn.hutool.core.map.WeakConcurrentMap;
 
+import java.lang.ref.WeakReference;
+
 /**
  * 使用WeakHashMap(线程安全)存储对象的规范化对象，注意此对象需单例使用！<br>
  *
@@ -10,13 +12,16 @@ import cn.hutool.core.map.WeakConcurrentMap;
  */
 public class WeakInterner<T> implements Interner<T>{
 
-	private final WeakConcurrentMap<T, T> cache = new WeakConcurrentMap<>();
+	private final WeakConcurrentMap<T, WeakReference<T>> cache = new WeakConcurrentMap<>();
 
-	@Override
 	public T intern(T sample) {
-		if(null == sample){
+		if (sample == null) {
 			return null;
 		}
-		return cache.computeIfAbsent(sample, (key)->sample);
+		T val;
+		do {
+			val = this.cache.computeIfAbsent(sample, WeakReference::new).get();
+		} while (val == null);
+		return val;
 	}
 }


### PR DESCRIPTION
1. [bug修复] 弱引用队列 利用WeakConcurrentMap时 key value为相同对象 会导致弱引用的key无法被回收