### PR TITLE
feat:HttpUtil#post请求参数支持数值类型，不在强转为字符串

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
@@ -511,7 +511,7 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 		}
 
 		// 普通值
-		String strValue;
+		Object strValue;
 		if (value instanceof Iterable) {
 			// 列表对象
 			strValue = CollUtil.join((Iterable<?>) value, ",");
@@ -522,7 +522,10 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 			}
 			// 数组对象
 			strValue = ArrayUtil.join((Object[]) value, ",");
-		} else {
+		} else if (value instanceof Integer){
+			// 数值对象
+			strValue = Convert.toInt(value, null);
+		}else {
 			// 其他对象一律转换为字符串
 			strValue = Convert.toStr(value, null);
 		}


### PR DESCRIPTION
#### 说明

1. HttpUtil#post请求对参数封装过程中，兜底操作将其他类型都转换为字符串，在参数匹配严格的请求中，无法正常使用。

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  封装参数过程中，增加一层逻辑判断，value类型为Integer类型参数不在转为String类型。

### 提交前自测
> 提交前已完成本地自测