### PR TITLE
添加 BCCipher 绕过 JCE 实现对 BC 库对称算法的直接调用

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/BCCipher.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/BCCipher.java
@@ -17,6 +17,7 @@ import org.bouncycastle.crypto.io.CipherOutputStream;
 import org.bouncycastle.crypto.modes.*;
 import org.bouncycastle.crypto.paddings.PKCS7Padding;
 import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
+import org.bouncycastle.crypto.paddings.ZeroBytePadding;
 import org.bouncycastle.crypto.params.AEADParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.crypto.params.ParametersWithIV;
@@ -37,7 +38,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * 支持
  * AES/SM4/Blowfish/DESede 算法
  * ECB/CBC/CFB/OFB/CTR/GCM 模式
- * NoPadding/PKCS5Padding/PKCS7Padding 填充
+ * NoPadding/ZeroPadding/PKCS5Padding/PKCS7Padding 填充
  *
  * @author changhr2013
  */
@@ -315,6 +316,8 @@ public class BCCipher implements SymmetricEncryptor, SymmetricDecryptor, Seriali
 			return new BufferedBlockCipher(blockCipher);
 		} else if ("PKCS7Padding".equalsIgnoreCase(padding) || "PKCS5Padding".equalsIgnoreCase(padding)) {
 			return new PaddedBufferedBlockCipher(blockCipher, new PKCS7Padding());
+		} else if ("ZeroPadding".equalsIgnoreCase(padding)) {
+			return new PaddedBufferedBlockCipher(blockCipher, new ZeroBytePadding());
 		} else {
 			throw new CryptoException("unsupported padding" + cipherAlgorithm);
 		}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/BCCipher.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/BCCipher.java
@@ -1,0 +1,323 @@
+package cn.hutool.crypto.symmetric;
+
+import cn.hutool.core.io.IORuntimeException;
+import cn.hutool.core.io.IoUtil;
+import cn.hutool.core.lang.Assert;
+import cn.hutool.crypto.CipherMode;
+import cn.hutool.crypto.CryptoException;
+import org.bouncycastle.crypto.BlockCipher;
+import org.bouncycastle.crypto.BufferedBlockCipher;
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.engines.BlowfishEngine;
+import org.bouncycastle.crypto.engines.DESedeEngine;
+import org.bouncycastle.crypto.engines.SM4Engine;
+import org.bouncycastle.crypto.io.CipherInputStream;
+import org.bouncycastle.crypto.io.CipherOutputStream;
+import org.bouncycastle.crypto.modes.*;
+import org.bouncycastle.crypto.paddings.PKCS7Padding;
+import org.bouncycastle.crypto.paddings.PaddedBufferedBlockCipher;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * 绕过 JCE 完全基于 BC 库的对称加/解密算法实现，可以在不加载 BC Provider 的情况下执行加解密运算
+ * 这可以解决重打包和 graalvm 的签名校验问题
+ * <p>
+ * 支持
+ * AES/SM4/Blowfish/DESede 算法
+ * ECB/CBC/CFB/OFB/CTR/GCM 模式
+ * NoPadding/PKCS5Padding/PKCS7Padding 填充
+ *
+ * @author changhr2013
+ */
+public class BCCipher implements SymmetricEncryptor, SymmetricDecryptor, Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * 表示当前的算法
+	 */
+	private String algorithm;
+
+	/**
+	 * 算法的参数
+	 */
+	private CipherParameters parameters;
+
+	private BufferedBlockCipher blockCipher;
+
+	private final Lock lock = new ReentrantLock();
+
+	/**
+	 * 获取当前的算法
+	 *
+	 * @return 算法/模式/填充
+	 */
+	public String getAlgorithm() {
+		return algorithm;
+	}
+
+	/**
+	 * 获取当前的加/解密密钥
+	 *
+	 * @return {@link SecretKeySpec}
+	 */
+	public SecretKey getSecretKey() {
+		String keyAlgo = algorithm.split("/")[0];
+
+		if (parameters instanceof KeyParameter) {
+			return new SecretKeySpec(((KeyParameter) parameters).getKey(), keyAlgo);
+		} else if (parameters instanceof ParametersWithIV) {
+			return new SecretKeySpec(((KeyParameter) ((ParametersWithIV) parameters).getParameters()).getKey(), keyAlgo);
+		} else if (parameters instanceof AEADParameters) {
+			return new SecretKeySpec(((AEADParameters) parameters).getKey().getKey(), keyAlgo);
+		} else {
+			throw new CryptoException("unsupported algorithm parameters " + parameters.getClass().getName());
+		}
+	}
+
+	/**
+	 * 设置 {@link CipherParameters}，通常用于加盐或偏移向量
+	 *
+	 * @param params {@link CipherParameters}
+	 * @return 自身
+	 */
+	public BCCipher setParams(CipherParameters params) {
+		this.parameters = params;
+		return this;
+	}
+
+	/**
+	 * 设置偏移向量
+	 *
+	 * @param iv {@link IvParameterSpec}偏移向量
+	 * @return 自身
+	 */
+	public BCCipher setIv(IvParameterSpec iv) {
+		return setIv(iv.getIV());
+	}
+
+	/**
+	 * 动态设置当前 BlockCipher 参数的 IV 值
+	 *
+	 * @param iv IV
+	 */
+	public BCCipher setIv(byte[] iv) {
+		if (parameters instanceof ParametersWithIV) {
+			parameters = new ParametersWithIV(((ParametersWithIV) parameters).getParameters(), iv);
+		} else if (parameters instanceof AEADParameters) {
+			AEADParameters aeadParameters = (AEADParameters) parameters;
+			parameters = new AEADParameters(aeadParameters.getKey(), aeadParameters.getMacSize(), iv, aeadParameters.getAssociatedText());
+		} else {
+			// ignore KeyParameter
+		}
+		return this;
+	}
+
+	/**
+	 * 初始化模式并清空数据
+	 *
+	 * @param mode 模式枚举
+	 * @return this
+	 */
+	public BCCipher setMode(CipherMode mode) {
+		lock.lock();
+		try {
+			if (CipherMode.encrypt == mode) {
+				this.blockCipher.init(true, this.parameters);
+			} else if (CipherMode.decrypt == mode) {
+				this.blockCipher.init(false, this.parameters);
+			} else {
+				throw new CryptoException("unsupported CipherMode " + mode.name());
+			}
+		} catch (Exception e) {
+			throw new CryptoException(e);
+		} finally {
+			lock.unlock();
+		}
+		return this;
+	}
+
+	/**
+	 * 构造
+	 *
+	 * @param algorithm  算法
+	 * @param paramsSpec 算法参数，例如加盐等
+	 */
+	public BCCipher(String algorithm, CipherParameters paramsSpec) {
+		Assert.notBlank(algorithm, "'algorithm' must be not blank !");
+
+		this.blockCipher = getInstance(algorithm);
+		this.algorithm = algorithm;
+		this.parameters = paramsSpec;
+	}
+
+	@Override
+	public byte[] decrypt(byte[] bytes) {
+		lock.lock();
+		try {
+			// 初始化
+			this.blockCipher.init(false, this.parameters);
+			// 执行解密运算
+			return process(bytes);
+		} catch (Exception e) {
+			throw new CryptoException("decrypt exception.", e);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void decrypt(InputStream data, OutputStream out, boolean isClose) {
+		lock.lock();
+		CipherInputStream cipherInputStream = null;
+		try {
+			// 初始化
+			this.blockCipher.init(false, this.parameters);
+			// 构建输入流
+			cipherInputStream = new CipherInputStream(data, this.blockCipher);
+			IoUtil.copy(cipherInputStream, out);
+		} catch (IORuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new CryptoException(e);
+		} finally {
+			lock.unlock();
+			// issue#I4EMST@Gitee
+			// CipherOutputStream必须关闭，才能完全写出
+			IoUtil.close(cipherInputStream);
+			if (isClose) {
+				IoUtil.close(data);
+			}
+		}
+	}
+
+	@Override
+	public byte[] encrypt(byte[] data) {
+		lock.lock();
+		try {
+			// 初始化
+			this.blockCipher.init(true, this.parameters);
+			// 执行加密运算
+			return process(data);
+		} catch (Exception e) {
+			throw new CryptoException("encrypt exception.", e);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Override
+	public void encrypt(InputStream data, OutputStream out, boolean isClose) {
+		lock.lock();
+		CipherOutputStream cipherOutputStream = null;
+		try {
+			// 初始化
+			this.blockCipher.init(true, this.parameters);
+			// 构建输出流
+			cipherOutputStream = new CipherOutputStream(out, this.blockCipher);
+			IoUtil.copy(data, cipherOutputStream);
+		} catch (IORuntimeException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new CryptoException(e);
+		} finally {
+			lock.unlock();
+			// issue#I4EMST@Gitee
+			// CipherOutputStream必须关闭，才能完全写出
+			IoUtil.close(cipherOutputStream);
+			if (isClose) {
+				IoUtil.close(data);
+			}
+		}
+	}
+
+	/**
+	 * 使用当前的 BlockCipher 做运算
+	 *
+	 * @param data 待运算的数据
+	 * @return 运算结果
+	 */
+	private byte[] process(byte[] data) {
+		byte[] out;
+		try {
+			BufferedBlockCipher cipher = this.blockCipher;
+			int updateOutputSize = cipher.getOutputSize(data.length);
+			byte[] buf = new byte[updateOutputSize];
+			int len = cipher.processBytes(data, 0, data.length, buf, 0);
+			len += cipher.doFinal(buf, len);
+			out = new byte[len];
+			System.arraycopy(buf, 0, out, 0, len);
+		} catch (Exception e) {
+			throw new CryptoException("encrypt/decrypt process exception.", e);
+		}
+		return out;
+	}
+
+	/**
+	 * 获取 BlockCipher
+	 *
+	 * @param cipherAlgorithm 算法
+	 * @return BufferedBlockCipher
+	 */
+	private static BufferedBlockCipher getInstance(String cipherAlgorithm) {
+
+		String[] transform = cipherAlgorithm.split("/");
+		if (transform.length < 3) {
+			throw new RuntimeException("unsupported cipherAlgorithm format");
+		}
+
+		final String algorithm = transform[0];
+		BlockCipher cipherEngine;
+		if ("AES".equalsIgnoreCase(algorithm)) {
+			cipherEngine = new AESEngine();
+		} else if ("SM4".equalsIgnoreCase(algorithm)) {
+			cipherEngine = new SM4Engine();
+		} else if ("Blowfish".equalsIgnoreCase(algorithm)) {
+			cipherEngine = new BlowfishEngine();
+		} else if ("DESede".equalsIgnoreCase(algorithm)) {
+			cipherEngine = new DESedeEngine();
+		} else {
+			throw new CryptoException("unsupported algorithm" + cipherAlgorithm);
+		}
+
+		final String mode = transform[1];
+		BlockCipher blockCipher;
+		if ("CBC".equalsIgnoreCase(mode)) {
+			blockCipher = new CBCBlockCipher(cipherEngine);
+		} else if ("CFB".equalsIgnoreCase(mode)) {
+			blockCipher = new CFBBlockCipher(cipherEngine, cipherEngine.getBlockSize() * 8);
+		} else if ("OFB".equalsIgnoreCase(mode)) {
+			blockCipher = new OFBBlockCipher(cipherEngine, cipherEngine.getBlockSize() * 8);
+		} else if ("CTR".equalsIgnoreCase(mode)) {
+			blockCipher = new SICBlockCipher(cipherEngine);
+		} else if ("ECB".equalsIgnoreCase(mode)) {
+			blockCipher = cipherEngine;
+		} else if ("GCM".equalsIgnoreCase(mode)) {
+			blockCipher = new GCMBlockCipher(cipherEngine).getUnderlyingCipher();
+		} else {
+			throw new CryptoException("unsupported cipher algorithm");
+		}
+
+		final String padding = transform[2];
+		if ("NoPadding".equalsIgnoreCase(padding)) {
+			return new BufferedBlockCipher(blockCipher);
+		} else if ("PKCS7Padding".equalsIgnoreCase(padding) || "PKCS5Padding".equalsIgnoreCase(padding)) {
+			return new PaddedBufferedBlockCipher(blockCipher, new PKCS7Padding());
+		} else {
+			throw new CryptoException("unsupported padding" + cipherAlgorithm);
+		}
+	}
+
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/SM4.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/SM4.java
@@ -1,10 +1,14 @@
 package cn.hutool.crypto.symmetric;
 
 import cn.hutool.core.util.ArrayUtil;
+import cn.hutool.core.util.RandomUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.crypto.Mode;
 import cn.hutool.crypto.Padding;
 import cn.hutool.crypto.SecureUtil;
+import org.bouncycastle.crypto.params.AEADParameters;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.bouncycastle.crypto.params.ParametersWithIV;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
@@ -23,17 +27,17 @@ import javax.crypto.spec.IvParameterSpec;
  * @author Looly
  * @since 4.6.8
  */
-public class SM4 extends SymmetricCrypto{
+public class SM4 extends BCCipher {
 	private static final long serialVersionUID = 1L;
 
-	public static final String ALGORITHM_NAME = "SM4";
+	public static final String ALGORITHM_NAME = "SM4/ECB/PKCS7Padding";
 
 	//------------------------------------------------------------------------- Constrctor start
 	/**
 	 * 构造，使用随机密钥
 	 */
 	public SM4() {
-		super(ALGORITHM_NAME);
+		super(ALGORITHM_NAME, new KeyParameter(RandomUtil.randomBytes(16)));
 	}
 
 	/**
@@ -42,7 +46,7 @@ public class SM4 extends SymmetricCrypto{
 	 * @param key 密钥
 	 */
 	public SM4(byte[] key) {
-		super(ALGORITHM_NAME, key);
+		super(ALGORITHM_NAME, new KeyParameter(key));
 	}
 
 	/**
@@ -168,7 +172,22 @@ public class SM4 extends SymmetricCrypto{
 	 * @param iv      加盐
 	 */
 	public SM4(String mode, String padding, SecretKey key, IvParameterSpec iv) {
-		super(StrUtil.format("SM4/{}/{}", mode, padding), key, iv);
+		super(StrUtil.format("SM4/{}/{}", mode, padding),
+			Mode.ECB.name().equalsIgnoreCase(mode) ?
+				new KeyParameter(key.getEncoded()) :
+				new ParametersWithIV(new KeyParameter(key.getEncoded()),
+					iv == null ?
+						new byte[16] :
+						iv.getIV()));
+	}
+
+	/**
+	 * 构造 AEAD 参数
+	 *
+	 * @param parameters {@link AEADParameters}
+	 */
+	public SM4(AEADParameters parameters) {
+		super("SM4/GCM/NoPadding", parameters);
 	}
 	//------------------------------------------------------------------------- Constrctor end
 }


### PR DESCRIPTION
#### 说明

1. 添加 BCCipher 绕过 JCE 实现对 BC 库对称算法的直接调用
2. SM4 切换到 BCCipher 实现。

### 修改描述(包括说明bug修复或者添加新特性)

有一些设计上的取舍问题，还没有想好，先放在这里看看：

1. 移除了内部的 ZeroPadding，代码看起来更简洁了，BC 库有个 Padding 实现叫 ZeroBytePadding，其实就是目前 ZeroPadding 的实现。
2. update 方法目前还没加，其实加上也比较简单，但是原本那个 patch 也是后来合并来的，实现的很迷，加了 update 方法没加 final 方法，感觉实现的并不完整，需要思考下怎么更合理。
3. 上面的其实都不是啥问题，最大的问题出在暴露的 getCipher 上，由于 BC 原生实现暴露的是 BlockCipher，跟这个方法很难去做兼容，这间接影响到了测试用例中获取 algorithm 的方法，我初步先加了个 getAlgorithm 方法。
4. 我其实在思考要不要搞个 BCSM4 类出来，就不会存在任何兼容性问题，不过这样相当于又暴露一组 API，跟现有的代码集成性会变差，担心会不会留下技术债😂

无论如何，BCCipher 能看到的好处是可以让 SM4 也能像目前的 SM2 一样完全不再依赖 JCE 了，No Provider 的问题不会再出现了。