### PR TITLE
增加追踪列方法

### DIFF
--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/BigExcelWriteTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/BigExcelWriteTest.java
@@ -246,4 +246,47 @@ public class BigExcelWriteTest {
 		writer.autoSizeColumnAll();
 		writer.close();
 	}
+
+	@Test
+	@Ignore
+	public void autoSizeTrackedColumnsTest() {
+		// 通过工具类创建writer
+		String path = "d:/test/autoSizeTrackedColumnsTest.xlsx";
+		FileUtil.del(path);
+		BigExcelWriter writer = ExcelUtil.getBigWriter(1);
+		writer.setDestFile(FileUtil.file(path));
+		writer.addHeaderAlias("id", "SN");
+		writer.addHeaderAlias("userName", "User Name");
+
+		List<List<Map<String, Object>>> list = new ArrayList<>();
+		List<Map<String, Object>> row0 = new ArrayList<>();
+		row0.add(new HashMap<String, Object>() {
+			private static final long serialVersionUID = 1L;
+
+			{
+				put("id", 1);
+				put("userName", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+			}
+		});
+		List<Map<String, Object>> row1 = new ArrayList<>();
+		row1.add(new HashMap<String, Object>() {
+			private static final long serialVersionUID = 1L;
+
+			{
+				put("id", 22);
+				put("userName", "bbbbbbbbbbbbbb");
+			}
+		});
+		list.add(row0);
+		list.add(row1);
+
+		writer.write(list.get(0), false);
+		writer.trackColumnForAutoSizing(0); //从第一行开始追踪
+		writer.write(list.get(1), false);
+		writer.trackColumnForAutoSizing(1); //从第二行开始追踪
+		writer.autoSizeTrackedColumnAll();
+		writer.untrackColumnForAutoSizing(0);
+		writer.untrackColumnForAutoSizing(1);
+		writer.close();
+	}
 }


### PR DESCRIPTION
```
final SXSSFSheet sheet = (SXSSFSheet) this.sheet;
sheet.trackColumnForAutoSizing(columnIndex);
super.autoSizeColumn(columnIndex);
sheet.untrackColumnForAutoSizing(columnIndex);
```
上述写法的效果是计算当前滑窗内的最大列宽，并不是整个文件的最大列宽，可以通过将单元测试的滑窗大小改为1复现
```
BigExcelWriter writer = ExcelUtil.getBigWriter(1);
```
SXSSFSheet的源码同时从内部缓存和当前滑窗取得各自的最大列宽，最后取最大值设置列宽，所以如果想找到全局最大列宽，需要手动在数据写入硬盘前调用`trackColumnsForAutoSizing`