### PR TITLE
fix：ReUtil.replaceAll()方法，当replacementTemplate为null对象时，出现空指针异常

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/regex/ReUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/regex/ReUtil.java
@@ -876,6 +876,9 @@ public class ReUtil {
 			return StrUtil.str(content);
 		}
 
+		// replacementTemplate字段不能为null，否则无法抉择如何处理结果
+		Assert.notNull(replacementTemplate, "ReplacementTemplate must be not null !");
+
 		final Matcher matcher = pattern.matcher(content);
 		boolean result = matcher.find();
 		if (result) {

--- a/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
@@ -116,6 +116,16 @@ public class ReUtilTest {
 	}
 
 	@Test
+	public void replaceAllTest3() {
+		// 修改前：ReUtil.replaceAll()方法，当replacementTemplate为null对象时，出现空指针异常
+		final String str = null;
+		// Assert.assertThrows(NullPointerException.class, () -> ReUtil.replaceAll(content, "(\\d+)", str));
+
+		// 修改后：判断ReUtil.replaceAll()方法，当replacementTemplate为null对象时，提示为非法的参数异常：ReplacementTemplate must be not null !
+		Assert.assertThrows(IllegalArgumentException.class, () -> ReUtil.replaceAll(content, "(\\d+)", str));
+	}
+
+	@Test
 	public void replaceTest() {
 		final String str = "AAABBCCCBBDDDBB";
 		String replace = StrUtil.replace(str, 0, "BB", "22", false);

--- a/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ReUtilTest.java
@@ -119,10 +119,15 @@ public class ReUtilTest {
 	public void replaceAllTest3() {
 		// 修改前：ReUtil.replaceAll()方法，当replacementTemplate为null对象时，出现空指针异常
 		final String str = null;
-		// Assert.assertThrows(NullPointerException.class, () -> ReUtil.replaceAll(content, "(\\d+)", str));
+		final Pattern pattern = Pattern.compile("(\\d+)");
+		// Assert.assertThrows(NullPointerException.class, () -> ReUtil.replaceAll(content, pattern, str));
+
+		// 修改后：测试正常的方法访问是否有效
+		final String replaceAll = ReUtil.replaceAll(content, pattern, parameters -> "->" + parameters.group(1) + "<-");
+		Assert.assertEquals("ZZZaaabbbccc中文->1234<-", replaceAll);
 
 		// 修改后：判断ReUtil.replaceAll()方法，当replacementTemplate为null对象时，提示为非法的参数异常：ReplacementTemplate must be not null !
-		Assert.assertThrows(IllegalArgumentException.class, () -> ReUtil.replaceAll(content, "(\\d+)", str));
+		Assert.assertThrows(IllegalArgumentException.class, () -> ReUtil.replaceAll(content, pattern, str));
 	}
 
 	@Test


### PR DESCRIPTION
fix：ReUtil.replaceAll()方法，当replacementTemplate为null对象时，出现空指针异常

因为替换模板为null对象，不知道后续带替换的字符串如何处理，所以，增加一个不为空的判断条件，防止空指针异常再次发生！
Assert.notNull(replacementTemplate, "ReplacementTemplate must be not null !");

@looly 请查收