### PR TITLE
[bug修复] 修复金额转换为英文时缺少 trillion 单位

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/NumberWordFormatter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/NumberWordFormatter.java
@@ -19,7 +19,7 @@ public class NumberWordFormatter {
 			"FIFTEEN", "SIXTEEN", "SEVENTEEN", "EIGHTEEN", "NINETEEN"};
 	private static final String[] NUMBER_TEN = new String[]{"TEN", "TWENTY", "THIRTY", "FORTY", "FIFTY", "SIXTY",
 			"SEVENTY", "EIGHTY", "NINETY"};
-	private static final String[] NUMBER_MORE = new String[]{"", "THOUSAND", "MILLION", "BILLION"};
+	private static final String[] NUMBER_MORE = new String[]{"", "THOUSAND", "MILLION", "BILLION", "TRILLION"};
 
 	private static final String[] NUMBER_SUFFIX = new String[]{"k", "w", "", "m", "", "", "b", "", "", "t", "", "", "p", "", "", "e"};
 

--- a/hutool-core/src/test/java/cn/hutool/core/convert/NumberWordFormatTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/convert/NumberWordFormatTest.java
@@ -12,6 +12,9 @@ public class NumberWordFormatTest {
 
 		String format2 = NumberWordFormatter.format("2100.00");
 		Assert.assertEquals("TWO THOUSAND ONE HUNDRED AND CENTS  ONLY", format2);
+
+		String format3 = NumberWordFormatter.format("1234567890123.12");
+		Assert.assertEquals("ONE TRILLION TWO HUNDRED AND THIRTY FOUR BILLION FIVE HUNDRED AND SIXTY SEVEN MILLION EIGHT HUNDRED AND NINETY THOUSAND ONE HUNDRED AND TWENTY THREE AND CENTS TWELVE ONLY", format3);
 	}
 
 	@Test


### PR DESCRIPTION
当出现如下测试用例所示数值达到万亿的金额时，会导致`ArrayIndexOutOfBoundsException`，根因是`parseMore`函数中`NUMBER_MORE`数组中单位仅到 `BILLION`，万亿金额找不到下一个单位，故数组溢出，此处在`NUMBER_MORE`数组中加上该单位修复这一问题。