### PR TITLE
[新特性] ObjectUtil 新增判空/null 时抛异常工具方法

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/ObjectUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ObjectUtil.java
@@ -4,9 +4,11 @@ import cn.hutool.core.collection.IterUtil;
 import cn.hutool.core.comparator.CompareUtil;
 import cn.hutool.core.convert.Convert;
 import cn.hutool.core.exceptions.UtilException;
+import cn.hutool.core.exceptions.ValidateException;
 import cn.hutool.core.map.MapUtil;
 
 import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -585,8 +587,8 @@ public class ObjectUtil {
 	 * 注意！！！ 此方法不会检查反序列化安全，可能存在反序列化漏洞风险！！！
 	 * </p>
 	 *
-	 * @param <T>   对象类型
-	 * @param bytes 反序列化的字节码
+	 * @param <T>           对象类型
+	 * @param bytes         反序列化的字节码
 	 * @param acceptClasses 白名单的类
 	 * @return 反序列化后的对象
 	 */
@@ -749,5 +751,145 @@ public class ObjectUtil {
 	 */
 	public static boolean isAllNotEmpty(Object... objs) {
 		return ArrayUtil.isAllNotEmpty(objs);
+	}
+
+	/**
+	 * 判断对象是否为 {@code null}，若为 {@code null} 则抛出 ValidateException 异常
+	 * <pre>
+	 * 默认异常为 ValidateException
+	 * 异常信息为 Target Must Be Not Null
+	 * </pre>
+	 *
+	 * @param object 被判断的对象
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static void throwIfNull(Object object) {
+		throwIfNull(object, "Target Must Be Not Null");
+	}
+
+	/**
+	 * 判断对象是否为 {@code null}，若为 {@code null} 则抛出 ValidateException 异常
+	 *
+	 * @param object   被判断的对象
+	 * @param throwMsg 抛出异常的信息
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static void throwIfNull(Object object, String throwMsg) {
+		throwIfNull(object, throwMsg, ValidateException.class);
+	}
+
+	/**
+	 * 判断对象是否为 {@code null}，若为 {@code null} 则抛出自定义运行时异常
+	 * <pre>
+	 * 默认异常为 ValidateException
+	 * </pre>
+	 *
+	 * @param object         被判断的对象
+	 * @param throwMsg       异常的信息
+	 * @param exceptionClass 异常类型， 需要此类继承运行时异常，并且提供字符串构造才能将 throwMsg 抛出
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static void throwIfNull(Object object, String throwMsg, Class<? extends RuntimeException> exceptionClass) {
+		if (isNull(object)) {
+			try {
+				// 通过反射创建异常实例
+				try {
+					throw exceptionClass.getDeclaredConstructor(String.class).newInstance(throwMsg);
+				} catch (NoSuchMethodException e) {
+					throw exceptionClass.newInstance();
+				}
+			} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+				// 处理异常实例化过程中的异常
+				throw new ValidateException(throwMsg);
+			}
+		}
+	}
+
+	/**
+	 * 判断对象是否为 {@code null}，若为 {@code null} 则抛出异常（由 exceptionSupplier 提供）
+	 *
+	 * @param object            被判断的对象
+	 * @param exceptionSupplier 运行时异常提供者
+	 * @param <X>               异常类型
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static <X extends RuntimeException> void throwIfNull(Object object, Supplier<? extends X> exceptionSupplier) throws X {
+		if (isNull(object)) {
+			throw exceptionSupplier.get();
+		}
+	}
+
+	/**
+	 * 判断对象是否为空，若为空则抛出 ValidateException 异常
+	 * <pre>
+	 * 默认异常为 ValidateException
+	 * 异常信息为 Target Must Be Not Empty
+	 * </pre>
+	 *
+	 * @param object 被判断的对象
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static void throwIfEmpty(Object object) {
+		throwIfEmpty(object, "Target Must Be Not Empty");
+	}
+
+	/**
+	 * 判断对象是否为空，若为空则抛出 ValidateException 异常
+	 *
+	 * @param object   被判断的对象
+	 * @param throwMsg 抛出异常的信息
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static void throwIfEmpty(Object object, String throwMsg) {
+		throwIfEmpty(object, throwMsg, ValidateException.class);
+	}
+
+	/**
+	 * 判断对象是否为空，若为空则抛出自定义运行时异常
+	 * <pre>
+	 * 默认异常为 ValidateException
+	 * </pre>
+	 *
+	 * @param object         被判断的对象
+	 * @param throwMsg       异常的信息
+	 * @param exceptionClass 异常类型， 需要此类继承运行时异常，并且提供字符串构造才能将 throwMsg 抛出
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static void throwIfEmpty(Object object, String throwMsg, Class<? extends RuntimeException> exceptionClass) {
+		if (isEmpty(object)) {
+			try {
+				// 通过反射创建异常实例
+				try {
+					throw exceptionClass.getDeclaredConstructor(String.class).newInstance(throwMsg);
+				} catch (NoSuchMethodException e) {
+					throw exceptionClass.newInstance();
+				}
+			} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+				// 处理异常实例化过程中的异常
+				throw new ValidateException(throwMsg);
+			}
+		}
+	}
+
+	/**
+	 * 判断对象是否为空，若为空则抛出异常（由 exceptionSupplier 提供）
+	 *
+	 * @param object            被判断的对象
+	 * @param exceptionSupplier 运行时异常提供者
+	 * @param <X>               异常类型
+	 * @author XUEW
+	 * @since 5.8.17
+	 */
+	public static <X extends RuntimeException> void throwIfEmpty(Object object, Supplier<? extends X> exceptionSupplier) throws X {
+		if (isEmpty(object)) {
+			throw exceptionSupplier.get();
+		}
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/ObjectUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ObjectUtilTest.java
@@ -68,10 +68,10 @@ public class ObjectUtilTest {
 		final String nullValue = null;
 		final String dateStr = "2020-10-23 15:12:30";
 		Instant result1 = ObjectUtil.defaultIfNull(dateStr,
-				(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
+			(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
 		Assert.assertNotNull(result1);
 		Instant result2 = ObjectUtil.defaultIfNull(nullValue,
-				(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
+			(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
 		Assert.assertNotNull(result2);
 
 		Obj obj = new Obj();
@@ -88,10 +88,10 @@ public class ObjectUtilTest {
 		final String emptyValue = "";
 		final String dateStr = "2020-10-23 15:12:30";
 		Instant result1 = ObjectUtil.defaultIfEmpty(emptyValue,
-				(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
+			(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
 		Assert.assertNotNull(result1);
 		Instant result2 = ObjectUtil.defaultIfEmpty(dateStr,
-				(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
+			(source) -> DateUtil.parse(source, DatePattern.NORM_DATETIME_PATTERN).toInstant(), Instant.now());
 		Assert.assertNotNull(result2);
 	}
 
@@ -107,5 +107,38 @@ public class ObjectUtilTest {
 	public void isNotNullTest() {
 		String a = null;
 		Assert.assertFalse(ObjectUtil.isNotNull(a));
+	}
+
+	@Test
+	public void throwIfNullTest() {
+		String name = null;
+//	    ObjectUtil.throwIfNull(name);
+//	    ObjectUtil.throwIfNull(name, "名称不可为 null");
+//		ObjectUtil.throwIfNull(name, "名称不可为 null", NewRuntimeException.class);
+//		ObjectUtil.throwIfNull(name, () -> new NewRuntimeException("名称不可为 null"));
+	}
+
+	@Test
+	public void throwIfEmptyTest() {
+		String name = "";
+//	    ObjectUtil.throwIfEmpty(name);
+//	    ObjectUtil.throwIfEmpty(name, "名称不可为空");
+//		ObjectUtil.throwIfEmpty(name, "名称不可为空", NewRuntimeException.class);
+//		ObjectUtil.throwIfEmpty(name, () -> new NewRuntimeException("名称不可为空"));
+	}
+
+	/**
+	 * 自定义运行时异常用于 throwIfNull、throwIfEmpty 测试
+	 *
+	 * @author XUEW
+	 */
+	public static class NewRuntimeException extends RuntimeException {
+
+		public NewRuntimeException() {
+		}
+
+		public NewRuntimeException(String msg) {
+			super(msg);
+		}
 	}
 }


### PR DESCRIPTION
判空判null均提供四种方法重载：
1. 若为空/null，抛出 Hutool 自带的 ValidateException，默认信息为：Target Must Be Not Null/Empty
2. 若为空/null，抛出 Hutool 自带的 ValidateException，可指定抛出的异常信息
3. 若为空/null，抛出自定义的运行时异常，可指定抛出的异常信息
4. 若为空/null，通过函数式接口提供异常
