### PR TITLE
修复DateUtil.date(java.time.temporal.TemporalAccessor)方法入参为null时报NullPointerException异常问题，调整为入参为null时return null

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -121,6 +121,9 @@ public class DateUtil extends CalendarUtil {
 	 * @since 5.0.0
 	 */
 	public static DateTime date(TemporalAccessor temporalAccessor) {
+		if (temporalAccessor == null) {
+			return null;
+		}
 		return new DateTime(temporalAccessor);
 	}
 


### PR DESCRIPTION
修复DateUtil.date(java.time.temporal.TemporalAccessor)方法入参为null时报NullPointerException异常问题，调整为入参为null时return null