### PR TITLE
HttpRequest 和 GlobalInterceptor 增加请求异常拦截器

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/GlobalInterceptor.java
+++ b/hutool-http/src/main/java/cn/hutool/http/GlobalInterceptor.java
@@ -11,6 +11,7 @@ public enum GlobalInterceptor {
 	INSTANCE;
 
 	private final HttpInterceptor.Chain<HttpRequest> requestInterceptors = new HttpInterceptor.Chain<>();
+	private final HttpInterceptor.Chain<HttpRequest> exceptionInterceptors = new HttpInterceptor.Chain<>();
 	private final HttpInterceptor.Chain<HttpResponse> responseInterceptors = new HttpInterceptor.Chain<>();
 
 	/**
@@ -21,6 +22,16 @@ public enum GlobalInterceptor {
 	 */
 	synchronized public GlobalInterceptor addRequestInterceptor(HttpInterceptor<HttpRequest> interceptor) {
 		this.requestInterceptors.addChain(interceptor);
+		return this;
+	}
+	/**
+	 * 设置拦截器，用于在请求中抛异常完成编辑或者读取
+	 *
+	 * @param interceptor 拦截器实现
+	 * @return this
+	 */
+	synchronized public GlobalInterceptor addExceptionInterceptor(HttpInterceptor<HttpRequest> interceptor) {
+		this.exceptionInterceptors.addChain(interceptor);
 		return this;
 	}
 
@@ -67,6 +78,16 @@ public enum GlobalInterceptor {
 	}
 
 	/**
+	 * 清空异常拦截器
+	 *
+	 * @return this
+	 */
+	synchronized public GlobalInterceptor clearException() {
+		exceptionInterceptors.clear();
+		return this;
+	}
+
+	/**
 	 * 复制请求过滤器列表
 	 *
 	 * @return {@link cn.hutool.http.HttpInterceptor.Chain}
@@ -74,6 +95,19 @@ public enum GlobalInterceptor {
 	HttpInterceptor.Chain<HttpRequest> getCopiedRequestInterceptor() {
 		final HttpInterceptor.Chain<HttpRequest> copied = new HttpInterceptor.Chain<>();
 		for (HttpInterceptor<HttpRequest> interceptor : this.requestInterceptors) {
+			copied.addChain(interceptor);
+		}
+		return copied;
+	}
+
+	/**
+	 * 复制异常过滤器列表
+	 *
+	 * @return {@link cn.hutool.http.HttpInterceptor.Chain}
+	 */
+	HttpInterceptor.Chain<HttpRequest> getCopiedExceptionInterceptor() {
+		final HttpInterceptor.Chain<HttpRequest> copied = new HttpInterceptor.Chain<>();
+		for (HttpInterceptor<HttpRequest> interceptor : this.exceptionInterceptors) {
 			copied.addChain(interceptor);
 		}
 		return copied;

--- a/hutool-http/src/main/java/cn/hutool/http/HttpConfig.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpConfig.java
@@ -81,6 +81,10 @@ public class HttpConfig {
 	 */
 	final HttpInterceptor.Chain<HttpRequest> requestInterceptors = GlobalInterceptor.INSTANCE.getCopiedRequestInterceptor();
 	/**
+	 * 请求异常的拦截器，用于在请求异常重新编辑请求
+	 */
+	final HttpInterceptor.Chain<HttpRequest> exceptionInterceptors = GlobalInterceptor.INSTANCE.getCopiedExceptionInterceptor();
+	/**
 	 * 响应后的拦截器，用于在响应后处理逻辑
 	 */
 	final HttpInterceptor.Chain<HttpResponse> responseInterceptors = GlobalInterceptor.INSTANCE.getCopiedResponseInterceptor();
@@ -278,6 +282,16 @@ public class HttpConfig {
 	 */
 	public HttpConfig addRequestInterceptor(HttpInterceptor<HttpRequest> interceptor) {
 		this.requestInterceptors.addChain(interceptor);
+		return this;
+	}
+	/**
+	 * 设置拦截器，用于在请求异常重新编辑请求
+	 *
+	 * @param interceptor 拦截器实现
+	 * @return this
+	 */
+	public HttpConfig addExceptionInterceptor(HttpInterceptor<HttpRequest> interceptor) {
+		this.exceptionInterceptors.addChain(interceptor);
 		return this;
 	}
 

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -204,6 +204,7 @@ public class HttpRequestTest {
 		HttpUtil.createGet("https://hutool.cn")
 				.addInterceptor(Console::log)
 				.addResponseInterceptor((res)-> Console.log(res.getStatus()))
+				.addExceptionInterceptor(Console::log)
 				.execute();
 	}
 
@@ -211,6 +212,8 @@ public class HttpRequestTest {
 	@Ignore
 	public void addGlobalInterceptorTest() {
 		GlobalInterceptor.INSTANCE.addRequestInterceptor(Console::log);
+		GlobalInterceptor.INSTANCE.addResponseInterceptor((res)-> Console.log(res.getStatus()));
+		GlobalInterceptor.INSTANCE.addExceptionInterceptor(Console::log);
 		HttpUtil.createGet("https://hutool.cn").execute();
 	}
 


### PR DESCRIPTION
#### 说明

1. 已确认fork 自 'v5-dev'分支，并提交到 'v5-dev' 分支。
2. 已确认没有更改代码风格（如tab缩进）
3. 新特性添加已确认注释完备，已在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  http request 有请求拦截器和响应拦截器，但是对于请求报错（比如超时等HttpException,或者IOException）没有对应的拦截器，参考我在另外一个issues 下的回复 https://github.com/dromara/hutool/issues/2217#issuecomment-1751591782 ,但是有一点缺陷是，没有把Exception对象传入到拦截器里。

### 提交前自测
> 均自测通过(`mvn javadoc:javadoc ` ,`mvn clean test` ,`mvn clean package -Dmaven.test.skip=true -U`) 。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过