### PR TITLE
Fixed 2 flaky tests in `hutool-json`

### DIFF
--- a/hutool-json/src/test/java/cn/hutool/json/IssueI4XFMWTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI4XFMWTest.java
@@ -27,7 +27,7 @@ public class IssueI4XFMWTest {
 		entityList.add(entityB);
 
 		String jsonStr = JSONUtil.toJsonStr(entityList);
-		Assert.assertEquals("[{\"uid\":\"123\",\"password\":\"456\"},{\"uid\":\"789\",\"password\":\"098\"}]", jsonStr);
+		Assert.assertTrue(jsonStr.equals("[{\"uid\":\"123\",\"password\":\"456\"},{\"uid\":\"789\",\"password\":\"098\"}]") || jsonStr.equals("[{\"password\":\"456\",\"uid\":\"123\"},{\"password\":\"098\",\"uid\":\"789\"}]"));
 		List<TestEntity> testEntities = JSONUtil.toList(jsonStr, TestEntity.class);
 		Assert.assertEquals("123", testEntities.get(0).getId());
 		Assert.assertEquals("789", testEntities.get(1).getId());

--- a/hutool-json/src/test/java/cn/hutool/json/IssueI6SZYBTest.java
+++ b/hutool-json/src/test/java/cn/hutool/json/IssueI6SZYBTest.java
@@ -12,7 +12,7 @@ public class IssueI6SZYBTest {
 	public void pairTest() {
 		Pair<Integer,Integer> pair = Pair.of(1, 2);
 		String jsonStr = JSONUtil.toJsonStr(pair);
-		Assert.assertEquals("{\"key\":1,\"value\":2}", jsonStr);
+		Assert.assertTrue(jsonStr.equals("{\"key\":1,\"value\":2}") || jsonStr.equals("{\"value\":2,\"key\":1}"));
 
 		final Pair bean = JSONUtil.toBean(jsonStr, Pair.class);
 		Assert.assertEquals(pair, bean);


### PR DESCRIPTION
Created this PR to fix 2 flaky tests namely `pairTest` which can be found [here](https://github.com/dromara/hutool/blob/v5-dev/hutool-json/src/test/java/cn/hutool/json/IssueI6SZYBTest.java) and  `test` which can be found [here](https://github.com/dromara/hutool/blob/v5-dev/hutool-json/src/test/java/cn/hutool/json/IssueI4XFMWTest.java).


1. How was this test identified as flaky?
This test was identifies as flaky by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

2. What do the tests do?

- `pairTest `
It creates a `Pair` object with integers (1, 2), converts it to a JSON string, and then asserts that the resulting JSON string matches one of two expected formats. Afterwards, it deserializes the JSON string back into a Pair object and verifies that it matches the original Pair object created earlier.
- `test `
 It initializes a List of `TestEntity` objects, populates them with specific data, converts the list to a JSON string, and then asserts that the resulting JSON string matches one of two expected formats. It then deserializes the JSON string back into a list of `TestEntity` objects and verifies that the IDs of the entities match the original values set earlier.

3. Why do the tests fail?

- `pairTest` fails because there is a mismatch in the order of the key and value in the JSON string of the `pair` object.
The error occurs here:
https://github.com/dromara/hutool/blob/56a47b967954071362e00523cc3c5f92cedd5109/hutool-json/src/test/java/cn/hutool/json/IssueI6SZYBTest.java#L15

- `test` fails because there is a mismatch in the order of uid and password of `entityA` and `entityB` in the JSON string of the `entityList` object.
The error occurs here:
https://github.com/dromara/hutool/blob/56a47b967954071362e00523cc3c5f92cedd5109/hutool-json/src/test/java/cn/hutool/json/IssueI4XFMWTest.java#L30

4. How I fixed these tests?

This PR fixes `pairTest` by comparing the JSON string with the shuffled key/value string.

This PR also fixes `test` by comparing the JSON string with the shuffled uid/password string.

You can run the following commands to run the tests using NonDex tool:

```
 mvn -pl hutool-json edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=cn.hutool.json.IssueI6SZYBTest#pairTest
````
```
mvn -pl hutool-json edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=cn.hutool.json.IssueI4XFMWTest#test
```

(Optional) You can also run the following command to run the test:

```
mvn -pl hutool-json test -Dtest=cn.hutool.json.IssueI6SZYBTest#pairTest
````
```
mvn -pl hutool-json test -Dtest=cn.hutool.json.IssueI4XFMWTest#test
```

Test Environment:
```
java version "1.8.0_202"
Apache Maven 3.6.3
```

Kindly let me know if this fix is acceptable.

Thank you