### PR TITLE
修改：HtmlUtil中cleanHtmlTag方法和removeScriptTag方法的“替换空文本”，修改为静态常量空字符变量

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/regex/ReUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/regex/ReUtil.java
@@ -876,6 +876,9 @@ public class ReUtil {
 			return StrUtil.str(content);
 		}
 
+		// replacementTemplate字段不能为null，否则无法抉择如何处理结果
+		Assert.notNull(replacementTemplate, "ReplacementTemplate must be not null !");
+
 		final Matcher matcher = pattern.matcher(content);
 		boolean result = matcher.find();
 		if (result) {

--- a/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
@@ -116,6 +116,16 @@ public class ReUtilTest {
 	}
 
 	@Test
+	public void replaceAllTest3() {
+		// 修改前：ReUtil.replaceAll()方法，当replacementTemplate为null对象时，出现空指针异常
+		final String str = null;
+		// Assert.assertThrows(NullPointerException.class, () -> ReUtil.replaceAll(content, "(\\d+)", str));
+
+		// 修改后：判断ReUtil.replaceAll()方法，当replacementTemplate为null对象时，提示为非法的参数异常：ReplacementTemplate must be not null !
+		Assert.assertThrows(IllegalArgumentException.class, () -> ReUtil.replaceAll(content, "(\\d+)", str));
+	}
+
+	@Test
 	public void replaceTest() {
 		final String str = "AAABBCCCBBDDDBB";
 		String replace = StrUtil.replace(str, 0, "BB", "22", false);

--- a/hutool-http/src/main/java/cn/hutool/http/html/HtmlUtil.java
+++ b/hutool-http/src/main/java/cn/hutool/http/html/HtmlUtil.java
@@ -93,7 +93,7 @@ public class HtmlUtil {
 	 * @return 清除标签后的文本
 	 */
 	public static String cleanHtmlTag(final String content) {
-		return ReUtil.replaceAll(content, RE_HTML_MARK, "");
+		return ReUtil.replaceAll(content, RE_HTML_MARK, StrUtil.EMPTY);
 	}
 
 	/**
@@ -103,7 +103,7 @@ public class HtmlUtil {
 	 * @return 清除标签后的文本
 	 */
 	public static String removeScriptTag(final String content) {
-		return ReUtil.replaceAll(content, RE_SCRIPT, "");
+		return ReUtil.replaceAll(content, RE_SCRIPT, StrUtil.EMPTY);
 	}
 
 	/**


### PR DESCRIPTION
HtmlUtil中cleanHtmlTag方法和removeScriptTag方法的“替换空文本”，修改为静态常量空字符变量

@looly 请查收