### PR TITLE
[feature]增加根据金额和币种编码构建金额类的构造器

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/math/Money.java
+++ b/hutool-core/src/main/java/cn/hutool/core/math/Money.java
@@ -153,6 +153,19 @@ public class Money implements Serializable, Comparable<Money> {
 	 * 构造器。
 	 *
 	 * <p>
+	 * 创建一个具有金额{@code amount}元和指定币种编码{@code currencyCode}的货币对象。
+	 *
+	 * @param amount       金额，以元为单位。
+	 * @param currencyCode 币种编码。币种编码需要符合ISO 4217标准
+	 */
+	public Money(String amount, String currencyCode) {
+		this(new BigDecimal(amount), Currency.getInstance(currencyCode));
+	}
+
+	/**
+	 * 构造器。
+	 *
+	 * <p>
 	 * 创建一个具有金额{@code amount}元和指定币种{@code currency}的货币对象。
 	 * 如果金额不能转换为整数分，则使用指定的取整模式{@code roundingMode}取整。
 	 *

--- a/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
@@ -3,6 +3,9 @@ package cn.hutool.core.math;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.util.Currency;
+
 public class MoneyTest {
 
 	@Test
@@ -19,5 +22,13 @@ public class MoneyTest {
 		Assert.assertEquals(1234.56D, money.getAmount().doubleValue(), 0);
 
 		Assert.assertEquals(1234.56D, MathUtil.centToYuan(123456), 0);
+	}
+
+	@Test
+	public void test() {
+		final Money money = new Money("1012.34", "USD");
+		Assert.assertEquals(101234L, money.getCent());
+		Assert.assertEquals(new BigDecimal("1012.34"), money.getAmount());
+		Assert.assertEquals(Currency.getInstance("USD"), money.getCurrency());
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
@@ -25,7 +25,7 @@ public class MoneyTest {
 	}
 
 	@Test
-	public void test() {
+	public void currencyCodeTest() {
 		final Money money = new Money("1012.34", "USD");
 		Assert.assertEquals(101234L, money.getCent());
 		Assert.assertEquals(new BigDecimal("1012.34"), money.getAmount());


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。--已确认
2. 请确认没有更改代码风格（如tab缩进）--已确认
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例 --已确认

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]增加根据金额和币种编码构建金额类的构造器。入参的amount单位为元，currencyCode为币种编码，例如：USD；币种编码需要符合ISO 4217标准

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过