### PR TITLE
fix: commonPrefix与commonSuffix无法匹配空字符串(前缀/后缀)

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
@@ -4594,7 +4594,7 @@ public class CharSequenceUtil {
 	 * @return 字符串1和字符串2的公共前缀
 	 */
 	public static CharSequence commonPrefix(CharSequence str1, CharSequence str2) {
-		if (isBlank(str1) || isBlank(str2)) {
+		if (isEmpty(str1) || isEmpty(str2)) {
 			return EMPTY;
 		}
 		final int minLength = Math.min(str1.length(), str2.length());
@@ -4618,7 +4618,7 @@ public class CharSequenceUtil {
 	 * @return 字符串1和字符串2的公共后缀
 	 */
 	public static CharSequence commonSuffix(CharSequence str1, CharSequence str2) {
-		if (isBlank(str1) || isBlank(str2)) {
+		if (isEmpty(str1) || isEmpty(str2)) {
 			return EMPTY;
 		}
 		int str1Index = str1.length() - 1;

--- a/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
@@ -183,6 +183,14 @@ public class CharSequenceUtilTest {
 
 		Assert.assertEquals("中文", CharSequenceUtil.commonPrefix("中文english", "中文french"));
 
+		// { space * 10 } + "abc"
+		final String str1 = CharSequenceUtil.repeat(CharSequenceUtil.SPACE, 10) + "abc";
+
+		// { space * 5 } + "efg"
+		final String str2 = CharSequenceUtil.repeat(CharSequenceUtil.SPACE, 5) + "efg";
+
+		// Expect common prefix: { space * 5 }
+		Assert.assertEquals(CharSequenceUtil.repeat(CharSequenceUtil.SPACE, 5), CharSequenceUtil.commonPrefix(str1, str2));
 	}
 
 	@Test
@@ -207,6 +215,14 @@ public class CharSequenceUtilTest {
 
 		Assert.assertEquals("中文", CharSequenceUtil.commonSuffix("english中文", "Korean中文"));
 
+		// "abc" + { space * 10 }
+		final String str1 = "abc" + CharSequenceUtil.repeat(CharSequenceUtil.SPACE, 10);
+
+		// "efg" + { space * 15 }
+		final String str2 = "efg" + CharSequenceUtil.repeat(CharSequenceUtil.SPACE, 15);
+
+		// Expect common suffix: { space * 10 }
+		Assert.assertEquals(CharSequenceUtil.repeat(CharSequenceUtil.SPACE, 10), CharSequenceUtil.commonSuffix(str1, str2));
 	}
 
 }


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复]  commonPrefix与commonSuffix无法匹配空字符串(前缀/后缀)