### PR TITLE
增加判断对象所有字段为NULL的函数

### DIFF
--- a/hutool-core/src/main/java/org/dromara/hutool/core/util/ObjUtil.java
+++ b/hutool-core/src/main/java/org/dromara/hutool/core/util/ObjUtil.java
@@ -21,12 +21,15 @@ import org.dromara.hutool.core.io.SerializeUtil;
 import org.dromara.hutool.core.map.MapUtil;
 import org.dromara.hutool.core.math.NumberUtil;
 import org.dromara.hutool.core.reflect.ClassUtil;
+import org.dromara.hutool.core.reflect.ModifierUtil;
+import org.dromara.hutool.core.reflect.ReflectUtil;
 import org.dromara.hutool.core.reflect.method.MethodUtil;
 import org.dromara.hutool.core.text.CharSequenceUtil;
 import org.dromara.hutool.core.text.StrUtil;
 
 import java.io.Serializable;
 import java.lang.reflect.Array;
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.function.Function;
@@ -493,5 +496,57 @@ public class ObjUtil {
 			return obj.toString();
 		}
 		return Convert.toStr(obj);
+	}
+
+	/**
+	 * 检查对象所有字段属性是否都为null<br>
+	 * 异常则返回false<br>
+	 * 判断标准为：
+	 *
+	 * <pre>
+	 * 1. == null
+	 * </pre>
+	 *
+	 * @param obj 对象
+	 * @return 该对象所有字段是否为null
+	 */
+	public static boolean isAllFieldNull(Object obj, boolean ignoreStaticFields) {
+		// 获取对象的所有字段（包括父类的字段）
+		Field[] fields = obj.getClass().getDeclaredFields();
+		// 遍历字段
+		for (Field field : fields) {
+			try {
+				// 设置字段可访问
+				ReflectUtil.setAccessible(field);
+				// 检查字段是否为静态字段
+				if (ignoreStaticFields && ModifierUtil.isStatic(field)) {
+					continue; // 如果是静态字段，ignoreStaticFields是true就跳过检查
+				}
+				// 检查字段值是否为null
+				if (field.get(obj) != null) {
+					return false; // 如果有一个字段不为null，则返回false
+				}
+			} catch (RuntimeException | IllegalAccessException e) {
+				// e.printStackTrace();
+				return false; // 抛出异常，则返回false
+			}
+		}
+		return true; // 所有字段都为null，返回true
+	}
+
+	/**
+	 * 检查对象所有字段属性是否都不为null<br>
+	 * 异常则返回true<br>
+	 * 判断标准为：
+	 *
+	 * <pre>
+	 * 1. == null
+	 * </pre>
+	 *
+	 * @param obj 对象
+	 * @return 该对象所有字段是否不为null
+	 */
+	public static boolean isAllFieldNotNull(Object obj, boolean ignoreStaticFields) {
+		return !isAllFieldNull(obj, ignoreStaticFields);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v6-dev'分支，否则我会手动修改代码并关闭PR。确定
2. 请确认没有更改代码风格（如tab缩进）确定
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例 确定

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  增加判断对象所有字段为NULL的函数, 以及取反的NOT NULL

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。 已自测

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过