### PR TITLE
fix(sec): upgrade org.yaml:snakeyaml to 

### DIFF
--- a/hutool-setting/pom.xml
+++ b/hutool-setting/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.33</version>
+			<version>2.0</version>
 			<optional>true</optional>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.yaml:snakeyaml 1.33
- [CVE-2022-1471](https://www.oscs1024.com/hd/CVE-2022-1471)


### What did I do？
Upgrade org.yaml:snakeyaml from 1.33 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:  pen4948453219@qq.com
