### PR TITLE
ListUtil.reverse()方法，当该方法的参数list为null对象时，出现空指针异常

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/ListUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/ListUtil.java
@@ -386,6 +386,9 @@ public class ListUtil {
 	 * @since 4.0.6
 	 */
 	public static <T> List<T> reverse(final List<T> list) {
+		if (CollUtil.isEmpty(list)) {
+			return list;
+		}
 		Collections.reverse(list);
 		return list;
 	}


### PR DESCRIPTION
fix：ListUtil.reverse()方法，当该方法的参数list为null对象时，出现空指针异常