### PR TITLE
add source code for dynamic compile

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/compiler/JavaSourceFileObject.java
+++ b/hutool-core/src/main/java/cn/hutool/core/compiler/JavaSourceFileObject.java
@@ -29,6 +29,11 @@ class JavaSourceFileObject extends SimpleJavaFileObject {
 	private InputStream inputStream;
 
 	/**
+	 * Source code.
+	 */
+	private String sourceCode;
+
+	/**
 	 * 构造，支持File等路径类型的源码
 	 *
 	 * @param uri  需要编译的文件uri
@@ -82,9 +87,12 @@ class JavaSourceFileObject extends SimpleJavaFileObject {
 	 */
 	@Override
 	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
-		try(final InputStream in = openInputStream()){
-			return IoUtil.readUtf8(in);
+		if (sourceCode == null) {
+			try(final InputStream in = openInputStream()){
+				sourceCode = IoUtil.readUtf8(in);
+			}
 		}
+		return sourceCode;
 	}
 
 }

--- a/hutool-core/src/test/java/cn/hutool/core/compiler/JavaSourceCompilerTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/compiler/JavaSourceCompilerTest.java
@@ -40,4 +40,17 @@ public class JavaSourceCompilerTest {
 		Assert.assertTrue(String.valueOf(obj).startsWith("c.C@"));
 	}
 
+	@Test
+	public void testErrorCompile() {
+		Exception exception = null;
+		try {
+			CompilerUtil.getCompiler(null)
+					.addSource(FileUtil.file("test-compile/error/ErrorClazz.java"))
+					.compile();
+		} catch (Exception ex) {
+			exception = ex;
+		} finally {
+			Assert.assertTrue(exception instanceof CompilerException);
+		}
+	}
 }

--- a/hutool-core/src/test/resources/test-compile/error/ErrorClazz.java
+++ b/hutool-core/src/test/resources/test-compile/error/ErrorClazz.java
@@ -1,0 +1,8 @@
+package error;
+
+public class ErrorClazz {
+
+	public static void 123main(String[] args) {
+		System.out.println("hello world");
+	}
+}


### PR DESCRIPTION
### 当前JDK环境版本
```
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
```
### 异常复现：
步骤如下
1. 修改 `src/test/resources/test-compile/c/C.java` 类，触发动态编译失败
```
package c;

import b.B;

public class C {
    public12 C() {
        new B();
    }
}
```
2. 执行单测 `cn.hutool.core.compiler.JavaSourceCompilerTest#testCompile`，报错信息期望值应该是编译异常，实际报错信息如下：
```
com.sun.tools.javac.util.ClientCodeException: cn.hutool.core.io.IORuntimeException: IOException: Stream closed

	at com.sun.tools.javac.api.ClientCodeWrapper$WrappedFileObject.getCharContent(ClientCodeWrapper.java:469)
	at com.sun.tools.javac.util.DiagnosticSource.initBuf(DiagnosticSource.java:185)
	at com.sun.tools.javac.util.DiagnosticSource.findLine(DiagnosticSource.java:153)
         ···
```

### 问题分析：
当编译失败后，将通过 `cn.hutool.core.compiler.DiagnosticUtil#getMessages` 方法获取编译失败详情，即
```
	public static String getMessages(DiagnosticCollector<?> collector) {
		final List<?> diagnostics = collector.getDiagnostics();
		return diagnostics.stream().map(String::valueOf)
				.collect(Collectors.joining(System.lineSeparator()));
	}
```
此时，将调用获取源码接口 `cn.hutool.core.compiler.JavaSourceFileObject#getCharContent`，见
```
	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
		try(final InputStream in = openInputStream()){
			return IoUtil.readUtf8(in);
		}
	}
```
此时流已关闭，导致获取源码失败，抛出异常类型非 `CompilerException`，而是 `IOException` 

### 解决思路：
1. `JavaSourceFileObject` 类绑定 `inputStream` ，从而绑定 `sourceCode`，内部持有源码内容，获取时直接返回即可，这种方式不破坏原有接口，向上兼容。
2. 变更`JavaSourceFileObject` 类构造方法，从 `uri` 拿到 `sourceCode`，但是需要在构造方法中抛出 `IOException`，影响上层接口调用。
3. 此处保留 `sourceCode` 后也避免每次获取时进行流的拷贝，提升一定的性能。
4. 最终按照1方式修改

---

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
6. 请确认没有更改代码风格（如tab缩进）
7. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
6. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
8. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
9. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过