### PR TITLE
Fix: issue#2845 源和新目录名称一样时FileUtil.rename()会误删除源目录

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/file/PathMover.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/PathMover.java
@@ -80,15 +80,15 @@ public class PathMover {
 		Path target = this.target;
 		final CopyOption[] options = this.options;
 
-		if (PathUtil.isDirectory(target)) {
-			// 创建子路径的情况，1是目标是目录，需要移动到目录下，2是目标不能存在，自动创建目录
-			target = target.resolve(src.getFileName());
-		}
-
 		// issue#2893 target 不存在导致NoSuchFileException
 		if (Files.exists(target) && PathUtil.equals(src, target)) {
 			// issue#2845，当用户传入目标路径与源路径一致时，直接返回，否则会导致删除风险。
 			return target;
+		}
+
+		if (PathUtil.isDirectory(target)) {
+			// 创建子路径的情况，1是目标是目录，需要移动到目录下，2是目标不能存在，自动创建目录
+			target = target.resolve(src.getFileName());
 		}
 
 		// 自动创建目标的父目录

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileUtilTest.java
@@ -2,6 +2,7 @@ package cn.hutool.core.io;
 
 import cn.hutool.core.collection.ListUtil;
 import cn.hutool.core.io.file.LineSeparator;
+import cn.hutool.core.io.file.PathUtil;
 import cn.hutool.core.lang.Console;
 import cn.hutool.core.util.CharsetUtil;
 import org.junit.Assert;
@@ -78,6 +79,16 @@ public class FileUtilTest {
 	@Ignore
 	public void renameTest2() {
 		FileUtil.move(FileUtil.file("d:/test/a"), FileUtil.file("d:/test/b"), false);
+	}
+
+	@Test
+	@Ignore
+	public void renameTest3() {
+		Path path1 = Paths.get("D:\\test");
+		FileUtil.mkdir(path1);
+		PathUtil.rename(path1, "test", false);
+
+		PathUtil.rename(path1, "test1", false);
 	}
 
 	@Test


### PR DESCRIPTION
Bug修复Fix: issue#2845 源和新目录名称一样时FileUtil.rename()会误删除源目录
调整了判断路径相同的if case的顺序