### PR TITLE
CollUtil新加两个集合可高度自定义的对比方法

### DIFF
--- a/hutool-core/src/test/java/org/dromara/hutool/core/collection/CollUtilTest.java
+++ b/hutool-core/src/test/java/org/dromara/hutool/core/collection/CollUtilTest.java
@@ -5,6 +5,8 @@ import org.dromara.hutool.core.collection.set.SetUtil;
 import org.dromara.hutool.core.comparator.CompareUtil;
 import org.dromara.hutool.core.date.DateUtil;
 import org.dromara.hutool.core.lang.Console;
+import org.dromara.hutool.core.lang.mutable.MutableEntry;
+import org.dromara.hutool.core.lang.tuple.Triple;
 import org.dromara.hutool.core.map.Dict;
 import org.dromara.hutool.core.map.MapUtil;
 import org.dromara.hutool.core.text.StrUtil;
@@ -1152,5 +1154,63 @@ public class CollUtilTest {
 		Assertions.assertFalse(CollUtil.isEqualList(list, ListUtil.of(1, 2, 3, 3)));
 		Assertions.assertFalse(CollUtil.isEqualList(list, ListUtil.of(1, 2, 3)));
 		Assertions.assertFalse(CollUtil.isEqualList(list, ListUtil.of(4, 3, 2, 1)));
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class People {
+		private Long id;
+		private String name;
+	}
+
+	@Data
+	@AllArgsConstructor
+	@NoArgsConstructor
+	static class American {
+		private Long id;
+		private String name;
+	}
+
+	@Test
+	public void diffTest() {
+		People p1 = new People(1L, "Tom");
+		People p2 = new People(2L, "Tony");
+		People p2p = new People(2L, "Tony2");
+		People p3 = new People(null, "Jerry");
+		List<People> coll1 = ListUtil.of(p1, p2);
+		List<People> coll2 = ListUtil.of(p2p, p3);
+		// 通过 People 的 id 来比较出新增的和删除的
+		MutableEntry<List<People>, List<People>> pair = CollUtil.diff(coll1, coll2, People::getId);
+		Assertions.assertTrue(CollUtil.isEqualList(pair.getKey(), ListUtil.of(p3)));
+		Assertions.assertTrue(CollUtil.isEqualList(pair.getValue(), ListUtil.of(p1)));
+
+		// 通过 Person 的 id 来比较出新增和删除的，通过 name 比较出修改的（修改的集合里面为自己选择出来的）
+		Triple<List<People>, List<People>, List<People>> triple1 =
+				CollUtil.diff(
+						coll1,
+						coll2,
+						People::getId,
+						(people, people2) -> people.getName().equals(people2.getName()),
+						(people, people2) -> people2);
+		Assertions.assertTrue(CollUtil.isEqualList(triple1.getLeft(), ListUtil.of(p3)));
+		Assertions.assertTrue(CollUtil.isEqualList(triple1.getMiddle(), ListUtil.of(p1)));
+		Assertions.assertTrue(CollUtil.isEqualList(triple1.getRight(), ListUtil.of(p2p)));
+
+		// 两个包含不同元素集合比较，key都为元素的id，比较出新增的，删除的，修改的
+		American a1 = new American(2L, "Tony2");
+		American a2 = new American(null, "Jerry");
+		List<American> coll3 = ListUtil.of(a1, a2);
+		Triple<List<American>, List<People>, List<American>> triple2 =
+				CollUtil.diff(
+						coll1,
+						coll3,
+						People::getId,
+						American::getId,
+						(people, american) -> people.getName().equals(american.getName()),
+						(people, american) -> american);
+		Assertions.assertTrue(CollUtil.isEqualList(triple2.getLeft(), ListUtil.of(a2)));
+		Assertions.assertTrue(CollUtil.isEqualList(triple2.getMiddle(), ListUtil.of(p1)));
+		Assertions.assertTrue(CollUtil.isEqualList(triple2.getRight(), ListUtil.of(a1)));
 	}
 }


### PR DESCRIPTION
在日常的开发中，会经常遇到前端传过来的集合（VO集合）与后端从数据库查出来的集合（DO集合）做对比，找出新增的，删除的及修改的，然后再做判断或转换等操作。两个集合里面的元素可能类型不一样，也可能是一样的类型，但是只需要比较指定字段（例如用id等）是否一样，如果重写`hashCode`和`equals`方法不仅显得割裂，代码也臃肿，同时也做不到一次性找出增删改的元素。所以这里新加diff方法，支持高度自定义和扩展，自己指定比较的key，支持自定义判断两个key值一样的对象是否发生变化，对于发生了变化的元素也有扩展的方法支持灵活返回和组合。