### PR TITLE
为EnumUtil添加了一个新的方法:getEnumMapList(),用于获取每个枚举常量的属性名及其对应的属性值

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/EnumUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/EnumUtil.java
@@ -304,6 +304,35 @@ public class EnumUtil {
 	}
 
 	/**
+	 * 获取一个枚举类的所有字段及其对应的枚举常量，并将它们存储在一个List<Map<String, Object>>结构中返回<br>
+	 * 结果中List中的一个Map对应着一个枚举常量,其中Map的key为属性名，value为属性值,特殊的:我们会约定将"enumConstName"为key,枚举常量字段名为value放入Map中,用来标识这个Map对应的是哪个枚举常量
+	 *
+	 * @param enumClazz 需要获取字段的枚举类的Class对象
+	 * @return 包含枚举类所有字段及其对应枚举常量的List<Map<String, Object>>结构
+	 */
+	public static List<Map<String, Object>> getEnumMapList(final Class<? extends Enum<?>> enumClazz) {
+		List<Map<String, Object>> enumMapList = new ArrayList<>();
+		Enum<?>[] enumConstants = enumClazz.getEnumConstants();
+		Field[] declaredEnumFields = ClassUtil.getDeclaredFields(enumClazz);
+		for (Field declaredEnumField : declaredEnumFields) {
+			declaredEnumField.setAccessible(true);
+		}
+		for (Enum<?> enumConstant : enumConstants) {
+			Map<String, Object> map = new LinkedHashMap<>();
+			for (Field field : declaredEnumFields) {
+				if (field.isEnumConstant() && ObjectUtil.equal(ReflectUtil.getFieldValue(enumConstant,field), enumConstant)) {
+					map.put("enumConstantName", field.getName());
+				}
+				if (!field.isEnumConstant() && !field.isSynthetic() && !field.getName().contains("$VALUES")) {
+					map.put(field.getName(),ReflectUtil.getFieldValue(enumConstant,field));
+				}
+			}
+			enumMapList.add(map);
+		}
+		return enumMapList;
+	}
+
+	/**
 	 * 获得枚举名对应指定字段值的Map<br>
 	 * 键为枚举名，值为字段值
 	 *

--- a/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/EnumUtilTest.java
@@ -64,6 +64,22 @@ public class EnumUtilTest {
 	}
 
 	@Test
+	public void getEnumMapList(){
+		List<Map<String, Object>> enumMapList = EnumUtil.getEnumMapList(TestEnum.class);
+
+		Assert.assertEquals(3, enumMapList.size());
+
+		for (Map<String, Object> enumMap : enumMapList) {
+			Assert.assertTrue(enumMap.containsKey("enumConstantName"));
+			String enumConstantName = (String) enumMap.get("enumConstantName");
+			Assert.assertTrue(enumConstantName.equals("TEST1") || enumConstantName.equals("TEST2") || enumConstantName.equals("TEST3"));
+			Assert.assertTrue(enumMap.containsKey("type"));
+			Assert.assertEquals(TestEnum.valueOf(enumConstantName).getType(), enumMap.get("type"));
+			Assert.assertEquals(TestEnum.valueOf(enumConstantName).getName(), enumMap.get("name"));
+		}
+	}
+
+	@Test
 	public void getNameFieldMapTest() {
 		Map<String, Object> enumMap = EnumUtil.getNameFieldMap(TestEnum.class, "type");
 		assert enumMap != null;


### PR DESCRIPTION
该新方法使用反射，获取一个枚举中所有枚举常量，将一个枚举常量的属性名以及属性的值还有枚举常量字段名放入Map中，并将所有Map添加至List中(list中一个Map对应一个枚举常量).  我创建该方法是因为我在开发中，后端中的枚举类中存储了数据字典，需要将该枚举类中的值转换成List,传给前端