### PR TITLE
解决FtpTest.java的downloadTest下载会将文件夹下载成文件的问题

### DIFF
--- a/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/ftp/FtpTest.java
@@ -91,12 +91,19 @@ public class FtpTest {
 	@Test
 	@Ignore
 	public void downloadTest() {
-		try(final Ftp ftp = new Ftp("localhost")){
-			final List<String> fileNames = ftp.ls("temp/");
-			for(final String name: fileNames) {
-				ftp.download("",
-						name,
-						FileUtil.file("d:/test/download/" + name));
+		String downloadPath = "d:/test/download/";
+		try (final Ftp ftp = new Ftp("localhost")) {
+			final List<FTPFile> ftpFiles = ftp.lsFiles("temp/", null);
+			for (final FTPFile ftpFile : ftpFiles) {
+				String name = ftpFile.getName();
+				if (ftpFile.isDirectory()) {
+					File dp = new File(downloadPath + name);
+					if (!dp.exists()) {
+						dp.mkdir();
+					}
+				} else {
+					ftp.download("", name, FileUtil.file(downloadPath + name));
+				}
 			}
 		} catch (final IOException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
fix:解决FtpTest.java的downloadTest下载会将文件夹下载成文件的问题