### PR TITLE
Remove LambdaUtil cache

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/func/LambdaUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/func/LambdaUtil.java
@@ -18,8 +18,6 @@ import java.lang.invoke.SerializedLambda;
  */
 public class LambdaUtil {
 
-	private static final WeakConcurrentMap<String, SerializedLambda> cache = new WeakConcurrentMap<>();
-
 	/**
 	 * 通过对象的方法或类的静态方法引用，获取lambda实现类
 	 * 传入lambda无参数但含有返回值的情况能够匹配到此方法：
@@ -61,8 +59,7 @@ public class LambdaUtil {
 	}
 
 	/**
-	 * 解析lambda表达式,加了缓存。
-	 * 该缓存可能会在任意不定的时间被清除
+	 * 解析lambda表达式
 	 *
 	 * @param <T>  Lambda类型
 	 * @param func 需要解析的 lambda 对象（无参方法）
@@ -73,8 +70,7 @@ public class LambdaUtil {
 	}
 
 	/**
-	 * 解析lambda表达式,加了缓存。
-	 * 该缓存可能会在任意不定的时间被清除
+	 * 解析lambda表达式
 	 *
 	 * @param <R>  Lambda返回类型
 	 * @param func 需要解析的 lambda 对象（无参方法）
@@ -190,8 +186,7 @@ public class LambdaUtil {
 	}
 
 	/**
-	 * 解析lambda表达式,加了缓存。
-	 * 该缓存可能会在任意不定的时间被清除。
+	 * 解析lambda表达式
 	 *
 	 * <p>
 	 * 通过反射调用实现序列化接口函数对象的writeReplace方法，从而拿到{@link SerializedLambda}<br>
@@ -202,7 +197,7 @@ public class LambdaUtil {
 	 * @return 返回解析后的结果
 	 */
 	private static SerializedLambda _resolve(Serializable func) {
-		return cache.computeIfAbsent(func.getClass().getName(), (key) -> ReflectUtil.invoke(func, "writeReplace"));
+		return ReflectUtil.invoke(func, "writeReplace");
 	}
 	//endregion
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/func/LambdaUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/func/LambdaUtilTest.java
@@ -18,6 +18,19 @@ public class LambdaUtilTest {
 	}
 
 	@Test
+	public  <P> void lambdaClassName() {
+		String lambdaClassName1 = LambdaUtilTestHelper.getLambdaClassName(MyTeacher::getAge);
+		String lambdaClassName2 = LambdaUtilTestHelper.getLambdaClassName(MyTeacher::getAge);
+		Assert.assertNotEquals(lambdaClassName1, lambdaClassName2);
+	}
+
+	static class LambdaUtilTestHelper {
+		public static <P> String getLambdaClassName(Func1<P, ?> func) {
+			return func.getClass().getName();
+		}
+	}
+
+	@Test
 	public void getFieldNameTest() {
 		String fieldName = LambdaUtil.getFieldName(MyTeacher::getAge);
 		Assert.assertEquals("age", fieldName);


### PR DESCRIPTION
### 问题描述
现有 LambdaUtil 类，借助 `WeakConcurrentMap` 作缓存，缓存 `Key` 为 `func.getClass().getName()`，预期相同的lambda函数的`func.getClass().getName()`的值相同。

### 测试结果
```
	@Test
	public  <P> void lambdaClassName() {
		String lambdaClassName1 = LambdaUtilTestHelper.getLambdaClassName(MyTeacher::getAge);
		String lambdaClassName2 = LambdaUtilTestHelper.getLambdaClassName(MyTeacher::getAge);
		Assert.assertNotEquals(lambdaClassName1, lambdaClassName2);
	}

	static class LambdaUtilTestHelper {
		public static <P> String getLambdaClassName(Func1<P, ?> func) {
			return func.getClass().getName();
		}
	}
```
测试结果显示二者并不相同
```
		System.out.println(lambdaClassName1);
		System.out.println(lambdaClassName2);
```
打印输出结果如下：
```

cn.hutool.core.lang.func.LambdaUtilTest$$Lambda$47/0x0000000800c1a230
cn.hutool.core.lang.func.LambdaUtilTest$$Lambda$48/0x0000000800c1a658
```
实际值结果类似于 `target class name + "$$Lambda$" + a counter`，见 [https://stackoverflow.com/questions/34589435/get-the-enclosing-class-of-a-java-lambda-expression](url)

### 解决思路
解决思路有两种：
1. 移除 cache 缓存，暂不作缓存处理
2. 选择其他合适的 `Key`

实际过程中观察 `SerializedLambda` 并未选择到合适的`Key`，故此处直接移除 cache ，以减少资源使用

---

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
4. 请确认没有更改代码风格（如tab缩进）
5. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
6. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
7. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过