### PR TITLE
fix DateUtil.parseUTC

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -862,6 +862,7 @@ public class DateUtil extends CalendarUtil {
 
 			if (StrUtil.contains(utcString, CharUtil.DOT)) {
 				// 带毫秒，格式类似：2018-09-13T05:34:31.999+08:00
+				utcString = normalizeMillSeconds(utcString, ".", "+");
 				return parse(utcString, DatePattern.UTC_MS_WITH_XXX_OFFSET_FORMAT);
 			} else {
 				// 格式类似：2018-09-13T05:34:31+08:00
@@ -878,6 +879,7 @@ public class DateUtil extends CalendarUtil {
 
 			if (StrUtil.contains(utcString, CharUtil.DOT)) {
 				// 带毫秒，格式类似：2018-09-13T05:34:31.999-08:00
+				utcString = normalizeMillSeconds(utcString, ".", "-");
 				return new DateTime(utcString, DatePattern.UTC_MS_WITH_XXX_OFFSET_FORMAT);
 			} else {
 				// 格式类似：2018-09-13T05:34:31-08:00
@@ -892,6 +894,7 @@ public class DateUtil extends CalendarUtil {
 				return parse(utcString + ":00", DatePattern.UTC_SIMPLE_FORMAT);
 			} else if (StrUtil.contains(utcString, CharUtil.DOT)) {
 				// 可能为：  2021-03-17T06:31:33.99
+				utcString = normalizeMillSeconds(utcString, ".", null);
 				return parse(utcString, DatePattern.UTC_SIMPLE_MS_FORMAT);
 			}
 		}
@@ -2337,4 +2340,23 @@ public class DateUtil extends CalendarUtil {
 		return builder.toString();
 	}
 	// ------------------------------------------------------------------------ Private method end
+
+	/**
+	 * 如果日期中的毫秒部分超出3位，会导致秒数增加，因此只保留前三位
+	 *
+	 * @param dateStr 日期字符串
+	 * @param before  毫秒部分的前一个字符
+	 * @param after   毫秒部分的后一个字符
+	 * @return 规范之后的毫秒部分
+	 */
+	private static String normalizeMillSeconds(String dateStr, CharSequence before, CharSequence after) {
+		if (StrUtil.isBlank(after)) {
+			String millOrNaco = StrUtil.subPre(StrUtil.subAfter(dateStr, before, true), 3);
+			return StrUtil.subBefore(dateStr, before, true) + before + millOrNaco;
+		}
+		String millOrNaco = StrUtil.subPre(StrUtil.subBetween(dateStr, before, after), 3);
+		return StrUtil.subBefore(dateStr, before, true)
+				+ before
+				+ millOrNaco + after + StrUtil.subAfter(dateStr, after, true);
+	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
@@ -1101,10 +1101,33 @@ public class DateUtilTest {
 	}
 
 	@Test
-	public void isLastDayTest(){
+	public void isLastDayTest() {
 		DateTime dateTime = DateUtil.parse("2022-09-30");
-		int dayOfMonth  = DateUtil.getLastDayOfMonth(dateTime);
-		Assert.assertEquals(dayOfMonth,dateTime.dayOfMonth());
-		Assert.assertTrue("not is last day of this month !!",DateUtil.isLastDayOfMonth(dateTime));
+		int dayOfMonth = DateUtil.getLastDayOfMonth(dateTime);
+		Assert.assertEquals(dayOfMonth, dateTime.dayOfMonth());
+		Assert.assertTrue("not is last day of this month !!", DateUtil.isLastDayOfMonth(dateTime));
 	}
+
+
+	/**
+	 * issue#2887 由于UTC时间的毫秒部分超出3位导致的秒数增加的问题
+	 */
+	@Test
+	public void parseUTCTest4() {
+		final String dateStr = "2023-02-07T00:02:16.12345+08:00";
+		final DateTime dateTime = DateUtil.parse(dateStr);
+		Assert.assertNotNull(dateTime);
+		Assert.assertEquals("2023-02-07 00:02:16", dateTime.toString());
+
+		final String dateStr2 = "2023-02-07T00:02:16.12345-08:00";
+		final DateTime dateTime2 = DateUtil.parse(dateStr2);
+		Assert.assertNotNull(dateTime2);
+		Assert.assertEquals("2023-02-07 00:02:16", dateTime2.toString());
+
+		final String dateStr3 = "2021-03-17T06:31:33.9999";
+		final DateTime dateTime3 = DateUtil.parse(dateStr3);
+		Assert.assertNotNull(dateTime3);
+		Assert.assertEquals("2021-03-17 06:31:33", dateTime3.toString());
+	}
+
 }


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复DateUtil.paseUTC 由于毫秒部分超出3位导致秒数增加的问题

### 提交前自测

1. 单元测试已提交并测试通过