### PR TITLE
增加填充工具类

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/filler/Filler.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/filler/Filler.java
@@ -1,0 +1,158 @@
+package cn.hutool.core.bean.filler;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * 填充工具类
+ * 多服务调用或者多库查询时候，聚合数据使用
+ * 比如订单服务查询时，订单的用户相关参数需要填充，通过工具类可简化中间步骤
+ *
+ * @author pursue-wind
+ */
+public class Filler {
+
+	/**
+	 * @param collectionSupplier    原集合
+	 * @param collectionIdQueryData 根据 getter1 getter2 的值查询其他属性的函数
+	 * @param getter                原集合属性取出函数
+	 * @param setter                原集合属性赋值函数
+	 * @param <IN>                  原集合泛型
+	 * @param <ID>                  原集合属性取出类型
+	 * @param <R>                   collectionIdQueryData 根据取出类型查询返回类型
+	 */
+	public static <IN, ID, R> void fill(Supplier<Collection<IN>> collectionSupplier,
+										Function<Collection<ID>, Map<ID, R>> collectionIdQueryData,
+										Function<IN, ID> getter,
+										BiConsumer<IN, R> setter) {
+		Collection<IN> collection = collectionSupplier.get();
+		Collection<ID> ids = collection.stream().map(getter).filter(Objects::nonNull).collect(Collectors.toSet());
+		Map<ID, R> map = collectionIdQueryData.apply(ids);
+		collection.forEach(in ->
+				Optional.ofNullable(map.get(getter.apply(in)))
+						.ifPresent(r -> setter.accept(in, r)));
+	}
+
+
+	/**
+	 * @param collectionSupplier    原集合
+	 * @param collectionIdQueryData 根据 getter1 getter2 的值查询其他属性的函数
+	 * @param getter1               原集合属性取出函数1
+	 * @param setter1               原集合属性赋值函数1
+	 * @param getter2               原集合属性取出函数2
+	 * @param setter2               原集合属性赋值函数2
+	 * @param <IN>                  原集合泛型
+	 * @param <ID>                  原集合属性取出类型
+	 * @param <R>                   collectionIdQueryData 根据取出类型查询返回类型
+	 */
+	public static <IN, ID, R> void fill(
+			Supplier<Collection<IN>> collectionSupplier,
+			Function<Collection<ID>, Map<ID, R>> collectionIdQueryData,
+			Function<IN, ID> getter1, BiConsumer<IN, R> setter1,
+			Function<IN, ID> getter2, BiConsumer<IN, R> setter2
+	) {
+		Map<Function<IN, ID>, BiConsumer<IN, R>> getterSetterMap = new HashMap<Function<IN, ID>, BiConsumer<IN, R>>() {{
+			put(getter1, setter1);
+			put(getter2, setter2);
+		}};
+		fill(collectionSupplier, getterSetterMap, collectionIdQueryData);
+	}
+
+	/**
+	 * @param collectionSupplier    原集合
+	 * @param collectionIdQueryData 根据 getter1 getter2 的值查询其他属性的函数
+	 * @param getter1               原集合属性取出函数1
+	 * @param setter1               原集合属性赋值函数1
+	 * @param getter2               原集合属性取出函数2
+	 * @param setter2               原集合属性赋值函数2
+	 * @param getter2               原集合属性取出函数3
+	 * @param setter2               原集合属性赋值函数3
+	 * @param <IN>                  原集合泛型
+	 * @param <ID>                  原集合属性取出类型
+	 * @param <R>                   collectionIdQueryData 根据取出类型查询返回类型
+	 */
+	public static <IN, ID, R> void fill(Supplier<Collection<IN>> collectionSupplier,
+										Function<Collection<ID>, Map<ID, R>> collectionIdQueryData,
+										Function<IN, ID> getter1, BiConsumer<IN, R> setter1,
+										Function<IN, ID> getter2, BiConsumer<IN, R> setter2,
+										Function<IN, ID> getter3, BiConsumer<IN, R> setter3
+	) {
+		Map<Function<IN, ID>, BiConsumer<IN, R>> getterSetterMap = new HashMap<Function<IN, ID>, BiConsumer<IN, R>>() {{
+			put(getter1, setter1);
+			put(getter2, setter2);
+			put(getter3, setter3);
+		}};
+
+		fill(collectionSupplier, getterSetterMap, collectionIdQueryData);
+	}
+
+	/**
+	 * @param collectionSupplier    原集合
+	 * @param collectionIdQueryData 根据 getter1 getter2 的值查询其他属性的函数
+	 * @param getterSetterMap       {原集合属性取出函数:原集合属性赋值函数}
+	 * @param <IN>                  原集合泛型
+	 * @param <ID>                  原集合属性取出类型
+	 * @param <R>                   collectionIdQueryData 根据取出类型查询返回类型
+	 */
+	public static <IN, ID, R> void fill(Supplier<Collection<IN>> collectionSupplier,
+										Map<Function<IN, ID>, BiConsumer<IN, R>> getterSetterMap,
+										Function<Collection<ID>, Map<ID, R>> collectionIdQueryData) {
+		Collection<IN> collection = collectionSupplier.get();
+		if (null == collection || collection.isEmpty()) {
+			return;
+		}
+		Collection<ID> ids = getterSetterMap.keySet().stream()
+				.map(getter -> collection.stream().map(getter).filter(Objects::nonNull))
+				.flatMap(Stream::distinct)
+				.collect(Collectors.toSet());
+		Map<ID, R> map = collectionIdQueryData.apply(ids);
+		getterSetterMap.forEach((getter, setter) ->
+				collection.forEach(in ->
+						Optional.ofNullable(map.get(getter.apply(in)))
+								.ifPresent(r -> setter.accept(in, r))));
+	}
+
+	public static <IN, ID, R> void fillMultiValueString(Supplier<Collection<IN>> collectionSupplier,
+														Function<IN, ID> collectionIdGetter,
+														Function<Collection<ID>, Map<ID, R>> collectionIdQueryData,
+														Map<Function<R, String>, BiConsumer<IN, String>> queryDataGetterAndCollectionSetter
+	) {
+		fillMultiValue(collectionSupplier, collectionIdGetter, collectionIdQueryData, queryDataGetterAndCollectionSetter);
+	}
+
+	/**
+	 * 填充多个值
+	 *
+	 * @param collectionSupplier                 原集合
+	 * @param collectionIdGetter                 集合映射原属性
+	 * @param collectionIdQueryData              根据 collectionIdGetter 的值查询其他属性的函数
+	 * @param queryDataGetterAndCollectionSetter collectionIdQueryData为对象或需要转换时，取值和设值函数映射
+	 * @param <IN>                               原集合泛型
+	 * @param <ID>                               原集合属性取出类型
+	 * @param <R>                                collectionIdQueryData 根据取出类型查询返回类型
+	 * @param <S>                                将 collectionIdQueryData 的 R 类型进行转换为赋值给原集合的类型
+	 */
+	public static <IN, ID, R, S> void fillMultiValue(Supplier<Collection<IN>> collectionSupplier,
+													 Function<IN, ID> collectionIdGetter,
+													 Function<Collection<ID>, Map<ID, R>> collectionIdQueryData,
+													 Map<Function<R, S>, BiConsumer<IN, S>> queryDataGetterAndCollectionSetter
+	) {
+		Collection<IN> collection = collectionSupplier.get();
+		if (null == collection || collection.isEmpty()) {
+			return;
+		}
+
+		Collection<ID> ids = collection.stream().map(collectionIdGetter).filter(Objects::nonNull).collect(Collectors.toSet());
+
+		Map<ID, R> map = collectionIdQueryData.apply(ids);
+		queryDataGetterAndCollectionSetter
+				.forEach((queryDataGetter, collectionSetter) ->
+						collection.forEach(in ->
+								Optional.ofNullable(map.get(collectionIdGetter.apply(in)))
+										.ifPresent(r -> collectionSetter.accept(in, queryDataGetter.apply(r)))));
+	}
+}

--- a/hutool-core/src/test/java/cn/hutool/core/bean/filler/FillerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/filler/FillerTest.java
@@ -1,0 +1,183 @@
+package cn.hutool.core.bean.filler;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * 填充工具类
+ * <p>
+ * 多服务调用时候，聚合数据使用
+ * 比如订单服务查询时，订单的用户相关参数需要填充，通过工具类可省去很多中间步骤
+ *
+ * @author pursue-wind
+ */
+public class FillerTest {
+
+	Random random = new Random();
+
+	/**
+	 * 模拟feignClient 或者 dao 根据用户id列表查询UserName
+	 *
+	 * @param userIds 用户id列表
+	 * @return 返回 Map{userId : userName}
+	 */
+	private Map<Integer, String> queryMapByIds(Collection<Integer> userIds) {
+		return userIds.stream()
+				.map(i -> User.builder().id(i).userName("用户" + i + "号").build())
+				.collect(Collectors.toMap(User::getId, User::getUserName));
+	}
+
+	/**
+	 * 填充前
+	 * <p>
+	 * Order [{id = 1, createUserId = x1, createUserName = null} ...]
+	 * <p>
+	 * 填充后
+	 * <p>
+	 * Order [{id = 1, createUserId = x1, createUserName = 用户x1号} ...]
+	 */
+	@Test
+	public void fill() {
+		List<Order> orders = IntStream.rangeClosed(1, 5)
+				.mapToObj(i -> Order.builder().id(i).createUserId(random.nextInt(50)).build())
+				.collect(Collectors.toList());
+		System.out.println(orders);
+
+		Filler.fill(
+				() -> orders,                        // 数据列表
+				userIds -> queryMapByIds(userIds),    // 根据 userIds 查询 userName 的函数
+				Order::getCreateUserId, Order::setCreateUserName // 从查询出的 Map{userId : userName} 中 取出 Order.createUserId 对应的 userId 把 userName 赋值给 Order 对象的 createUserName
+		);
+		System.out.println(orders);
+
+		Assert.assertNotNull(orders.get(orders.size() / 2).getCreateUserName());
+	}
+
+
+	/**
+	 * 填充前
+	 * <p>
+	 * Order [{id = 1, createUserId = x1, createUserName = null, updateUserId = x2, updateUserName = null} ...]
+	 * <p>
+	 * 填充后
+	 * <p>
+	 * Order [{id = 1, createUserId = x1, createUserName = 用户x1号, updateUserId = x2, updateUserName = 用户x2号} ...]
+	 */
+	@Test
+	public void fill2() {
+		List<Order> orders = IntStream.rangeClosed(1, 5)
+				.mapToObj(i -> Order.builder().id(i).createUserId(random.nextInt(50)).updateUserId(random.nextInt(50)).build())
+				.collect(Collectors.toList());
+		System.out.println(orders);
+
+		Filler.fill(
+				() -> orders,                            // 数据列表
+				userIds -> queryMapByIds(userIds),    // 根据 userIds 查询 userName 的函数
+				Order::getCreateUserId, Order::setCreateUserName, // 从查询出的 Map{userId : userName} 中 取出 Order.createUserId 对应的 userId 把 userName 赋值给 Order 对象的 createUserName
+				Order::getUpdateUserId, Order::setUpdateUserName  // 同上
+		);
+		System.out.println(orders);
+
+		Assert.assertNotNull(orders.get(orders.size() / 2).getCreateUserName());
+		Assert.assertNotNull(orders.get(orders.size() / 2).getUpdateUserName());
+	}
+
+	/**
+	 * 模拟 feignClient 或者 dao 根据 用户idcard列表 查询 IdCard
+	 *
+	 * @param idCardIds 用户idcard列表
+	 * @return 返回 Map{idcardId : IdCard}
+	 */
+	private Map<Integer, IdCard> queryUserIdCardByIds(Collection<Integer> idCardIds) {
+		return idCardIds.stream()
+				.map(i -> IdCard.builder().id(i).username("名字" + i + "号").cardNo("身份证" + i + "号").build())
+				.collect(Collectors.toMap(IdCard::getId, Function.identity()));
+	}
+
+	/**
+	 * 填充前
+	 * <p>
+	 * User [{id = 1, createUserId = x, idCardName = null, idCardNo = null},{id = 2, idCardId = x, idCardName = null, idCardNo = null}...]
+	 * <p>
+	 * 填充后
+	 * <p>
+	 * User [{id = 1, idCardId = x, idCardName = 名字x号, idCardNo = 身份证x号},{id = 2, idCardId = x1, idCardName = 名字x1号, idCardNo = 身份证x1号}...]
+	 */
+	@Test
+	public void fillMultiValue() {
+		List<User> userList = IntStream.rangeClosed(1, 5)
+				.mapToObj(i -> User.builder().id(i).idCardId(random.nextInt(50)).build())
+				.collect(Collectors.toList());
+		System.out.println(userList);
+
+		/*
+			Filler.<User, Integer, IdCard, String>fillMultiValue(
+					() -> userList,                                          // 数据列表
+					User::getIdCardId,                                       // 取出列表的每个idCardId
+					userIds -> queryUserIdCardByIds(userIds),                // 取出的idCardList 去做查询
+					ImmutableMap.of(
+							IdCard::getUsername, User::setIdCardName,    	// 从查询出的IdCard中 取出 IdCard.username 赋值给 User 对象的 idCardName
+							IdCard::getCardNo, User::setIdCardNo            // 从查询出的IdCard中 取出 IdCard.cardNo 赋值给 User 对象的 idCardNo
+					)
+			);
+		*/
+		Filler.<User, Integer, IdCard, String>fillMultiValue(
+				() -> userList,                                          // 数据列表
+				User::getIdCardId,                                       // 取出列表的每个idCardId
+				userIds -> queryUserIdCardByIds(userIds),                // 取出的idCardList 去做查询
+				new HashMap<Function<IdCard, String>, BiConsumer<User, String>>() {{
+					put(IdCard::getUsername, User::setIdCardName);        // 从查询出的IdCard中 取出 IdCard.username 赋值给 User 对象的 idCardName
+					put(IdCard::getCardNo, User::setIdCardNo);            // 从查询出的IdCard中 取出 IdCard.cardNo 赋值给 User 对象的 idCardNo
+				}}
+		);
+		System.out.println(userList);
+		Assert.assertNotNull(userList.get(userList.size() / 2).getIdCardNo());
+		Assert.assertNotNull(userList.get(userList.size() / 2).getIdCardName());
+	}
+
+	@Data
+	@AllArgsConstructor(staticName = "of")
+	@Builder
+	@NoArgsConstructor
+	public static class User {
+		private Integer id;
+		private String userName;
+		private Integer idCardId;
+		private String idCardName;
+		private String idCardNo;
+	}
+
+
+	@Data
+	@AllArgsConstructor(staticName = "of")
+	@Builder
+	@NoArgsConstructor
+	public static class Order {
+		private Integer id;
+		private Integer createUserId;
+		private String createUserName;
+		private Integer updateUserId;
+		private String updateUserName;
+	}
+
+
+	@Data
+	@AllArgsConstructor(staticName = "of")
+	@Builder
+	@NoArgsConstructor
+	public static class IdCard {
+		private Integer id;
+		private String username;
+		private String cardNo;
+	}
+}


### PR DESCRIPTION
### 修改描述 - 增加Bean属性填充工具类
> 多服务调用或者多库查询时候，聚合数据使用
比如订单服务查询时，订单的用户相关参数需要填充，通过工具类可简化中间步骤

 [新特性1] 

- 从queryMapByIds查询出的 Map{userId : userName} 中
- 取出 Order.createUserId 对应 Map 的 userId 把 userName 
- 赋值给 Order 对象的 createUserName
```java
Filler.fill(
    () -> orders,                        
    userIds -> queryMapByIds(userIds),  
    Order::getCreateUserId,     
    Order::setCreateUserName 
    ...
);
```
![image](https://user-images.githubusercontent.com/40025981/221138292-7bc556e1-564d-4db7-8ca5-7c8c2b1b7d66.png)

 [新特性2] 
- 取出列表的每个idCardId
- 从queryUserIdCardByIds查询出 Map{idcardId : IdCard} 
- 从查询出的IdCard中 取出 IdCard.username 赋值给 User 对象的 idCardName
- 从查询出的IdCard中 取出 IdCard.cardNo 赋值给 User 对象的 idCardNo
```java
Filler.<User, Integer, IdCard, String>fillMultiValue(
    () -> userList,                                              
    User::getIdCardId,                                      
    userIds -> queryUserIdCardByIds(userIds),                
    ImmutableMap.of(
        IdCard::getUsername, User::setIdCardName, 
        IdCard::getCardNo, User::setIdCardNo            
    )
);
```
![image](https://user-images.githubusercontent.com/40025981/221138603-f16fcb79-a0ab-4467-950d-6c3c6792cafa.png)

### 提交前自测
![image](https://user-images.githubusercontent.com/40025981/221137362-68eb5135-663b-4fe1-a65d-01ab944427c9.png)

> 修改CoordinateUtilTest.wgs84toBd09Test2方法 `Assert.assertEquals(45.00636909189589, coordinate.getLat(), 0); `后，测试通过