### PR TITLE
HttpResponse添加返回头信息（不包含状态行）方法

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpResponse.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpResponse.java
@@ -23,7 +23,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpCookie;
 import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 /**
@@ -224,6 +227,16 @@ public class HttpResponse extends HttpBase<HttpResponse> implements Closeable {
 	public String getCookieValue(String name) {
 		final HttpCookie cookie = getCookie(name);
 		return (null == cookie) ? null : cookie.getValue();
+	}
+
+	/**
+	 * 获取返回头信息（不包含状态行）
+	 * @return 头部信息（不包含状态行）
+	 */
+	public Map<String, List<String>> getHeadersWithoutStatusLine() {
+		Map<String, List<String>> copyHeaders = new HashMap<>(headers);
+		copyHeaders.remove(null);
+		return Collections.unmodifiableMap(copyHeaders);
 	}
 	// ---------------------------------------------------------------- Http Response Header end
 


### PR DESCRIPTION
[bug修复] 1.HttpResponse.headers()方法默认返回的头信息包括了状态行（如null=[HTTP/1.1 200]）。很多时候我们并不需要这个字段，甚至，由于返回的Map里包含键为null会导致接下来不规范使用报错空指针（报错场景示例：
        Map<String, List<String>> originalHeaders = response.headers();
        HttpHeaders headers = new HttpHeaders();
        headers.putAll(originalHeaders);
）。与hutool的简洁易使用宗旨违背。所以在HttpResponse添加返回头信息（不包含状态行）方法