### PR TITLE
关于修复bimap的bug以及增加新特性

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/map/BiMap.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/BiMap.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
  * 值的顺序在HashMap中不确定，所以谁覆盖谁也不确定，在有序的Map中按照先后顺序覆盖，保留最后的值<br>
  * 它与TableMap的区别是，BiMap维护两个Map实现高效的正向和反向查找
  *
- * @param <K> 键类型
+ * @param <K> 键类型 //
  * @param <V> 值类型
  * @since 5.2.6
  */

--- a/hutool-core/src/main/java/cn/hutool/core/map/BiMap.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/BiMap.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
  * 值的顺序在HashMap中不确定，所以谁覆盖谁也不确定，在有序的Map中按照先后顺序覆盖，保留最后的值<br>
  * 它与TableMap的区别是，BiMap维护两个Map实现高效的正向和反向查找
  *
- * @param <K> 键类型 //
+ * @param <K> 键类型
  * @param <V> 值类型
  * @since 5.2.6
  */

--- a/hutool-core/src/main/java/cn/hutool/core/map/BiMap.java
+++ b/hutool-core/src/main/java/cn/hutool/core/map/BiMap.java
@@ -1,6 +1,9 @@
 package cn.hutool.core.map;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -26,14 +29,35 @@ public class BiMap<K, V> extends MapWrapper<K, V> {
 	 */
 	public BiMap(Map<K, V> raw) {
 		super(raw);
+		if(raw instanceof HashMap){
+			inverse = new HashMap<>();
+		}else if(raw instanceof ConcurrentMap){
+			inverse = new ConcurrentHashMap<>();
+		}
 	}
 
 	@Override
 	public V put(K key, V value) {
+		if(super.containsKey(key)){
+			throw new IllegalArgumentException("value already present");
+		}
 		if (null != this.inverse) {
 			this.inverse.put(value, key);
 		}
 		return super.put(key, value);
+	}
+
+	/**
+	 * 如果已经存在绑定的键值对，用这个方法更改其绑定关系而不是put。直接使用put可能会破坏bimap的一对一特性
+	 *
+	 * @param key
+	 * @param value
+	 *
+	 */
+	public V forcePut(K key, V value){
+		V formerValue = super.remove(key);
+		inverse.remove(formerValue);
+		return put(key,value);
 	}
 
 	@Override

--- a/hutool-core/src/test/java/cn/hutool/core/map/BiMapTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/map/BiMapTest.java
@@ -41,4 +41,27 @@ public class BiMapTest {
 		Assert.assertEquals(new Integer(333), biMap.get("ccc"));
 		Assert.assertEquals("ccc", biMap.getKey(333));
 	}
+
+	@Test
+	public void putExistedValueErrorTest(){
+		final BiMap<String, Integer> biMap = new BiMap<>(new HashMap<>());
+		try{
+		biMap.put("aaa", 111);
+		biMap.put("aaa", 222);
+		Assert.fail("未抛出异常");
+				}
+		catch (IllegalArgumentException e){
+			System.out.println("捕获");
+		}
+
+	}
+
+	@Test
+	public void forcePutTest(){
+		final BiMap<String, Integer> biMap = new BiMap<>(new HashMap<>());
+		biMap.put("aaa", 111);
+		biMap.forcePut("aaa", 222);
+		Assert.assertEquals(new Integer(222),biMap.get("aaa"));
+		Assert.assertEquals(new String("aaa"),biMap.getKey(222));
+	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。（确认）
2. 请确认没有更改代码风格（如tab缩进）（确认）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例 （已自测）

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 在gitee上发现有人反映关于bimap的bug，我看了一下源码，问题出在bimap类中的inverse没有初始化，因此我修复了这个bug。（备注：目前instanceof不全面，可能需要进一步列举）另一个bug：重复put之后仍可以通过旧value访问到新的key。
2. [新特性]  浏览了一下源码我觉得需要增加一些新特性。比如现有的put方法可能会破坏原有的一对一关系（见如下），
biMap.put("aaa", 111);
biMap.getKey(111);
biMap.put("aaa", 222);
System.out.println(biMap.getKey(111)) 在这种情况下111仍然指向"aaa"，也就是说同时有222指向“aaa”和111指向“aaa”。
同时我们缺乏一种有效的办法更改已有的一对一关系。为此我的想法是如果发现重复put相同的键就直接报非法参数的错误，提示用户一对一关系已经存在。如果想要修改一对一关系，就使用新的forcePut方法

### 提交前自测
> 已完成自测，新方法已注释，希望通过pr

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过