### PR TITLE
fix FileUtil.move

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/file/PathUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/PathUtil.java
@@ -488,7 +488,8 @@ public class PathUtil {
 		Assert.notNull(src, "Src path must be not null !");
 		Assert.notNull(target, "Target path must be not null !");
 
-		if(equals(src, target)){
+		// issue#2893 target 不存在导致NoSuchFileException
+		if (Files.exists(target) && equals(src, target)) {
 			// issue#2845，当用户传入目标路径与源路径一致时，直接返回，否则会导致删除风险。
 			return target;
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/io/file/PathUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/file/PathUtilTest.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.File;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
@@ -77,5 +78,14 @@ public class PathUtilTest {
 	public void getMimeOf7zTest(){
 		String contentType = FileUtil.getMimeType("a001.7z");
 		Assert.assertEquals("application/x-7z-compressed", contentType);
+	}
+
+	/**
+	 * issue#2893 target不存在空导致异常
+	 */
+	@Test
+	@Ignore
+	public void moveTest2(){
+		PathUtil.move(Paths.get("D:\\project\\test1.txt"), Paths.get("D:\\project\\test2.txt"), false);
 	}
 }


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复FileUtil.move 判断同一文件导致的NoSuchFileException

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过