### PR TITLE
fix:BeanUtil.getBeanDesc set方法赋值错误 #3096 #3110

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanDesc.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanDesc.java
@@ -310,9 +310,9 @@ public class BeanDesc implements Serializable {
 		// 针对Boolean类型特殊检查
 		if (isBooleanField && fieldName.startsWith("is")) {
 			// 字段是is开头
-			if (("set" + StrUtil.removePrefix(fieldName, "is")).equals(methodName)// isName -》 setName
-					|| ("set" + handledFieldName).equals(methodName)// isName -》 setIsName
-			) {
+			if ((("set" + StrUtil.removePrefix(fieldName, "is")).equals(methodName) // isName -》 setName
+				|| ("set" + handledFieldName).equals(methodName)) // isName -》 setIsName
+				&& !methodName.startsWith("setIs")) { // 排除 "setIs" 前缀
 				return true;
 			}
 		}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR
2. fix:BeanUtil.getBeanDesc set方法赋值错误 #3096 #3110

1. [bug修复] fix:BeanUtil.getBeanDesc set方法赋值错误 #3096 #3110
2. 可以在"isBooleanField && fieldName.startsWith("is")" 的判断条件中添加一个排除 "setIs" 前缀的判断条件，这样就确保了如果字段以 "is" 开头，优先匹配 "setIs" 方法

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
3. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过