### PR TITLE
HtmlUtil方法加局部final修饰

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HtmlUtil.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HtmlUtil.java
@@ -1,5 +1,6 @@
 package cn.hutool.http;
 
+import cn.hutool.core.text.StrBuilder;
 import cn.hutool.core.util.EscapeUtil;
 import cn.hutool.core.util.ReUtil;
 import cn.hutool.core.util.StrUtil;
@@ -184,11 +185,11 @@ public class HtmlUtil {
 	 * @return 编码后的字符
 	 */
 	private static String encode(String text) {
-		int len;
+		final int len;
 		if ((text == null) || ((len = text.length()) == 0)) {
 			return StrUtil.EMPTY;
 		}
-		StringBuilder buffer = new StringBuilder(len + (len >> 2));
+		final StrBuilder buffer = StrBuilder.create(len + (len >> 2));
 		char c;
 		for (int i = 0; i < len; i++) {
 			c = text.charAt(i);


### PR DESCRIPTION
1.HtmlUtil方法（编码文本的方法：encode）加局部final修饰
说明：html文本相对来说都是大文本，加final约束：1.访问局部变量要比访问成员变量要快；2.访问局部变量要比每次调用方法去获取对象要快；3.使用final修饰可以避免变量被重新赋值(引用赋值) ；4.使用final修饰时，JVM不用去跟踪该引用是否被更改；

注：代码能力有限，但想做点共享，还请指教！