### PR TITLE
fix:BeanUtil.getBeanDesc set方法赋值错误 #3096

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanDesc.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanDesc.java
@@ -310,9 +310,9 @@ public class BeanDesc implements Serializable {
 		// 针对Boolean类型特殊检查
 		if (isBooleanField && fieldName.startsWith("is")) {
 			// 字段是is开头
-			if (("set" + StrUtil.removePrefix(fieldName, "is")).equals(methodName)// isName -》 setName
-					|| ("set" + handledFieldName).equals(methodName)// isName -》 setIsName
-			) {
+			if ((("set" + StrUtil.removePrefix(fieldName, "is")).equals(methodName) // isName -》 setName
+				|| ("set" + handledFieldName).equals(methodName)) // isName -》 setIsName
+				&& !methodName.startsWith("setIs")) { // 排除 "setIs" 前缀
 				return true;
 			}
 		}

--- a/hutool-db/src/main/java/cn/hutool/db/ds/simple/AbstractDataSource.java
+++ b/hutool-db/src/main/java/cn/hutool/db/ds/simple/AbstractDataSource.java
@@ -53,4 +53,13 @@ public abstract class AbstractDataSource implements DataSource, Cloneable, Close
 	public Logger getParentLogger() throws SQLFeatureNotSupportedException {
 		throw new SQLFeatureNotSupportedException("DataSource can't support getParentLogger method!");
 	}
+
+	@Override
+	public AbstractDataSource clone() {
+		try {
+			return (AbstractDataSource) super.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new AssertionError();
+		}
+	}
 }


### PR DESCRIPTION
#### 说明

fix:BeanUtil.getBeanDesc set方法赋值错误 #3096

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] fix:BeanUtil.getBeanDesc set方法赋值错误 #3096.  
2. 可以在"isBooleanField && fieldName.startsWith("is")" 的判断条件中添加一个排除 "setIs" 前缀的判断条件，这样就确保了如果字段以 "is" 开头，优先匹配 "setIs" 方法