### PR TITLE
新增类 StrTemplate 实现了自定义字符串参数装配，以及反向解析

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/StrTemplate.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/StrTemplate.java
@@ -114,6 +114,21 @@ public class StrTemplate {
 
 	/**
 	 * 格式化文本，使用 {varName} 占位<br>
+	 * map = {a: "aValue", b: "bValue"} format("{a} and {b}", map) ---=》 aValue and bValue<br>
+	 * 默认忽略null值:即Map中没有的参数或值为null的不会进行替换
+	 *
+	 * @param template 文本模板，被替换的部分用 {key} 表示
+	 * @param map      参数值对
+	 * @return 格式化后的文本
+	 * @since 5.8.12
+	 */
+	public String format(CharSequence template, Map<?, ?> map){
+		return format(template, map, true);
+
+	}
+
+	/**
+	 * 格式化文本，使用 {varName} 占位<br>
 	 * map = {a: "aValue", b: "bValue"} format("{a} and {b}", map) ---=》 aValue and bValue
 	 *
 	 * @param template   文本模板，被替换的部分用 {key} 表示
@@ -139,10 +154,10 @@ public class StrTemplate {
 			String name = templateStr.substring(tS + DEFAULT_PREFIX.length(), tE);
 			String patton = templateStr.substring(tS, tE + DEFAULT_SUFFIX.length());
 			Object value = map.get(name);
-			if (ignoreNull && null == value) {
+			if (!ignoreNull && null == value) {
 				value = "";
 			}
-			if (!ignoreNull && null == value) {
+			if (ignoreNull && null == value) {
 				tE = tS + templateStr.length();
 				continue;
 			}
@@ -151,6 +166,23 @@ public class StrTemplate {
 
 		}
 		return templateStr;
+	}
+
+	/**
+	 * 解析格式化后的参数，使用 {@link StrTemplate#DEFAULT_PREFIX} 与 {@link StrTemplate#DEFAULT_SUFFIX} 内字符串 作为参数名<br>
+	 * 将格式化后的字符串按照文本模板解析对应的参数<br>
+	 * 例：<br>
+	 * 通常使用：<br>
+	 * template: siot/sys/{productKey}/{deviceKey}/property/{get}<br>
+	 * formatStr: siot/sys/11/22/property/33<br>
+	 *
+	 * @param template  文本模板，参数名为 {@link StrTemplate#DEFAULT_PREFIX} 与 {@link StrTemplate#DEFAULT_SUFFIX} 内字符串
+	 * @param formatStr 已经完成了字符串参数替换后的文本
+	 * @return 解析对应的参数Map
+	 * @since 5.8.12
+	 */
+	public Map<String, String> parse(CharSequence template, CharSequence formatStr){
+		return parse(template.toString(), formatStr.toString());
 	}
 
 

--- a/hutool-core/src/main/java/cn/hutool/core/text/StrTemplate.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/StrTemplate.java
@@ -1,0 +1,202 @@
+package cn.hutool.core.text;
+
+import cn.hutool.core.util.StrUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * 常用参数替换与解析方法
+ *
+ * @author ZhuBobi
+ * @since 5.8.12
+ */
+public class StrTemplate {
+
+	/**
+	 * 解析或替换变量的开始标志
+	 **/
+	private static String DEFAULT_PREFIX = "{";
+
+	/**
+	 * 解析或替换变量的结束标志
+	 **/
+	private static String DEFAULT_SUFFIX = "}";
+
+	/**
+	 * 默认构造方式：使用 { } 来标记变量：如/{param1}/hello
+	 **/
+	private static StrTemplate template = getInstance();
+
+	/**
+	 * 私有构造方法，只能通过 getInstance 方法来获取实例
+	 **/
+	private StrTemplate() {
+	}
+
+	/**
+	 * 私有构造方法，只能通过 getInstance 方法来获取实例
+	 *
+	 * @param prefix 参数起始标志前缀
+	 * @param suffix 参数结束标志后缀
+	 */
+	private StrTemplate(String prefix, String suffix) {
+		DEFAULT_PREFIX = prefix;
+		DEFAULT_SUFFIX = suffix;
+	}
+
+	/**
+	 * 通过 getInstance 方法来获取实例
+	 *
+	 * @param prefix 参数起始标志前缀
+	 * @param suffix 参数结束标志后缀
+	 */
+	public synchronized static StrTemplate getInstance(String prefix, String suffix) {
+		if (null == template) {
+			template = new StrTemplate(prefix, suffix);
+		} else if (!DEFAULT_PREFIX.equals(prefix)) {
+			DEFAULT_PREFIX = prefix;
+			DEFAULT_SUFFIX = suffix;
+		}
+		return template;
+	}
+
+
+	/**
+	 * 通过 getInstance 方法来获取实例，不带参数即默认使用 {  } 作为参数标志
+	 */
+	public synchronized static StrTemplate getInstance() {
+		if (null == template) {
+			template = new StrTemplate();
+		}
+		return template;
+	}
+
+	/**
+	 * 格式化文本，使用 {index} 占位, 按照下标进行替换<br>
+	 * 例如：<br>
+	 * template: I say {0} {1} to the {1} 或 I say {} {} to the {}<br>
+	 * args: ["hello","world"]<br>
+	 *
+	 * @param template   文本模板，被替换的部分用 {index} 表示
+	 * @param args       参数数组
+	 * @return 格式化后的文本
+	 * @since 5.8.12
+	 */
+	public String format(CharSequence template, Object... args) {
+		if (null == template || template.length() == 0) {
+			return null;
+		}
+
+		String templateStr = template.toString();
+		int tE = 0;
+		int index = 0;
+		while (true) {
+			int tS = templateStr.indexOf(DEFAULT_PREFIX, tE);
+			if (tS == -1) {
+				break;
+			}
+			tE = templateStr.indexOf(DEFAULT_SUFFIX, tS);
+			String substring = templateStr.substring(tS + DEFAULT_PREFIX.length(), tE);
+			if(StrUtil.isNotEmpty(substring)){
+				index = Integer.parseInt(substring);
+			}
+
+			String patton = templateStr.substring(tS, tE + DEFAULT_SUFFIX.length());
+			templateStr = StrUtil.replace(templateStr, patton, args[index].toString());
+			tE = tS + args[index].toString().length();
+			index++;
+
+		}
+		return templateStr;
+	}
+
+	/**
+	 * 格式化文本，使用 {varName} 占位<br>
+	 * map = {a: "aValue", b: "bValue"} format("{a} and {b}", map) ---=》 aValue and bValue
+	 *
+	 * @param template   文本模板，被替换的部分用 {key} 表示
+	 * @param map        参数值对
+	 * @param ignoreNull 是否忽略 {@code null} 值，忽略则 {@code null} 值对应的变量不被替换，否则替换为""
+	 * @return 格式化后的文本
+	 * @since 5.8.12
+	 */
+	public String format(CharSequence template, Map<?, ?> map, boolean ignoreNull) {
+
+		if (null == template || template.length() == 0) {
+			return null;
+		}
+
+		String templateStr = template.toString();
+		int tE = 0;
+		while (true) {
+			int tS = templateStr.indexOf(DEFAULT_PREFIX, tE);
+			if (tS == -1) {
+				break;
+			}
+			tE = templateStr.indexOf(DEFAULT_SUFFIX, tS);
+			String name = templateStr.substring(tS + DEFAULT_PREFIX.length(), tE);
+			String patton = templateStr.substring(tS, tE + DEFAULT_SUFFIX.length());
+			Object value = map.get(name);
+			if(ignoreNull && null == value ){
+				value = "";
+			}
+			if(!ignoreNull && null == value){
+				tE = tS + templateStr.length();
+				continue;
+			}
+			templateStr = StrUtil.replace(templateStr, patton, value.toString());
+			tE = tS + value.toString().length();
+
+		}
+		return templateStr;
+	}
+
+
+	/**
+	 * 解析格式化后的参数，使用 {@link StrTemplate#DEFAULT_PREFIX} 与 {@link StrTemplate#DEFAULT_SUFFIX} 内字符串 作为参数名<br>
+	 * 将格式化后的字符串按照文本模板解析对应的参数<br>
+	 * 例：<br>
+	 * 通常使用：<br>
+	 * template: siot/sys/{productKey}/{deviceKey}/property/{get}<br>
+	 * formatStr: siot/sys/11/22/property/33<br>
+	 *
+	 * @param template  文本模板，参数名为 {@link StrTemplate#DEFAULT_PREFIX} 与 {@link StrTemplate#DEFAULT_SUFFIX} 内字符串
+	 * @param formatStr 已经完成了字符串参数替换后的文本
+	 * @return 解析对应的参数Map
+	 * @since 5.8.12
+	 */
+	public Map<String, String> parse(String template, String formatStr) {
+
+		Map<String, String> result = new HashMap<>();
+		int indexT = 0;
+		int indexF = 0;
+		int fS;
+		while (true) {
+			int tS = template.indexOf(DEFAULT_PREFIX, indexT);
+			if (tS == -1) {
+				break;
+			}
+			int tE = template.indexOf(DEFAULT_SUFFIX, tS);
+			if (tE == template.length() - DEFAULT_SUFFIX.length()) {
+				int i = formatStr.lastIndexOf(template.charAt(tS - 1));
+				result.put(template.substring(tS + DEFAULT_PREFIX.length(), tE), formatStr.substring(i + 1));
+				break;
+			}
+
+			if (indexF == 0) {
+				fS = tS;
+			} else {
+				fS = indexF + tS - indexT - DEFAULT_SUFFIX.length();
+			}
+			int fE = formatStr.indexOf(template.charAt(tE + DEFAULT_SUFFIX.length()), fS);
+			result.put(template.substring(tS + DEFAULT_PREFIX.length(), tE), formatStr.substring(fS, fE));
+			indexF = fE;
+			indexT = tE;
+		}
+		return result;
+	}
+
+
+}

--- a/hutool-core/src/main/java/cn/hutool/core/text/StrTemplate.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/StrTemplate.java
@@ -32,7 +32,7 @@ public class StrTemplate {
 	/**
 	 * 私有构造方法，只能通过 getInstance 方法来获取实例
 	 **/
-	private StrTemplate() {
+	private StrTemplate(){
 	}
 
 	/**
@@ -41,7 +41,7 @@ public class StrTemplate {
 	 * @param prefix 参数起始标志前缀
 	 * @param suffix 参数结束标志后缀
 	 */
-	private StrTemplate(String prefix, String suffix) {
+	private StrTemplate(String prefix, String suffix){
 		DEFAULT_PREFIX = prefix;
 		DEFAULT_SUFFIX = suffix;
 	}
@@ -52,7 +52,7 @@ public class StrTemplate {
 	 * @param prefix 参数起始标志前缀
 	 * @param suffix 参数结束标志后缀
 	 */
-	public synchronized static StrTemplate getInstance(String prefix, String suffix) {
+	public synchronized static StrTemplate getInstance(String prefix, String suffix){
 		if (null == template) {
 			template = new StrTemplate(prefix, suffix);
 		} else if (!DEFAULT_PREFIX.equals(prefix)) {
@@ -66,7 +66,7 @@ public class StrTemplate {
 	/**
 	 * 通过 getInstance 方法来获取实例，不带参数即默认使用 {  } 作为参数标志
 	 */
-	public synchronized static StrTemplate getInstance() {
+	public synchronized static StrTemplate getInstance(){
 		if (null == template) {
 			template = new StrTemplate();
 		}
@@ -79,12 +79,12 @@ public class StrTemplate {
 	 * template: I say {0} {1} to the {1} 或 I say {} {} to the {}<br>
 	 * args: ["hello","world"]<br>
 	 *
-	 * @param template   文本模板，被替换的部分用 {index} 表示
-	 * @param args       参数数组
+	 * @param template 文本模板，被替换的部分用 {index} 表示
+	 * @param args     参数数组
 	 * @return 格式化后的文本
 	 * @since 5.8.12
 	 */
-	public String format(CharSequence template, Object... args) {
+	public String format(CharSequence template, Object... args){
 		if (null == template || template.length() == 0) {
 			return null;
 		}
@@ -99,7 +99,7 @@ public class StrTemplate {
 			}
 			tE = templateStr.indexOf(DEFAULT_SUFFIX, tS);
 			String substring = templateStr.substring(tS + DEFAULT_PREFIX.length(), tE);
-			if(StrUtil.isNotEmpty(substring)){
+			if (StrUtil.isNotEmpty(substring)) {
 				index = Integer.parseInt(substring);
 			}
 
@@ -122,7 +122,7 @@ public class StrTemplate {
 	 * @return 格式化后的文本
 	 * @since 5.8.12
 	 */
-	public String format(CharSequence template, Map<?, ?> map, boolean ignoreNull) {
+	public String format(CharSequence template, Map<?, ?> map, boolean ignoreNull){
 
 		if (null == template || template.length() == 0) {
 			return null;
@@ -139,10 +139,10 @@ public class StrTemplate {
 			String name = templateStr.substring(tS + DEFAULT_PREFIX.length(), tE);
 			String patton = templateStr.substring(tS, tE + DEFAULT_SUFFIX.length());
 			Object value = map.get(name);
-			if(ignoreNull && null == value ){
+			if (ignoreNull && null == value) {
 				value = "";
 			}
-			if(!ignoreNull && null == value){
+			if (!ignoreNull && null == value) {
 				tE = tS + templateStr.length();
 				continue;
 			}
@@ -167,7 +167,7 @@ public class StrTemplate {
 	 * @return 解析对应的参数Map
 	 * @since 5.8.12
 	 */
-	public Map<String, String> parse(String template, String formatStr) {
+	public Map<String, String> parse(String template, String formatStr){
 
 		Map<String, String> result = new HashMap<>();
 		int indexT = 0;

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
@@ -10,53 +10,52 @@ public class StrTemplateTest {
 
 	@Test
 	public void parserTest(){
-		StrTemplate strTemplate = StrTemplate.getInstance("{","}");
+		StrTemplate strTemplate = StrTemplate.getInstance("{", "}");
 		Map<String, String> parse1 = strTemplate.parse("siot/sys/{productKey}/{deviceKey}/property/{get}", "siot/sys/11/22/property/get");
 
-		Assert.assertEquals(parse1.get("productKey"),"11");
-		Assert.assertEquals(parse1.get("deviceKey"),"22");
-		Assert.assertEquals(parse1.get("get"),"get");
+		Assert.assertEquals(parse1.get("productKey"), "11");
+		Assert.assertEquals(parse1.get("deviceKey"), "22");
+		Assert.assertEquals(parse1.get("get"), "get");
 
-		strTemplate = StrTemplate.getInstance("${","}");
+		strTemplate = StrTemplate.getInstance("${", "}");
 		Map<String, String> parse = strTemplate.parse("siot/sys/${productKey}/${deviceKey}/property/${get}", "siot/sys/11/22/property/get");
 
-		Assert.assertEquals(parse.get("productKey"),"11");
-		Assert.assertEquals(parse.get("deviceKey"),"22");
-		Assert.assertEquals(parse.get("get"),"get");
+		Assert.assertEquals(parse.get("productKey"), "11");
+		Assert.assertEquals(parse.get("deviceKey"), "22");
+		Assert.assertEquals(parse.get("get"), "get");
 
 
-
-		strTemplate = StrTemplate.getInstance("{{","}}");
+		strTemplate = StrTemplate.getInstance("{{", "}}");
 		Map<String, String> parse2 = strTemplate.parse("siot/sys/{{pKey}}/{{dKey}}/property/{{get}}", "siot/sys/111111/22222222/property/33333333");
 
-		Assert.assertEquals(parse2.get("pKey"),"111111");
-		Assert.assertEquals(parse2.get("dKey"),"22222222");
-		Assert.assertEquals(parse2.get("get"),"33333333");
+		Assert.assertEquals(parse2.get("pKey"), "111111");
+		Assert.assertEquals(parse2.get("dKey"), "22222222");
+		Assert.assertEquals(parse2.get("get"), "33333333");
 	}
 
 
 	@Test
 	public void format(){
-		StrTemplate strTemplate = StrTemplate.getInstance("{","}");
-		Assert.assertEquals(strTemplate.format("I say {0} {1} to the {1}", (Object[]) new String[]{"hello", "world", "world"}),"I say hello world to the world");
+		StrTemplate strTemplate = StrTemplate.getInstance("{", "}");
+		Assert.assertEquals(strTemplate.format("I say {0} {1} to the {1}", (Object[]) new String[]{"hello", "world", "world"}), "I say hello world to the world");
 
-		strTemplate = StrTemplate.getInstance("{{","}}");
-		Assert.assertEquals(strTemplate.format("I say {{0}} {{1}} to the {{1}}", (Object[]) new String[]{"hello", "world"}),"I say hello world to the world");
+		strTemplate = StrTemplate.getInstance("{{", "}}");
+		Assert.assertEquals(strTemplate.format("I say {{0}} {{1}} to the {{1}}", (Object[]) new String[]{"hello", "world"}), "I say hello world to the world");
 	}
 
 
 	@Test
 	public void format1(){
-		StrTemplate strTemplate = StrTemplate.getInstance("{","}");
-		Map<String,String> map = new HashMap<>();
-		map.put("param1","hello");
-		map.put("param2","world");
-		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map,true),"I/say/hello/world/");
-		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map,false),"I/say/hello/world/{param3}");
+		StrTemplate strTemplate = StrTemplate.getInstance("{", "}");
+		Map<String, String> map = new HashMap<>();
+		map.put("param1", "hello");
+		map.put("param2", "world");
+		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map, true), "I/say/hello/world/");
+		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map, false), "I/say/hello/world/{param3}");
 
-		strTemplate = StrTemplate.getInstance("{{","}}");
-		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map,true),"I/say/hello/world/");
-		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map,false),"I/say/hello/world/{{param3}}");
+		strTemplate = StrTemplate.getInstance("{{", "}}");
+		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map, true), "I/say/hello/world/");
+		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map, false), "I/say/hello/world/{{param3}}");
 
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
@@ -1,5 +1,7 @@
 package cn.hutool.core.text;
 
+import cn.hutool.core.lang.Dict;
+import cn.hutool.core.util.StrUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,12 +52,12 @@ public class StrTemplateTest {
 		Map<String, String> map = new HashMap<>();
 		map.put("param1", "hello");
 		map.put("param2", "world");
-		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map, true), "I/say/hello/world/");
-		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map, false), "I/say/hello/world/{param3}");
+		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map, true), "I/say/hello/world/{param3}");
+		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map, false), "I/say/hello/world/");
 
 		strTemplate = StrTemplate.getInstance("{{", "}}");
-		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map, true), "I/say/hello/world/");
-		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map, false), "I/say/hello/world/{{param3}}");
+		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map, true), "I/say/hello/world/{{param3}}");
+		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map, false), "I/say/hello/world/");
 
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
@@ -1,6 +1,5 @@
 package cn.hutool.core.text;
 
-import cn.hutool.core.lang.StrFormatterTest;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/StrTemplateTest.java
@@ -1,0 +1,63 @@
+package cn.hutool.core.text;
+
+import cn.hutool.core.lang.StrFormatterTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StrTemplateTest {
+
+	@Test
+	public void parserTest(){
+		StrTemplate strTemplate = StrTemplate.getInstance("{","}");
+		Map<String, String> parse1 = strTemplate.parse("siot/sys/{productKey}/{deviceKey}/property/{get}", "siot/sys/11/22/property/get");
+
+		Assert.assertEquals(parse1.get("productKey"),"11");
+		Assert.assertEquals(parse1.get("deviceKey"),"22");
+		Assert.assertEquals(parse1.get("get"),"get");
+
+		strTemplate = StrTemplate.getInstance("${","}");
+		Map<String, String> parse = strTemplate.parse("siot/sys/${productKey}/${deviceKey}/property/${get}", "siot/sys/11/22/property/get");
+
+		Assert.assertEquals(parse.get("productKey"),"11");
+		Assert.assertEquals(parse.get("deviceKey"),"22");
+		Assert.assertEquals(parse.get("get"),"get");
+
+
+
+		strTemplate = StrTemplate.getInstance("{{","}}");
+		Map<String, String> parse2 = strTemplate.parse("siot/sys/{{pKey}}/{{dKey}}/property/{{get}}", "siot/sys/111111/22222222/property/33333333");
+
+		Assert.assertEquals(parse2.get("pKey"),"111111");
+		Assert.assertEquals(parse2.get("dKey"),"22222222");
+		Assert.assertEquals(parse2.get("get"),"33333333");
+	}
+
+
+	@Test
+	public void format(){
+		StrTemplate strTemplate = StrTemplate.getInstance("{","}");
+		Assert.assertEquals(strTemplate.format("I say {0} {1} to the {1}", (Object[]) new String[]{"hello", "world", "world"}),"I say hello world to the world");
+
+		strTemplate = StrTemplate.getInstance("{{","}}");
+		Assert.assertEquals(strTemplate.format("I say {{0}} {{1}} to the {{1}}", (Object[]) new String[]{"hello", "world"}),"I say hello world to the world");
+	}
+
+
+	@Test
+	public void format1(){
+		StrTemplate strTemplate = StrTemplate.getInstance("{","}");
+		Map<String,String> map = new HashMap<>();
+		map.put("param1","hello");
+		map.put("param2","world");
+		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map,true),"I/say/hello/world/");
+		Assert.assertEquals(strTemplate.format("I/say/{param1}/{param2}/{param3}", map,false),"I/say/hello/world/{param3}");
+
+		strTemplate = StrTemplate.getInstance("{{","}}");
+		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map,true),"I/say/hello/world/");
+		Assert.assertEquals(strTemplate.format("I/say/{{param1}}/{{param2}}/{{param3}}", map,false),"I/say/hello/world/{{param3}}");
+
+	}
+}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

[新特性] 新增类 StrTemplate 实现了自定义字符串参数装配。参数标志自定义，字符串装配完成后的反向解析。

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过