### PR TITLE
为EnumUtil提供getByCode方法

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
@@ -1,6 +1,7 @@
 package cn.hutool.core.util;
 
 import cn.hutool.core.collection.ListUtil;
+import lombok.Getter;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,7 +12,6 @@ import java.util.Map;
  * EnumUtil单元测试
  *
  * @author looly
- *
  */
 public class EnumUtilTest {
 
@@ -39,6 +39,23 @@ public class EnumUtilTest {
 		// 枚举中字段互相映射使用
 		final TestEnum testEnum = EnumUtil.getBy(TestEnum::ordinal, 1);
 		Assert.assertEquals("TEST2", testEnum.name());
+	}
+
+	@Test
+	public void getByCodeTest() {
+		// 通过code获取枚举值
+		Assert.assertEquals(TestEnum2.TEST_A, EnumUtil.getByCode(TestEnum2.class, 1001));
+		Assert.assertEquals(TestEnum2.TEST_B, EnumUtil.getByCode(TestEnum2.class, 1002));
+		Assert.assertEquals(TestEnum2.TEST_C, EnumUtil.getByCode(TestEnum2.class, 1003));
+		// 枚举值不存在
+		Assert.assertNull(EnumUtil.getByCode(TestEnum2.class, 1004));
+		// 缓存已存在的情况
+		Assert.assertEquals(TestEnum2.TEST_A, EnumUtil.getByCode(TestEnum2.class, 1001));
+		// code为字符串时
+		Assert.assertEquals(TestEnum3.TEST_ONE, EnumUtil.getByCode(TestEnum3.class, "one"));
+		Assert.assertEquals(TestEnum3.getByCode("two"), EnumUtil.getByCode(TestEnum3.class, "two"));
+		Assert.assertEquals(TestEnum3.getByCode("three"), EnumUtil.getByCode(TestEnum3.class, "three"));
+		Assert.assertEquals(TestEnum3.getByCode("four"), EnumUtil.getByCode(TestEnum3.class, "four"));
 	}
 
 	@Test
@@ -89,4 +106,37 @@ public class EnumUtilTest {
 			return this.name;
 		}
 	}
+
+
+	@Getter
+	public enum TestEnum2 {
+		TEST_A(1001), TEST_B(1002), TEST_C(1003);
+
+		TestEnum2(final Integer code) {
+			this.code = code;
+		}
+
+		private final Integer code;
+	}
+
+	@Getter
+	public enum TestEnum3 {
+		TEST_ONE("one"), TEST_TWO("two"), TEST_THREE("three");
+
+		TestEnum3(final String code) {
+			this.code = code;
+		}
+
+		private final String code;
+
+		public static TestEnum3 getByCode(String code) {
+			for (TestEnum3 value : values()) {
+				if (value.code.equals(code)) {
+					return value;
+				}
+			}
+			return null;
+		}
+	}
+
 }


### PR DESCRIPTION
### 修改描述

1. [新特性]  枚举工具类提供getByCode方法，通过枚举类型及code值可以快速获得枚举值。背景：业务开发过程中经常在枚举中定义code字段，自定义的code字段灵活性和可维护性都比原始枚举父类定义的name和ordinal要好，hutool提供了getBy方法，但使用起来仍然不够直接，不够sweet。