### PR TITLE
增加按字节长度截断字符串方法

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/StrUtilTest.java
@@ -1,10 +1,11 @@
 package cn.hutool.core.util;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import cn.hutool.core.lang.Dict;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.List;
 
 /**
  * 字符串工具类单元测试
@@ -647,5 +648,44 @@ public class StrUtilTest {
 		final String template = "I''m {0} years old.";
 		final String result = StrUtil.indexedFormat(template, 10);
 		Assert.assertEquals("I'm 10 years old.", result);
+	}
+
+	@Test
+	public void truncateUtf8Test() {
+		String str = "这是This一段中英文";
+		String ret = StrUtil.truncateUtf8(str, 12);
+		Assert.assertEquals("这是Thi...", ret);
+
+		ret = StrUtil.truncateUtf8(str, 13);
+		Assert.assertEquals("这是This...", ret);
+
+		ret = StrUtil.truncateUtf8(str, 14);
+		Assert.assertEquals("这是This...", ret);
+
+		ret = StrUtil.truncateUtf8(str, 999);
+		Assert.assertEquals(str, ret);
+	}
+
+	@Test
+	public void truncateGb18030Test() {
+		String str = "这是This一段中英文";
+		String ret = StrUtil.truncateGb18030(str, 12);
+		Assert.assertEquals("这是This...", ret);
+
+		ret = StrUtil.truncateGb18030(str, 13);
+		Assert.assertEquals("这是This一...", ret);
+
+		ret = StrUtil.truncateGb18030(str, 14);
+		Assert.assertEquals("这是This一...", ret);
+
+		ret = StrUtil.truncateGb18030(str, 999);
+		Assert.assertEquals(str, ret);
+	}
+
+	@Test
+	public void truncateByByteLengthTest() {
+		String str = "This is English";
+		String ret = StrUtil.truncateByByteLength(str, StandardCharsets.ISO_8859_1,10, 1, false);
+		Assert.assertEquals("This is En", ret);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1.[新特性]  按照UTF-8/GB18030等编码格式截断字符串，截断后的字符串不会超过指定的字节数，用于数据库存储等需要限制字节数场景（例如数据库字段类型为varchar(500)）

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过