### PR TITLE
fix：ArrayUtil.addAll()方法，判断空数据组优化

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/ArrayUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ArrayUtil.java
@@ -588,15 +588,19 @@ public class ArrayUtil extends PrimitiveArrayUtil {
 
 		int length = 0;
 		for (final T[] array : arrays) {
-			if (null != array) {
+			if (isNotEmpty(array)) {
 				length += array.length;
 			}
 		}
+
 		final T[] result = newArray(arrays.getClass().getComponentType().getComponentType(), length);
+		if (length == 0) {
+			return result;
+		}
 
 		length = 0;
 		for (final T[] array : arrays) {
-			if (null != array) {
+			if (isNotEmpty(array)) {
 				System.arraycopy(array, 0, result, length, array.length);
 				length += array.length;
 			}


### PR DESCRIPTION
ArrayUtil.addAll()方法，判断空数据组优化

描述现象：
入参可能会出现多个全部是长度为0的空数组