### PR TITLE
修复在高版本jdk下测试用例不通过的问题(https://github.com/dromara/hutool/issues/2739)

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/stream/EntryStreamTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/stream/EntryStreamTest.java
@@ -4,7 +4,16 @@ import cn.hutool.core.map.multi.Table;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -116,7 +125,7 @@ public class EntryStreamTest {
 		final List<Integer> keys = new ArrayList<>();
 		EntryStream.of(Arrays.asList(new Entry<>(1, 1), new Entry<>(1, 2), new Entry<>(2, 1), new Entry<>(2, 2)))
 			.peekKey(keys::add)
-			.count();
+			.collect(Collectors.toList());
 		Assert.assertEquals(Arrays.asList(1, 1, 2, 2), keys);
 	}
 
@@ -125,7 +134,7 @@ public class EntryStreamTest {
 		final List<Integer> values = new ArrayList<>();
 		EntryStream.of(Arrays.asList(new Entry<>(1, 1), new Entry<>(1, 2), new Entry<>(2, 1), new Entry<>(2, 2)))
 			.peekValue(values::add)
-			.count();
+			.collect(Collectors.toList());
 		Assert.assertEquals(Arrays.asList(1, 2, 1, 2), values);
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/stream/EntryStreamTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/stream/EntryStreamTest.java
@@ -125,7 +125,7 @@ public class EntryStreamTest {
 		final List<Integer> keys = new ArrayList<>();
 		EntryStream.of(Arrays.asList(new Entry<>(1, 1), new Entry<>(1, 2), new Entry<>(2, 1), new Entry<>(2, 2)))
 			.peekKey(keys::add)
-			.collect(Collectors.toList());
+			.toList();
 		Assert.assertEquals(Arrays.asList(1, 1, 2, 2), keys);
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/stream/EntryStreamTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/stream/EntryStreamTest.java
@@ -134,7 +134,7 @@ public class EntryStreamTest {
 		final List<Integer> values = new ArrayList<>();
 		EntryStream.of(Arrays.asList(new Entry<>(1, 1), new Entry<>(1, 2), new Entry<>(2, 1), new Entry<>(2, 2)))
 			.peekValue(values::add)
-			.collect(Collectors.toList());
+			.toList();
 		Assert.assertEquals(Arrays.asList(1, 2, 1, 2), values);
 	}
 


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

fix  #2739 

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过