### PR TITLE
IP地址和路径的通配符检测

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/net/Ipv4Util.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/Ipv4Util.java
@@ -7,6 +7,7 @@ import cn.hutool.core.lang.PatternPool;
 import cn.hutool.core.lang.Validator;
 import cn.hutool.core.util.CharUtil;
 import cn.hutool.core.util.StrUtil;
+import com.sun.istack.internal.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -365,6 +366,34 @@ public class Ipv4Util {
 		isInnerIp = isInner(ipNum, aBegin, aEnd) || isInner(ipNum, bBegin, bEnd) || isInner(ipNum, cBegin, cEnd) || LOCAL_IP.equals(ipAddress);
 		return isInnerIp;
 	}
+
+	/**
+	 * 检测指定 IP 地址是否匹配通配符 wildcard
+	 *
+	 * @param wildcard  通配符，如 192.168.*.1
+	 * @param ipAddress 待检测的 IP 地址
+	 * @return 是否匹配
+	 */
+	public static boolean matches(@NotNull String wildcard, @NotNull String ipAddress) {
+		if (!Validator.isMatchRegex(PatternPool.IPV4, ipAddress)) {
+			return false;
+		}
+
+		String[] patternSegments = wildcard.split("\\.");
+		String[] ipSegments = ipAddress.split("\\.");
+
+		if (patternSegments.length != ipSegments.length) {
+			return false;
+		}
+
+		for (int i = 0; i < patternSegments.length; i++) {
+			if (!patternSegments[i].equals("*") && !patternSegments[i].equals(ipSegments[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 
 	//-------------------------------------------------------------------------------- Private method start
 

--- a/hutool-core/src/main/java/cn/hutool/core/util/PathUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/PathUtil.java
@@ -1,0 +1,49 @@
+package cn.hutool.core.util;
+
+/**
+ * 路径工具类
+ *
+ * @author zhinushannan
+ */
+public class PathUtil {
+
+	/**
+	 * 检测指定 路径 是否匹配通配符 wildcard
+	 *
+	 * @param wildcard 通配符
+	 * @param path     路径
+	 * @return 是否匹配
+	 */
+	public static boolean matches(String wildcard, String path) {
+		if (wildcard.equals("**")) {
+			return true;
+		}
+
+		String[] wildcards = wildcard.split("/");
+		String[] paths = path.split("/");
+
+		int wildcardIndex = 0;
+		int pathIndex = 0;
+		int wildcardLen = wildcards.length;
+		int pathLen = paths.length;
+
+		while (wildcardIndex < wildcardLen && pathIndex < pathLen) {
+			String wildcardSplit = wildcards[wildcardIndex];
+			if (wildcardSplit.equals("**")) {
+				return true;
+			}
+
+			String pathSplit = paths[pathIndex];
+
+			if (!(wildcardSplit.equals("*") || wildcardSplit.equals(pathSplit))) {
+				return false;
+			}
+
+			wildcardIndex++;
+			pathIndex++;
+		}
+
+		return wildcardIndex == wildcardLen && pathIndex == pathLen;
+	}
+
+}

--- a/hutool-core/src/test/java/cn/hutool/core/net/Ipv4UtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/Ipv4UtilTest.java
@@ -108,6 +108,15 @@ public class Ipv4UtilTest {
 	}
 
 	@Test
+	public void matchesTest() {
+		boolean matches1 = Ipv4Util.matches("127.*.*.1", "127.0.0.1");
+		Assert.assertTrue("IP地址通配符匹配1", matches1);
+
+		boolean matches2 = Ipv4Util.matches("192.168.*.1", "127.0.0.1");
+		Assert.assertFalse("IP地址通配符匹配2", matches2);
+	}
+
+	@Test
 	public void ipv4ToLongTest(){
 		long l = Ipv4Util.ipv4ToLong("127.0.0.1");
 		Assert.assertEquals(2130706433L, l);

--- a/hutool-core/src/test/java/cn/hutool/core/util/PathUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/PathUtilTest.java
@@ -1,0 +1,17 @@
+package cn.hutool.core.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PathUtilTest {
+
+	@Test
+	public void matchesTest() {
+		boolean matches1 = PathUtil.matches("/api/**", "/api/test1/test2");
+		Assert.assertTrue(matches1);
+
+		boolean matches2 = PathUtil.matches("/api/*/test", "/api/test1/test2");
+		Assert.assertTrue(matches2);
+	}
+
+}


### PR DESCRIPTION
Ipv4Util 新增方法：检测指定 IP 地址是否匹配通配符 wildcard
新增 PathUtil 工具类，检测指定 路径 是否匹配通配符 wildcard

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  检测指定 IP 地址是否匹配通配符 wildcard
2. [新特性]  检测指定 路径 是否匹配通配符 wildcard
