### PR TITLE
修改CollUtil.union intersection 等方法泛型，使其支持多种子类union一个父类集合

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/CollUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/CollUtil.java
@@ -79,7 +79,7 @@ public class CollUtil {
 	 * @param coll2 集合2
 	 * @return 并集的集合，返回 {@link ArrayList}
 	 */
-	public static <T> Collection<T> union(Collection<T> coll1, Collection<T> coll2) {
+	public static <T> Collection<T> union(Collection<? extends T> coll1, Collection<? extends T> coll2) {
 		if (isEmpty(coll1) && isEmpty(coll2)) {
 			return new ArrayList<>();
 		}
@@ -117,9 +117,9 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link ArrayList}
 	 */
 	@SafeVarargs
-	public static <T> Collection<T> union(Collection<T> coll1, Collection<T> coll2, Collection<T>... otherColls) {
+	public static <T> Collection<T> union(Collection<? extends T> coll1, Collection<? extends T> coll2, Collection<? extends T>... otherColls) {
 		Collection<T> union = union(coll1, coll2);
-		for (Collection<T> coll : otherColls) {
+		for (Collection<? extends T> coll : otherColls) {
 			if (isEmpty(coll)) {
 				continue;
 			}
@@ -141,7 +141,7 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link LinkedHashSet}
 	 */
 	@SafeVarargs
-	public static <T> Set<T> unionDistinct(Collection<T> coll1, Collection<T> coll2, Collection<T>... otherColls) {
+	public static <T> Set<T> unionDistinct(Collection<? extends T> coll1, Collection<? extends T> coll2, Collection<? extends T>... otherColls) {
 		final Set<T> result;
 		if (isEmpty(coll1)) {
 			result = new LinkedHashSet<>();
@@ -154,7 +154,7 @@ public class CollUtil {
 		}
 
 		if (ArrayUtil.isNotEmpty(otherColls)) {
-			for (Collection<T> otherColl : otherColls) {
+			for (Collection<? extends T> otherColl : otherColls) {
 				if (isEmpty(otherColl)) {
 					continue;
 				}
@@ -178,7 +178,7 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link ArrayList}
 	 */
 	@SafeVarargs
-	public static <T> List<T> unionAll(Collection<T> coll1, Collection<T> coll2, Collection<T>... otherColls) {
+	public static <T> List<T> unionAll(Collection<? extends T> coll1, Collection<? extends T> coll2, Collection<? extends T>... otherColls) {
 		if (CollUtil.isEmpty(coll1) && CollUtil.isEmpty(coll2) && ArrayUtil.isEmpty(otherColls)) {
 			return new ArrayList<>(0);
 		}
@@ -188,7 +188,7 @@ public class CollUtil {
 		totalSize += size(coll1);
 		totalSize += size(coll2);
 		if (otherColls != null) {
-			for (final Collection<T> otherColl : otherColls) {
+			for (final Collection<? extends T> otherColl : otherColls) {
 				totalSize += size(otherColl);
 			}
 		}
@@ -205,7 +205,7 @@ public class CollUtil {
 			return res;
 		}
 
-		for (final Collection<T> otherColl : otherColls) {
+		for (final Collection<? extends T> otherColl : otherColls) {
 			if (otherColl != null) {
 				res.addAll(otherColl);
 			}
@@ -537,7 +537,7 @@ public class CollUtil {
 	 * @return {@link Map}
 	 * @see IterUtil#countMap(Iterator)
 	 */
-	public static <T> Map<T, Integer> countMap(Iterable<T> collection) {
+	public static <T> Map<T, Integer> countMap(Iterable<? extends T> collection) {
 		return IterUtil.countMap(null == collection ? null : collection.iterator());
 	}
 
@@ -750,7 +750,7 @@ public class CollUtil {
 	 * @param collection 集合
 	 * @return HashSet对象
 	 */
-	public static <T> HashSet<T> newHashSet(Collection<T> collection) {
+	public static <T> HashSet<T> newHashSet(Collection<? extends T> collection) {
 		return newHashSet(false, collection);
 	}
 
@@ -762,7 +762,7 @@ public class CollUtil {
 	 * @param collection 集合，用于初始化Set
 	 * @return HashSet对象
 	 */
-	public static <T> HashSet<T> newHashSet(boolean isSorted, Collection<T> collection) {
+	public static <T> HashSet<T> newHashSet(boolean isSorted, Collection<? extends T> collection) {
 		return isSorted ? new LinkedHashSet<>(collection) : new HashSet<>(collection);
 	}
 

--- a/hutool-core/src/main/java/cn/hutool/core/collection/IterUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/IterUtil.java
@@ -151,7 +151,7 @@ public class IterUtil {
 	 * @param iter {@link Iterator}，如果为null返回一个空的Map
 	 * @return {@link Map}
 	 */
-	public static <T> Map<T, Integer> countMap(Iterator<T> iter) {
+	public static <T> Map<T, Integer> countMap(Iterator<? extends T> iter) {
 		final HashMap<T, Integer> countMap = new HashMap<>();
 		if (null != iter) {
 			T t;

--- a/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/CollUtilTest.java
@@ -5,6 +5,21 @@ import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.lang.Dict;
 import cn.hutool.core.map.MapUtil;
 import cn.hutool.core.util.StrUtil;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,8 +27,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.*;
 
 /**
  * 集合工具类单元测试
@@ -1051,6 +1064,26 @@ public class CollUtilTest {
 		}
 	}
 
+	@ToString(callSuper = true)
+	@EqualsAndHashCode(callSuper = true)
+	@Data
+	static class Cat extends Animal {
+
+		public Cat(String name, Integer age) {
+			super(name, age);
+		}
+	}
+
+	@ToString(callSuper = true)
+	@EqualsAndHashCode(callSuper = true)
+	@Data
+	static class Pig extends Animal {
+
+		public Pig(String name, Integer age) {
+			super(name, age);
+		}
+	}
+
 	@Test
 	public void getFirstTest() {
 		final List<?> nullList = null;
@@ -1084,4 +1117,18 @@ public class CollUtilTest {
 		Assert.assertNull(CollUtil.max(null));
 	}
 
+	@Test
+	public void unionExtendTest() {
+		List<Dog> dog = Arrays.asList(new Dog("dog1", 12), new Dog("dog2", 12));
+		List<Cat> cat = Arrays.asList(new Cat("cat1", 12), new Cat("cat2", 12));
+		Assert.assertEquals(CollUtil.union(dog, cat).size(), 4);
+	}
+
+	@Test
+	public void unionAllExtendTest() {
+		List<Dog> dog = Arrays.asList(new Dog("dog1", 12), new Dog("dog2", 12));
+		List<Cat> cat = Arrays.asList(new Cat("cat1", 12), new Cat("cat2", 12));
+		List<Pig> pig = Arrays.asList(new Pig("pig1", 12), new Pig("pig2", 12));
+		Assert.assertEquals(CollUtil.union(dog, cat, pig).size(), dog.size() + cat.size() + pig.size());
+	}
 }


### PR DESCRIPTION
1. [新特性] 
修改CollUtil.union intersection 等方法泛型，使其支持多种子类union一个父类集合