### PR TITLE
feat:Validator新增强密码验证，所有口令（密码）位数必须大于等于8，至少包含大小写字母、数字、特殊字符四种组合中的三种组合，符…

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/PatternPool.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/PatternPool.java
@@ -193,6 +193,11 @@ public class PatternPool {
 	 * 总结中国人姓名：2-60位，只能是中文和 ·
 	 */
 	public static final Pattern CHINESE_NAME = Pattern.compile(RegexPool.CHINESE_NAME);
+	/**
+	 * 强密码验证：
+	 * 所有口令（密码）位数必须大于等于8，至少包含大小写字母、数字、特殊字符四种组合中的三种组合，符合的为强密码，不符合此种规则的为弱口令
+	 */
+	public final static Pattern STRONGPASSWORD = Pattern.compile(RegexPool.STRONGPASSWORD);
 
 	// -------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	/**

--- a/hutool-core/src/main/java/cn/hutool/core/lang/RegexPool.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/RegexPool.java
@@ -222,4 +222,8 @@ public interface RegexPool {
 	 * 放宽汉字范围：如生僻姓名 刘欣䶮yǎn
 	 */
 	String CHINESE_NAME = "^[\u2E80-\u9FFF·]{2,60}$";
+	/**
+	 * 至少包含大小写字母、数字、特殊字符四种组合中的三种组合
+	 */
+	String STRONGPASSWORD = "^(?![a-zA-Z]+$)(?![A-Z0-9]+$)(?![A-Z\\W_]+$)(?![a-z0-9]+$)(?![a-z\\W_]+$)(?![0-9\\W_]+$)[a-zA-Z0-9\\W_]{8,}$";
 }

--- a/hutool-core/src/main/java/cn/hutool/core/lang/Validator.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Validator.java
@@ -111,7 +111,10 @@ public class Validator {
 	 * 驾驶证  别名：驾驶证档案编号、行驶证编号；12位数字字符串；仅限：中国驾驶证档案编号
 	 */
 	public final static Pattern CAR_DRIVING_LICENCE = PatternPool.CAR_DRIVING_LICENCE;
-
+	/**
+	 * 包含大小写字母、数字、特殊字符四种组合中的三种组合，符合的为强密码，不符合此种规则的为弱口令
+	 */
+	public final static Pattern STRONGPASSWORD = PatternPool.STRONGPASSWORD;
 	/**
 	 * 给定值是否为{@code true}
 	 *
@@ -1276,4 +1279,33 @@ public class Validator {
 			throw new ValidateException("Index [{}] is too large for size: [{}]", index, size);
 		}
 	}
+
+	/**
+	 * 强密码验证：
+	 * 所有口令（密码）位数必须大于等于8，至少包含大小写字母、数字、特殊字符四种组合中的三种组合，符合的为强密码，不符合此种规则的为弱口令
+	 *
+	 * @param value 值
+	 * @return 是否为强密码
+	 */
+	public static boolean isStrongPassword(CharSequence value) {
+		return isMatchRegex(STRONGPASSWORD, value);
+	}
+
+
+	/**
+	 * 验证是否为强密码
+	 *
+	 * @param <T>      字符串类型
+	 * @param value    值
+	 * @param errorMsg 验证错误的信息
+	 * @return 验证后的值
+	 * @throws ValidateException 验证异常
+	 */
+	public static <T extends CharSequence> T validateStrongPassword(T value, String errorMsg) throws ValidateException {
+		if (false == isStrongPassword(value)) {
+			throw new ValidateException(errorMsg);
+		}
+		return value;
+	}
+
 }

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
@@ -265,4 +265,14 @@ public class ValidatorTest {
 		Assert.assertFalse(Validator.isChineseName("连逍遥0"));
 		Assert.assertFalse(Validator.isChineseName("SHE"));
 	}
+
+	@Test
+	public void isStrongPasswordTest() {
+		Assert.assertTrue(Validator.isStrongPassword("123QWE321."));
+		Assert.assertTrue(Validator.isStrongPassword("123QWE321("));
+		Assert.assertTrue(Validator.isStrongPassword("123qwe.+"));
+		Assert.assertTrue(Validator.isStrongPassword("123qweQWE"));
+		Assert.assertFalse(Validator.isStrongPassword("123QWE321"));
+		Assert.assertFalse(Validator.isStrongPassword("123qweQ"));
+	}
 }


### PR DESCRIPTION
…合的为强密码，不符合此种规则的为弱口令。

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  Validator新增强密码验证，所有口令（密码）位数必须大于等于8，至少包含大小写字母、数字、特殊字符四种组合中的三种组合

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过