### PR TITLE
修改CollUtil.union等方法泛型，使其支持多种子类union一个父类集合

### DIFF
--- a/hutool-core/src/main/java/org/dromara/hutool/core/collection/CollUtil.java
+++ b/hutool-core/src/main/java/org/dromara/hutool/core/collection/CollUtil.java
@@ -297,7 +297,7 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link ArrayList}
 	 */
 	@SafeVarargs
-	public static <T> Collection<T> union(final Collection<T>... colls) {
+	public static <T> Collection<T> union(final Collection<? extends T>... colls) {
 		return CollectionOperation.of(colls).union();
 	}
 
@@ -312,7 +312,7 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link LinkedHashSet}
 	 */
 	@SafeVarargs
-	public static <T> Set<T> unionDistinct(final Collection<T>... colls) {
+	public static <T> Set<T> unionDistinct(final Collection<? extends T>... colls) {
 		return CollectionOperation.of(colls).unionDistinct();
 	}
 
@@ -327,7 +327,7 @@ public class CollUtil {
 	 * @return 并集的集合，返回 {@link ArrayList}
 	 */
 	@SafeVarargs
-	public static <T> List<T> unionAll(final Collection<T>... colls) {
+	public static <T> List<T> unionAll(final Collection<? extends T>... colls) {
 		return CollectionOperation.of(colls).unionAll();
 	}
 

--- a/hutool-core/src/main/java/org/dromara/hutool/core/collection/CollectionOperation.java
+++ b/hutool-core/src/main/java/org/dromara/hutool/core/collection/CollectionOperation.java
@@ -45,7 +45,7 @@ public class CollectionOperation<E> {
 	 * @return CollectionOperation
 	 */
 	@SafeVarargs
-	public static <E> CollectionOperation<E> of(final Collection<E>... colls) {
+	public static <E> CollectionOperation<E> of(final Collection<? extends E>... colls) {
 		return new CollectionOperation<>(colls);
 	}
 
@@ -56,8 +56,9 @@ public class CollectionOperation<E> {
 	 *
 	 * @param colls 集合数组
 	 */
-	public CollectionOperation(final Collection<E>[] colls) {
-		this.colls = colls;
+	@SuppressWarnings("unchecked")
+	public CollectionOperation(final Collection<? extends E>[] colls) {
+		this.colls = (Collection<E>[]) colls;
 	}
 
 	/**

--- a/hutool-core/src/test/java/org/dromara/hutool/core/collection/CollUtilTest.java
+++ b/hutool-core/src/test/java/org/dromara/hutool/core/collection/CollUtilTest.java
@@ -1110,6 +1110,26 @@ public class CollUtilTest {
 		}
 	}
 
+	@ToString(callSuper = true)
+	@EqualsAndHashCode(callSuper = true)
+	@Data
+	static class Cat extends Animal {
+
+		public Cat(String name, Integer age) {
+			super(name, age);
+		}
+	}
+
+	@ToString(callSuper = true)
+	@EqualsAndHashCode(callSuper = true)
+	@Data
+	static class Pig extends Animal {
+
+		public Pig(String name, Integer age) {
+			super(name, age);
+		}
+	}
+
 	@Test
 	public void getFirstTest() {
 		Assertions.assertNull(CollUtil.getFirst(null));
@@ -1180,5 +1200,28 @@ public class CollUtilTest {
 	@Test
 	public void minNullTest() {
 		Assertions.assertNull(CollUtil.max(null));
+	}
+
+	@Test
+	public void unionExtendTest() {
+		List<Dog> dog = Arrays.asList(new Dog("dog1", 12), new Dog("dog2", 12));
+		List<Cat> cat = Arrays.asList(new Cat("cat1", 12), new Cat("cat2", 12));
+		Assertions.assertEquals(CollUtil.union(dog, cat).size(), dog.size() + cat.size());
+	}
+
+	@Test
+	public void unionAllExtendTest() {
+		List<Dog> dog = Arrays.asList(new Dog("dog1", 12), new Dog("dog2", 12));
+		List<Cat> cat = Arrays.asList(new Cat("cat1", 12), new Cat("cat2", 12));
+		List<Pig> pig = Arrays.asList(new Pig("pig1", 12), new Pig("pig2", 12));
+		Assertions.assertEquals(CollUtil.unionAll(dog, cat, pig).size(), dog.size() + cat.size() + pig.size());
+	}
+
+	@Test
+	public void unionDistinctExtendTest() {
+		List<Dog> dog = Arrays.asList(new Dog("dog1", 12), new Dog("dog1", 12)); // same
+		List<Cat> cat = Arrays.asList(new Cat("cat1", 12), new Cat("cat2", 12));
+		List<Pig> pig = Arrays.asList(new Pig("pig1", 12), new Pig("pig2", 12));
+		Assertions.assertEquals(CollUtil.unionDistinct(dog, cat, pig).size(), 5);
 	}
 }


### PR DESCRIPTION
[新特性] 
修改CollUtil.union等方法泛型，使其支持多种子类union一个父类集合