### PR TITLE
punycode中大写字母解码异常问题修复，统一编码和解码为小写

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
+++ b/hutool-core/src/main/java/cn/hutool/core/codec/PunyCode.java
@@ -36,6 +36,7 @@ public class PunyCode {
 	 */
 	public static String encodeDomain(String domain) throws UtilException {
 		Assert.notNull(domain, "domain must not be null!");
+		domain = domain.toLowerCase();
 		final List<String> split = StrUtil.split(domain, CharUtil.DOT);
 		final StringBuilder result = new StringBuilder(domain.length() * 4);
 		for (final String str : split) {
@@ -156,6 +157,7 @@ public class PunyCode {
 	 */
 	public static String decodeDomain(String domain) throws UtilException {
 		Assert.notNull(domain, "domain must not be null!");
+		domain = domain.toLowerCase();
 		final List<String> split = StrUtil.split(domain, CharUtil.DOT);
 		final StringBuilder result = new StringBuilder(domain.length() / 4 + 1);
 		for (final String str : split) {


### PR DESCRIPTION
域名其实是不区分大小写的。但是punycode中如果包含大写字母时，解码异常。如：赵新虎.com 对应 xn--efVz93E52E.com，在解码时异常。结合各大域名业务平台部分对大写不友好，所以统一为小写。