### PR TITLE
feat:新增多线程环境获取线程安全的脚本引擎

### DIFF
--- a/hutool-script/src/test/java/cn/hutool/script/test/ScriptUtilTest.java
+++ b/hutool-script/src/test/java/cn/hutool/script/test/ScriptUtilTest.java
@@ -9,10 +9,11 @@ import org.junit.Test;
 import javax.script.CompiledScript;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 脚本单元测试类
- * 
+ *
  * @author looly
  *
  */
@@ -55,5 +56,48 @@ public class ScriptUtilTest {
 	public void groovyTest() throws ScriptException {
 		final ScriptEngine engine = ScriptUtil.getGroovyEngine();
 		engine.eval("println 'Hello Groovy'");
+	}
+
+	/**
+	 *  多线程环境下模拟脚本引擎变量交替初始化执行结果是否正确
+	 */
+	public static void groovySafeEnginTest() throws ScriptException {
+
+		new Thread(()->{
+			try {
+				System.out.println("groovySafeEnginTest-1-start");
+				ScriptEngine groovyEngine = ScriptUtil.getScriptEngine("groovy");
+				groovyEngine.put("s","test1");
+				Object result = groovyEngine.eval("return s");
+				System.out.println("线程1,s="+result);
+				TimeUnit.SECONDS.sleep(3);
+				groovyEngine.put("s","test1");
+				System.out.println("groovySafeEnginTest-1-end");
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}).start();
+
+		new Thread(()->{
+			try {
+				System.out.println("groovySafeEnginTest-2-start");
+				ScriptEngine groovyEngine = ScriptUtil.getScriptEngine("groovy");
+				groovyEngine.put("s","test2");
+				TimeUnit.SECONDS.sleep(4);
+				Object result = groovyEngine.eval("return s");
+				System.out.println("线程2,s="+result);
+				System.out.println("groovySafeEnginTest-2-end");
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}).start();
+	}
+
+	public static void main(String[] args) {
+		try {
+			groovySafeEnginTest();
+		} catch (ScriptException e) {
+			e.printStackTrace();
+		}
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。√
2. 请确认没有更改代码风格（如tab缩进）√
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例 √

### 修改描述(包括说明bug修复或者添加新特性)
原有提供的获取脚本引擎 在单线程下没有问题，在多线程下导致引擎变量有问题，所以另起了一个方法获取线程安全的脚本引擎。
1. [新特性]  增加ThreadLocal缓存保证在多线程环境下的脚本引擎变量不会相互覆盖。每个线程使用独立的ScriptEngine，支持重入同一线程多次执行可保留原有的脚本变量。

### 提交前自测
> 已自测通过，并且提交了单元测试，未加@Test注解