### PR TITLE
feat: UrlQuery#toStr 增加数组类型支持

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/net/url/UrlQuery.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/url/UrlQuery.java
@@ -9,6 +9,7 @@ import cn.hutool.core.map.TableMap;
 import cn.hutool.core.net.FormUrlencoded;
 import cn.hutool.core.net.RFC3986;
 import cn.hutool.core.net.URLDecoder;
+import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.StrUtil;
 
 import java.nio.charset.Charset;
@@ -384,6 +385,8 @@ public class UrlQuery {
 			result = CollUtil.join((Iterable<?>) value, ",");
 		} else if (value instanceof Iterator) {
 			result = IterUtil.join((Iterator<?>) value, ",");
+		} else if (ArrayUtil.isArray(value)) {
+			result = ArrayUtil.join(value, ",");
 		} else {
 			result = Convert.toStr(value);
 		}


### PR DESCRIPTION
#### 说明

UrlQuery#toStr 新增数组类型支持

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  增加map转url参数时对数组类型的适配

原UrlQuery转换时没有对数组类型进行适配
ServletRequest.getParameterMap()方法默认获取到的Map的value为数组类型
现在无需将value转换为集合即可以使用URLUtil转换

![image](https://user-images.githubusercontent.com/52345437/220584419-6e4ddb88-82c5-4eb4-8e41-c8ee42e0e789.png)

![image](https://user-images.githubusercontent.com/52345437/220583837-94d29fbc-66f5-4d06-ba2a-11d9997f5049.png)

### 提交前自测
1. 本地已通过自测

![image](https://user-images.githubusercontent.com/52345437/220585102-3895ef23-f722-4df1-890d-1f2522b98b2f.png)
