### PR TITLE
新增Lambda树形转换工具

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/LambdaTreeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/LambdaTreeUtil.java
@@ -1,0 +1,39 @@
+package cn.hutool.core.lang.tree.lambda;
+
+import java.util.List;
+
+/**
+ * Lambda树形转换工具
+ *
+ * @author adoph
+ * @version 1.0
+ * @since 2022/8/30
+ */
+public class LambdaTreeUtil {
+
+	/**
+	 * 树形构造器
+	 *
+	 * @param treeNodes 原节点数据集
+	 * @param <E>       节点类型
+	 * @param <R>       节点标识类型
+	 * @return {@link TreeBuilder}
+	 */
+	public static <E, R> TreeBuilder<E, R> builder(List<E> treeNodes) {
+		return new TreeBuilder<>(treeNodes);
+	}
+
+	/**
+	 * 树形构造器（指定根节点标识）
+	 *
+	 * @param treeNodes 原节点数据集
+	 * @param rootPid   根据点标识
+	 * @param <E>       节点类型
+	 * @param <R>       节点标识类型
+	 * @return {@link TreeBuilder}
+	 */
+	public static <E, R> TreeBuilder<E, R> builder(List<E> treeNodes, R rootPid) {
+		return new TreeBuilder<>(treeNodes, rootPid);
+	}
+
+}

--- a/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/MethodHandleRuntimeException.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/MethodHandleRuntimeException.java
@@ -1,0 +1,35 @@
+package cn.hutool.core.lang.tree.lambda;
+
+import cn.hutool.core.exceptions.ExceptionUtil;
+import cn.hutool.core.util.StrUtil;
+
+/**
+ * MethodHandle调用异常包装
+ *
+ * @author adoph
+ * @version 1.0
+ * @since 2022/11/25
+ */
+public class MethodHandleRuntimeException extends RuntimeException {
+
+	public MethodHandleRuntimeException(Throwable e) {
+		super(ExceptionUtil.getMessage(e), e);
+	}
+
+	public MethodHandleRuntimeException(String message) {
+		super(message);
+	}
+
+	public MethodHandleRuntimeException(String messageTemplate, Object... params) {
+		super(StrUtil.format(messageTemplate, params));
+	}
+
+	public MethodHandleRuntimeException(String message, Throwable throwable) {
+		super(message, throwable);
+	}
+
+	public MethodHandleRuntimeException(Throwable throwable, String messageTemplate, Object... params) {
+		super(StrUtil.format(messageTemplate, params), throwable);
+	}
+
+}

--- a/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/MethodHandleUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/MethodHandleUtil.java
@@ -1,0 +1,59 @@
+package cn.hutool.core.lang.tree.lambda;
+
+import cn.hutool.core.lang.func.Func1;
+import cn.hutool.core.lang.func.LambdaUtil;
+
+import java.lang.invoke.MethodType;
+import java.util.List;
+
+import static java.lang.invoke.MethodHandles.lookup;
+
+/**
+ * MethodHandleUtil
+ *
+ * @author adoph
+ * @version 1.0
+ * @since 2022/9/12
+ */
+public class MethodHandleUtil {
+
+	/**
+	 * setChildrenMethodType
+	 */
+	private static final MethodType setChildrenMethodType = MethodType.methodType(void.class, List.class);
+
+	/**
+	 * 根据get lambda方法获取set方法名
+	 */
+	protected static <T> String requireSetMethod(Func1<T, ?> func) {
+		return LambdaUtil.getMethodName(func).replaceFirst("get", "set");
+	}
+
+	/**
+	 * 通过MethodHandle调用方法
+	 *
+	 * @param obj        调用对象
+	 * @param params     参数
+	 * @param methodName 方法名
+	 */
+	protected static <E> void invokeByMethodHandle(E obj, List<E> params, String methodName) throws MethodHandleRuntimeException {
+		try {
+			invokeByMethodHandle(obj, params, methodName, setChildrenMethodType);
+		} catch (Throwable e) {
+			throw new MethodHandleRuntimeException("invoke by method handle exception", e);
+		}
+	}
+
+	/**
+	 * 通过MethodHandle调用方法
+	 *
+	 * @param obj        调用对象
+	 * @param params     参数
+	 * @param methodName 方法名
+	 * @param methodType MethodType
+	 */
+	protected static <E> void invokeByMethodHandle(E obj, List<E> params, String methodName, MethodType methodType) throws Throwable {
+		lookup().findVirtual(obj.getClass(), methodName, methodType).bindTo(obj).invokeExact(params);
+	}
+
+}

--- a/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/TreeBuilder.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/TreeBuilder.java
@@ -1,0 +1,236 @@
+package cn.hutool.core.lang.tree.lambda;
+
+import cn.hutool.core.lang.Assert;
+import cn.hutool.core.lang.func.Func1;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
+
+/**
+ * 树构造器
+ *
+ * @param <E> 树节点类型
+ * @param <R> 树节点标识类型
+ * @author adoph
+ */
+public class TreeBuilder<E, R> {
+
+	/**
+	 * 未指定根节点标识构造器
+	 *
+	 * @param treeNodes 原树节点集
+	 */
+	public TreeBuilder(List<E> treeNodes) {
+		this.treeNodes = treeNodes;
+	}
+
+	/**
+	 * 指定根节点标识构造器
+	 *
+	 * @param treeNodes 原树节点集
+	 * @param rootPid   根节点标识
+	 */
+	public TreeBuilder(List<E> treeNodes, R rootPid) {
+		this.treeNodes = treeNodes;
+		this.rootPid = rootPid;
+	}
+
+	/**
+	 * 原树节点集
+	 */
+	private final List<E> treeNodes;
+
+	/**
+	 * 根节点父标识
+	 */
+	private R rootPid;
+
+	/**
+	 * 获取节点标识表示func
+	 */
+	private Function<E, R> id;
+
+	/**
+	 * 获取父节点标识func
+	 */
+	private Function<E, R> pid;
+
+	/**
+	 * 获取子节点集func
+	 */
+	private Func1<E, List<E>> children;
+
+	/**
+	 * setChildrenMethodName
+	 */
+	private String setChildrenMethodName;
+
+	/**
+	 * 排序字段func，仅支持整数类型（Byte、Short、Integer、Long）
+	 */
+	private ToLongFunction<E> sort;
+
+	/**
+	 * 设置节点标识func
+	 *
+	 * @param id 获取节点标识func
+	 * @return this
+	 */
+	public TreeBuilder<E, R> id(Function<E, R> id) {
+		this.id = id;
+		return this;
+	}
+
+	/**
+	 * 设置节点父标识func
+	 *
+	 * @param pid 获取节点父标识func
+	 * @return this
+	 */
+	public TreeBuilder<E, R> pid(Function<E, R> pid) {
+		this.pid = pid;
+		return this;
+	}
+
+	/**
+	 * 设置子节点集func
+	 *
+	 * @param children 获取子节点集func
+	 * @return this
+	 */
+	public TreeBuilder<E, R> children(Func1<E, List<E>> children) {
+		this.children = children;
+		return this;
+	}
+
+	/**
+	 * 设置排序func
+	 *
+	 * @param sort 获取排序func
+	 * @return this
+	 */
+	public TreeBuilder<E, R> sort(ToLongFunction<E> sort) {
+		this.sort = sort;
+		return this;
+	}
+
+	/**
+	 * 开始构建树
+	 *
+	 * @return this
+	 */
+	public List<E> build() {
+		Assert.notNull(treeNodes, "treeNodes is null!");
+		Assert.notNull(id, "getId function is null!");
+		Assert.notNull(pid, "getPid function is null!");
+		Assert.notNull(children, "getChildren function is null!");
+
+		if (treeNodes.isEmpty()) {
+			return treeNodes;
+		}
+
+		// 获取设置子节点集方法名称
+		setChildrenMethodName = MethodHandleUtil.requireSetMethod(children);
+
+		if (Objects.isNull(rootPid)) {
+			// 未指定根节点标识
+			return doBuild();
+		}
+
+		// 指定根节点标识
+		return doBuild(rootPid);
+	}
+
+	/**
+	 * 指定根节点标识构建
+	 *
+	 * @param rootPid 根节点标识
+	 * @return 树形结构集
+	 */
+	public List<E> doBuild(R rootPid) {
+		List<E> tmpList = new ArrayList<>(treeNodes);
+
+		// 按父节点分组
+		Map<R, List<E>> treeMap = tmpList.stream().collect(Collectors.groupingBy(node -> pid.apply(node)));
+
+		// 排序
+		if (Objects.nonNull(sort)) {
+			treeMap.forEach((k, v) -> v.sort(Comparator.comparingLong(sort)));
+		}
+
+		// 根节点集
+		List<E> rootNodes = treeMap.get(rootPid);
+
+		rootNodes.forEach(node -> buildChild(node, treeMap));
+
+		return rootNodes;
+	}
+
+	/**
+	 * 未指定根节点标识构建
+	 *
+	 * @return 树形结构集
+	 */
+	public List<E> doBuild() {
+		List<E> tmpList = new ArrayList<>(treeNodes);
+		for (E node1 : treeNodes) {
+			for (E node2 : treeNodes) {
+				if (!Objects.equals(id.apply(node1), id.apply(node2))) {
+					if (Objects.equals(id.apply(node1), pid.apply(node2))) {
+						List<E> subNodes = null;
+						try {
+							subNodes = children.call(node1);
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+						if (subNodes == null) {
+							subNodes = new ArrayList<>();
+							setChildrenByMethodHandle(node1, subNodes);
+						}
+						subNodes.add(node2);
+						// 排序子节点
+						if (Objects.nonNull(sort)) {
+							subNodes.sort(Comparator.comparingLong(sort));
+						}
+						tmpList.remove(node2);
+					}
+				}
+			}
+		}
+
+		// 排序根节点
+		if (Objects.nonNull(sort) && tmpList.size() > 1) {
+			tmpList.sort(Comparator.comparingLong(sort));
+		}
+
+		return tmpList;
+	}
+
+	/**
+	 * 构建子节点集
+	 *
+	 * @param pNode   父节点
+	 * @param treeMap 分组节点集
+	 */
+	private void buildChild(E pNode, Map<R, List<E>> treeMap) {
+		R tmpPid = id.apply(pNode);
+		List<E> tmpChildren = treeMap.get(tmpPid);
+		if (Objects.nonNull(tmpChildren)) {
+			setChildrenByMethodHandle(pNode, tmpChildren);
+			tmpChildren.forEach(node -> buildChild(node, treeMap));
+		}
+	}
+
+	/**
+	 * 通过MethodHandle设置子节点集
+	 *
+	 * @param pNode    父节点
+	 * @param children 子节点集
+	 */
+	private void setChildrenByMethodHandle(E pNode, List<E> children) {
+		MethodHandleUtil.invokeByMethodHandle(pNode, children, setChildrenMethodName);
+	}
+
+}

--- a/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/package-info.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/tree/lambda/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Lambda树形转换工具
+ * <p>
+ * 背景说明：基于Lambda实现一个快捷易用的树形转换工具，此思想来源于Mybatis-plus的LambdaQuery实现。
+ * 核心主要是依赖lambda获取到 SerializedLambda，再通过SerializedLambda获取到对应的方法名，
+ * 最后结合MethodHandle进行方法调用（性能有待考究。这里使用反射也同样能够实现，但是我们知道反射在性能
+ * 上一直存在一些诟病。 而MethodHandle是模拟字节码层次的方法调用，虚拟机在这方面的优化空间会更大）。
+ * </p>
+ * <p>
+ * 优势：
+ * 无须转换指定的bean对象，使用示例：
+ * <code>
+ *     List<Menu> treeData = LambdaTreeUtil.builder(menuList, 0L)
+ * 				.id(Menu::getId) // 指定节点标识function
+ * 				.pid(Menu::getPid) // 指定父节点标识function
+ * 				.children(Menu::getChildren) // 指定子节点集function
+ * 				.sort(Menu::getSortNum) //指定排序function
+ * 				.build();
+ * </code>
+ * <p/>
+ *
+ * 本人源代码地址：https://github.com/SmithAdoph/AdophCloud/tree/master/adoph-framework/src/main/java/com/adoph/framework/util/tree/v4
+ * @author adoph
+ */
+package cn.hutool.core.lang.tree.lambda;

--- a/hutool-core/src/test/java/cn/hutool/core/lang/tree/lambda/LambdaTreeTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/tree/lambda/LambdaTreeTest.java
@@ -1,0 +1,109 @@
+package cn.hutool.core.lang.tree.lambda;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * LambdaTreeTest
+ *
+ * @author adoph
+ * @version 1.0
+ * @since 2022/11/25
+ */
+public class LambdaTreeTest {
+
+	static List<Menu> menuList = new ArrayList<>();
+
+	/*
+	 *	首页
+	 *	用户管理
+	 *		/用户列表
+	 *	任务管理
+	 *		/未处理任务
+	 *		/已完成任务
+	 *		/历史人物
+	 *	工单管理
+	 *		/我的工单
+	 */
+	static {
+		menuList.add(new Menu(1L, 0L, "首页", 1));
+		menuList.add(new Menu(2L, 0L, "用户管理", 2));
+		menuList.add(new Menu(3L, 0L, "任务管理", 3));
+		menuList.add(new Menu(4L, 0L, "工单管理", 1));
+		menuList.add(new Menu(5L, 2L, "用户列表", 1));
+		menuList.add(new Menu(7L, 3L, "未处理任务", 2));
+		menuList.add(new Menu(8L, 3L, "已完成任务", 3));
+		menuList.add(new Menu(9L, 3L, "历史任务", 1));
+		menuList.add(new Menu(10L, 4L, "我的工单", 1));
+	}
+
+	@Test
+	public void lambdaTreeTest() {
+		List<Menu> treeData = LambdaTreeUtil.builder(menuList, 0L)
+				.id(Menu::getId) // 指定节点标识function
+				.pid(Menu::getPid) // 指定父节点标识function
+				.children(Menu::getChildren) // 指定子节点集function
+				.sort(Menu::getSortNum) //指定排序function
+				.build();
+		Assert.assertEquals(4, treeData.size());
+	}
+
+}
+
+class Menu {
+	private Long id;
+	private Long pid;
+	private String name;
+	private Integer sortNum;
+	private List<Menu> children;
+
+	public Menu(Long id, Long pid, String name, Integer sortNum) {
+		this.id = id;
+		this.pid = pid;
+		this.name = name;
+		this.sortNum = sortNum;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public Long getPid() {
+		return pid;
+	}
+
+	public void setPid(Long pid) {
+		this.pid = pid;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Integer getSortNum() {
+		return sortNum;
+	}
+
+	public void setSortNum(Integer sortNum) {
+		this.sortNum = sortNum;
+	}
+
+	public List<Menu> getChildren() {
+		return children;
+	}
+
+	public void setChildren(List<Menu> children) {
+		this.children = children;
+	}
+}


### PR DESCRIPTION
### 扁平结构转树形结构工具类
> 基于Lambda实现一个快捷易用的树形转换工具，此思想来源于Mybatis-plus的LambdaQuery实现。核心主要是依赖lambda获取到再通过SerializedLambda获取到对应的方法名，最后结合MethodHandle进行方法调用（性能有待考究。这里使用反射也同样能够实现，但是我们知道反射在性能上一直存在一些诟病。而MethodHandle是模拟字节码层次的方法调用，虚拟机在这方面的优化空间会更大）。 

#### [代码示例](https://github.com/SmithAdoph/hutool/blob/v5-dev/hutool-core/src/test/java/cn/hutool/core/lang/tree/lambda/LambdaTreeTest.java) 
```java
List<Menu> treeData = LambdaTreeUtil.builder(menuList, 0L)
				.id(Menu::getId) // 指定节点标识function
				.pid(Menu::getPid) // 指定父节点标识function
				.children(Menu::getChildren) // 指定子节点集function
				.sort(Menu::getSortNum) //指定排序function
				.build();