### PR TITLE
fix 修复获取当前用户名不应加后面的路径/符号

### DIFF
--- a/hutool-system/src/main/java/cn/hutool/system/UserInfo.java
+++ b/hutool-system/src/main/java/cn/hutool/system/UserInfo.java
@@ -19,7 +19,7 @@ public class UserInfo implements Serializable{
 	private final String USER_COUNTRY;
 
 	public UserInfo(){
-		USER_NAME = fixPath(SystemUtil.get("user.name", false));
+		USER_NAME = SystemUtil.get("user.name", false);
 		USER_HOME = fixPath(SystemUtil.get("user.home", false));
 		USER_DIR = fixPath(SystemUtil.get("user.dir", false));
 		JAVA_IO_TMPDIR = fixPath(SystemUtil.get("java.io.tmpdir", false));


### PR DESCRIPTION
这里是获取系统的用户名，不是路径，不应该带有路径的/ 所以去掉fixPath方法的处理。