### PR TITLE
[fixbug]:  修复图片压缩自动旋转问题

### DIFF
--- a/hutool-swing/pom.xml
+++ b/hutool-swing/pom.xml
@@ -22,5 +22,10 @@
 			<artifactId>hutool-core</artifactId>
 			<version>${project.parent.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>com.drewnoakes</groupId>
+			<artifactId>metadata-extractor</artifactId>
+			<version>2.18.0</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/hutool-swing/pom.xml
+++ b/hutool-swing/pom.xml
@@ -26,6 +26,7 @@
 			<groupId>com.drewnoakes</groupId>
 			<artifactId>metadata-extractor</artifactId>
 			<version>2.18.0</version>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 </project>

--- a/hutool-swing/src/main/java/cn/hutool/swing/img/ImgRevolveUtil.java
+++ b/hutool-swing/src/main/java/cn/hutool/swing/img/ImgRevolveUtil.java
@@ -1,0 +1,88 @@
+package cn.hutool.swing.img;
+
+import cn.hutool.core.io.FileUtil;
+import cn.hutool.core.io.IORuntimeException;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.Tag;
+
+/**
+ * 图片避免旋转工具类
+ *
+ *@Date: 2023/2/28 19:21<br/>
+ * @author wdz
+ * @since 5.8.13
+ */
+public class ImgRevolveUtil {
+	/**
+	 * 纠正图片旋转
+	 *
+	 * @param srcFile
+	 */
+	public static BufferedImage correctBufferImg(File srcFile) throws IOException, ImageProcessingException {
+		// 获取偏转角度
+		int angle = getAngle(srcFile);
+		//如果不偏转，直接返回即可
+		if (angle != 90 && angle != 270) {
+			return ImageIO.read(srcFile);
+		}
+
+		// 原始图片缓存
+		BufferedImage srcImg = ImageIO.read(srcFile);
+
+		// 宽高互换
+		// 原始宽度
+		int imgWidth = srcImg.getHeight();
+		// 原始高度
+		int imgHeight = srcImg.getWidth();
+
+		// 中心点位置
+		double centerWidth = ((double) imgWidth) / 2;
+		double centerHeight = ((double) imgHeight) / 2;
+
+		// 图片缓存
+		BufferedImage targetImg = new BufferedImage(imgWidth, imgHeight, BufferedImage.TYPE_INT_RGB);
+
+		// 旋转对应角度
+		Graphics2D g = targetImg.createGraphics();
+		g.rotate(Math.toRadians(angle), centerWidth, centerHeight);
+		g.drawImage(srcImg, (imgWidth - srcImg.getWidth()) / 2, (imgHeight - srcImg.getHeight()) / 2, null);
+		g.rotate(Math.toRadians(-angle), centerWidth, centerHeight);
+		g.dispose();
+		return targetImg;
+	}
+
+
+	/**
+	 * 获取图片旋转角度
+	 *
+	 * @param file 上传图片
+	 * @return
+	 */
+	public static int getAngle(File file) throws ImageProcessingException, IOException {
+		Metadata metadata = ImageMetadataReader.readMetadata(file);
+		for (Directory directory : metadata.getDirectories()) {
+			for (Tag tag : directory.getTags()) {
+				if ("Orientation".equals(tag.getTagName())) {
+					String orientation = tag.getDescription();
+					if (orientation.contains("90")) {
+						return 90;
+					} else if (orientation.contains("180")) {
+						return 180;
+					} else if (orientation.contains("270")) {
+						return 270;
+					}
+				}
+			}
+		}
+		return 0;
+	}
+}

--- a/hutool-swing/src/main/java/cn/hutool/swing/img/ImgUtil.java
+++ b/hutool-swing/src/main/java/cn/hutool/swing/img/ImgUtil.java
@@ -1631,7 +1631,7 @@ public class ImgUtil {
 	public static BufferedImage read(final File imageFile) {
 		final BufferedImage result;
 		try {
-			result = ImageIO.read(imageFile);
+			result = ImgRevolveUtil.correctBufferImg(imageFile);
 		} catch (final IOException e) {
 			throw new IORuntimeException(e);
 		}


### PR DESCRIPTION
#### 说明

1. 提交合并v6-dev
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复图片压缩自动旋转问题 https://github.com/dromara/hutool/issues/2923
2. [新特性] 集成读取元数据的能力，借助第三方库完成

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过