### PR TITLE
Issue#3048: 添加 数字单元格精度据单元格实际数值自动适配新特性;  

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
@@ -308,6 +308,16 @@ public class ExcelWriter extends ExcelBase<ExcelWriter> {
 	}
 
 	/**
+	 * 设置 是否数字类型单元格精度根据单元格实际数值自动适配
+	 * @param autoPrecision
+	 * @return this
+	 */
+	public ExcelWriter setNumberAutoPrecision(boolean autoPrecision) {
+		this.styleSet.setNumberAutoPrecision(autoPrecision);
+		return this;
+	}
+
+	/**
 	 * 获取样式集，样式集可以自定义包括：<br>
 	 *
 	 * <pre>

--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/StyleSet.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/StyleSet.java
@@ -52,6 +52,10 @@ public class StyleSet implements Serializable {
 	protected final CellStyle cellStyleForHyperlink;
 
 	/**
+	 * 数字类型单元格精度根据单元格实际数值自动适配
+	 */
+	protected Boolean numberAutoPrecision;
+	/**
 	 * 构造
 	 *
 	 * @param workbook 工作簿
@@ -78,6 +82,9 @@ public class StyleSet implements Serializable {
 		font.setUnderline((byte) 1);
 		font.setColor(HSSFColor.HSSFColorPredefined.BLUE.getIndex());
 		this.cellStyleForHyperlink.setFont(font);
+
+		// 数字类型单元格精度根据单元格实际数值自动适配
+		this.setNumberAutoPrecision(false);
 	}
 
 	/**
@@ -124,6 +131,14 @@ public class StyleSet implements Serializable {
 	 */
 	public CellStyle getCellStyleForHyperlink() {
 		return this.cellStyleForHyperlink;
+	}
+
+	public Boolean getNumberAutoPrecision() {
+		return numberAutoPrecision;
+	}
+
+	public void setNumberAutoPrecision(Boolean numberAutoPrecision) {
+		this.numberAutoPrecision = numberAutoPrecision;
 	}
 
 	/**
@@ -254,7 +269,12 @@ public class StyleSet implements Serializable {
 			// 数字单独定义格式
 			if ((value instanceof Double || value instanceof Float || value instanceof BigDecimal) &&
 					null != this.cellStyleForNumber) {
-				style = this.cellStyleForNumber;
+				BigDecimal bigDecimalValue = new BigDecimal(value.toString());
+				if(numberAutoPrecision){
+					this.cellStyleForNumber.setDataFormat((short)bigDecimalValue.precision());
+				}else{
+					style = this.cellStyleForNumber;
+				}
 			}
 		} else if (value instanceof Hyperlink) {
 			// 自定义超链接样式

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/Issue3048Test.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/Issue3048Test.java
@@ -1,0 +1,39 @@
+package cn.hutool.poi.excel;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * https://github.com/dromara/hutool/issues/3048 Excel导出javaBean中有BigDecimal类型精度流失
+ *
+ */
+public class Issue3048Test {
+	@Test
+	@Ignore
+	public void excelOutPutBeanListToExcel(){
+		List<TestBean> excelExportList = new ArrayList<>();
+		excelExportList.add(new TestBean("1", new BigDecimal("1.22")));
+		excelExportList.add(new TestBean("2", new BigDecimal("2.342")));
+		excelExportList.add(new TestBean("3", new BigDecimal("1.2346")));
+		ExcelWriter excelWriter = ExcelUtil.getWriter(true);
+		excelWriter.setNumberAutoPrecision(true);
+		excelWriter.write(excelExportList, true);
+		excelWriter.flush(new File("e:/test.xlsx"));
+		excelWriter.close();
+	}
+
+	@Data
+	@AllArgsConstructor
+	static class TestBean{
+		private String testKey;
+		private BigDecimal testValue;
+	}
+}


### PR DESCRIPTION
#### 说明
测试类 Issue3048Test

### 修改描述(包括说明bug修复或者添加新特性)
1. [bug修复]  修复Issue#3048, 解决默认ExcelWriter 导出小数位超过两位的数字时，精度丢失
2. [新特性]  添加 numberAutoPrecision；ExcelWriter .setNumberAutoPrecision 设置为true后，每个数字类型单元格精度都可自动设置为 value对应的精度