### PR TITLE
修改：HtmlUtil中cleanHtmlTag方法和removeScriptTag方法的“替换空文本”，修改为静态常量空字符变量

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/html/HtmlUtil.java
+++ b/hutool-http/src/main/java/cn/hutool/http/html/HtmlUtil.java
@@ -93,7 +93,7 @@ public class HtmlUtil {
 	 * @return 清除标签后的文本
 	 */
 	public static String cleanHtmlTag(final String content) {
-		return ReUtil.replaceAll(content, RE_HTML_MARK, "");
+		return ReUtil.replaceAll(content, RE_HTML_MARK, StrUtil.EMPTY);
 	}
 
 	/**
@@ -103,7 +103,7 @@ public class HtmlUtil {
 	 * @return 清除标签后的文本
 	 */
 	public static String removeScriptTag(final String content) {
-		return ReUtil.replaceAll(content, RE_SCRIPT, "");
+		return ReUtil.replaceAll(content, RE_SCRIPT, StrUtil.EMPTY);
 	}
 
 	/**


### PR DESCRIPTION
HtmlUtil中cleanHtmlTag方法和removeScriptTag方法的“替换空文本”，修改为静态常量空字符变量

@looly 请查收