### PR TITLE
feat：ListUtil新增可重叠分段，对集合按照指定的每段长度和每段的可重叠长度分段，每一个段为单独的集合，返回这个集合的列表

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/collection/ListUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/collection/ListUtil.java
@@ -680,4 +680,54 @@ public class ListUtil {
 			}
 		}
 	}
+
+	/**
+	 * 可重叠分段，对集合按照指定的每段长度和每段的可重叠长度分段，每一个段为单独的集合，返回这个集合的列表
+	 *
+	 * <p>
+	 * 需要特别注意的是，此方法调用{@link List#subList(int, int)}切分List，
+	 * 此方法返回的是原List的视图，也就是说原List有变更，切分后的结果也会变更。
+	 * </p>
+	 *
+	 * <p>例：</p>
+	 * <pre>
+	 *     ListUtil.overlapPartition(null, 2, 0);	// []
+	 *     ListUtil.overlapPartition(ListUtil.empty(), 2, 0);	// []
+	 *     ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 0);	// [[1, 2], [3, 4], [5]]
+	 *     ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 1);	// [[1, 2], [2, 3], [3, 4], [4, 5]]
+	 *     ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 3, 2);	// [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
+	 *     ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 6, 1);	// [[1, 2, 3, 4, 5]]
+	 * </pre>
+	 *
+	 * @param <T>         元素类型
+	 * @param list        列表
+	 * @param size        每段长度
+	 * @param overlapSize 每段的可重叠长度
+	 * @return 分段列表
+	 * @throws IllegalArgumentException 指定的每段长度必须大于每段的可重叠长度，否则抛出{@code java.lang.IllegalArgumentException}
+	 * @author jin7
+	 * @since 6.0.0
+	 */
+	public static <T> List<List<T>> overlapPartition(List<T> list, int size, int overlapSize) {
+		if (size <= overlapSize) {
+			throw new IllegalArgumentException("The size must be greater than the overlapSize");
+		}
+		List<List<T>> lists = new ArrayList<>();
+		if (list != null && list.size() > 0) {
+			if (list.size() <= size) {
+				lists.add(list);
+			} else {
+				for (int i = 0; i < list.size(); ) {
+					int toIndex = Math.min(list.size(), i + size);
+					List<T> subList = list.subList(i, toIndex);
+					if (i == list.size() - overlapSize) {
+						break;
+					}
+					lists.add(subList);
+					i = toIndex - overlapSize;
+				}
+			}
+		}
+		return lists;
+	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/collection/ListUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/collection/ListUtilTest.java
@@ -261,4 +261,21 @@ public class ListUtilTest {
 		final List<Integer> reverse = ListUtil.reverseNew(view);
 		Assert.assertEquals("[3, 2, 1]", reverse.toString());
 	}
+
+	@Test
+	public void overlapPartitionTest() {
+		List<List<Integer>> lists = ListUtil.overlapPartition(null, 2, 0);
+		Assert.assertEquals("[]", lists.toString());
+		lists = ListUtil.overlapPartition(ListUtil.empty(), 2, 0);
+		Assert.assertEquals("[]", lists.toString());
+		lists = ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 0);
+		Assert.assertEquals("[[1, 2], [3, 4], [5]]", lists.toString());
+		lists = ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 1);
+		Assert.assertEquals("[[1, 2], [2, 3], [3, 4], [4, 5]]", lists.toString());
+		lists = ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 3, 2);
+		Assert.assertEquals("[[1, 2, 3], [2, 3, 4], [3, 4, 5]]", lists.toString());
+		lists = ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 6, 1);
+		Assert.assertEquals("[[1, 2, 3, 4, 5]]", lists.toString());
+		Assert.assertThrows(IllegalArgumentException.class, () -> ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 2));
+	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] N/A
2. [新特性]  可重叠分段，对集合按照指定的每段长度和每段的可重叠长度分段，每一个段为单独的集合，返回这个集合的列表。
指定的每段长度必须大于每段的可重叠长度，否则抛出IllegalArgumentException
<p>例：</p>
<pre>
    ListUtil.overlapPartition(null, 2, 0);	// []
    ListUtil.overlapPartition(ListUtil.empty(), 2, 0);	// []
    ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 0);	// [[1, 2], [3, 4], [5]]
    ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 2, 1);	// [[1, 2], [2, 3], [3, 4], [4, 5]]
    ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 3, 2);	// [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
    ListUtil.overlapPartition(Arrays.asList(1, 2, 3, 4, 5), 6, 1);	// [[1, 2, 3, 4, 5]]
</pre>
dromara/hutool#3219

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过