### PR TITLE
feat:策略模式封装，通过泛型构造不同请求、返回值、策略类型的策略上下文

### DIFF
--- a/hutool-strategy/pom.xml
+++ b/hutool-strategy/pom.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='utf-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<packaging>jar</packaging>
+
+	<parent>
+		<groupId>cn.hutool</groupId>
+		<artifactId>hutool-parent</artifactId>
+		<version>5.8.27-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>hutool-strategy</artifactId>
+	<name>${project.artifactId}</name>
+	<description>策略模式中策略、策略管理器实现</description>
+
+	<properties>
+		<Automatic-Module-Name>cn.hutool.strategy</Automatic-Module-Name>
+	</properties>
+
+</project>

--- a/hutool-strategy/src/main/java/cn/hutool/strategy/LockStrategyContext.java
+++ b/hutool-strategy/src/main/java/cn/hutool/strategy/LockStrategyContext.java
@@ -1,0 +1,98 @@
+package cn.hutool.strategy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * 策略上下文类，用于注册和执行策略。
+ * 使用ConcurrentHashMap来存储策略，以支持并发操作。
+ * 使用读写锁保护策略以支持取消注册策略。
+ *
+ * @param <T> 策略类型
+ * @param <R> 策略处理的数据类型。
+ * @param <P> 策略执行后返回的数据类型。
+ * @author Zhao QingYun
+ */
+public class LockStrategyContext<R, P, T> {
+
+    /**
+     * 上下文类型
+     */
+    private final String contextType;
+
+    /**
+     * 存储策略的映射，键为策略类型，值为策略实例。
+     */
+    private final Map<T, Strategy<?, ?, ?>> strategies = new ConcurrentHashMap<>();
+
+    /**
+     * 使用读写锁来保护对策略的访问。
+     */
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public LockStrategyContext(String contextType) {
+        this.contextType = contextType;
+    }
+
+    /**
+     * 注册策略的方法。
+     *
+     * @param strategy 要注册的策略实例。
+     */
+    public void register(Strategy<R, P, T> strategy) {
+        if (strategy == null) {
+            throw new IllegalArgumentException("Type and strategy cannot be null");
+        }
+        T type = strategy.getType();
+        if (type == null) {
+            throw new IllegalArgumentException("Type cannot be null");
+        }
+        lock.writeLock().lock();
+        try {
+            if (strategies.containsKey(type)) {
+                throw new IllegalArgumentException("Strategy for type " + type + " is already registered");
+            }
+            strategies.put(type, strategy);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+	/**
+	 * 取消注册策略的方法。
+	 * @param type 策略类型
+	 */
+    public void unregister(T type) {
+        lock.writeLock().lock();
+        try {
+            strategies.remove(type);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * 执行策略的方法。
+     *
+     * @param type    要执行的策略类型。
+     * @param request 策略处理的数据。
+     * @return 策略执行后返回的数据。
+     * @throws IllegalArgumentException 如果传入的策略类型未注册，则抛出此异常。
+     */
+    @SuppressWarnings("unchecked")
+    public P execute(T type, R request) {
+        lock.readLock().lock();
+        try {
+            Strategy<R, P, T> strategy = (Strategy<R, P, T>) strategies.get(type);
+            if (strategy != null) {
+                return strategy.execute(request);
+            } else {
+                throw new IllegalArgumentException("Unknown strategy type: " + type);
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+}

--- a/hutool-strategy/src/main/java/cn/hutool/strategy/Strategy.java
+++ b/hutool-strategy/src/main/java/cn/hutool/strategy/Strategy.java
@@ -1,0 +1,25 @@
+package cn.hutool.strategy;
+
+/**
+ * 策略接口，定义了策略的执行方法。
+ *
+ * @param <R> 策略处理的数据类型。
+ * @param <P> 策略执行后返回的数据类型。
+ * @param <T> 策略类型
+ * @author Zhao QingYun
+ */
+public interface Strategy<R, P, T> {
+    /**
+     * 执行策略的方法。
+     *
+     * @param request 策略处理的数据。
+     * @return 策略执行后返回的数据。
+     */
+    P execute(R request);
+
+    /**
+     * 策略类型
+     * @return 策略类型
+     */
+    T getType();
+}

--- a/hutool-strategy/src/main/java/cn/hutool/strategy/StrategyContext.java
+++ b/hutool-strategy/src/main/java/cn/hutool/strategy/StrategyContext.java
@@ -1,0 +1,73 @@
+package cn.hutool.strategy;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 策略上下文类，用于注册和执行策略。
+ * 使用ConcurrentHashMap来存储策略，以支持并发操作。
+ *
+ * @param <R> 策略处理的数据类型。
+ * @param <P> 策略执行后返回的数据类型。
+ * @param <T> 策略类型
+ * @author Zhao QingYun
+ */
+public class StrategyContext<R, P, T> {
+
+    /**
+     * 上下文类型
+     */
+    private final String contextType;
+
+
+    /**
+     * 存储策略的映射，键为策略类型，值为策略实例。
+     */
+    private final Map<T, Strategy<?, ?, ?>> strategies = new ConcurrentHashMap<>();
+
+    public StrategyContext(String contextType) {
+        this.contextType = contextType;
+    }
+
+    /**
+     * 注册策略的方法。
+     *
+     * @param strategy 要注册的策略实例。
+     */
+    public void register(Strategy<R, P, T> strategy) {
+        if (strategy == null) {
+            throw new IllegalArgumentException("Type and strategy cannot be null");
+        }
+        T type = strategy.getType();
+        if (type == null) {
+            throw new IllegalArgumentException("Type cannot be null");
+        }
+        if (strategies.containsKey(type)) {
+            throw new IllegalArgumentException("Strategy for type " + type + " is already registered");
+        }
+        strategies.put(type, strategy);
+    }
+
+    /**
+     * 执行策略的方法。
+     *
+     * @param type    要执行的策略类型。
+     * @param request 策略处理的数据。
+     * @return 策略执行后返回的数据。
+     * @throws IllegalArgumentException 如果传入的策略类型未注册，则抛出此异常。
+     */
+    @SuppressWarnings("unchecked")
+    public P execute(T type, R request) {
+        Strategy<R, P, T> strategy = (Strategy<R, P, T>) strategies.get(type);
+        if (strategy != null) {
+            return strategy.execute(request);
+        } else {
+            throw new IllegalArgumentException("Unknown strategy type: " + type);
+        }
+    }
+
+    public String getContextType() {
+        return contextType;
+    }
+}
+

--- a/hutool-strategy/src/main/java/cn/hutool/strategy/package-info.java
+++ b/hutool-strategy/src/main/java/cn/hutool/strategy/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * 策略模式 Strategy 封装
+ *
+ * @author Zhao QingYun
+ */
+package cn.hutool.strategy;

--- a/hutool-strategy/src/test/java/cn/hutool/strategy/StrategyContextTest.java
+++ b/hutool-strategy/src/test/java/cn/hutool/strategy/StrategyContextTest.java
@@ -1,0 +1,84 @@
+package cn.hutool.strategy;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StrategyContextTest {
+
+	@Test
+	public void strategyExecute(){
+		StrategyContext<Integer, Integer, String> strategyContext = new StrategyContext<>("add");
+
+		Strategy<Integer, Integer, String> strategyA = new Strategy<Integer, Integer, String>() {
+
+			@Override
+			public Integer execute(Integer request) {
+				return request + 1976;
+			}
+			@Override
+			public String getType() {
+				return "strategyA";
+			}
+		};
+		Strategy<Integer, Integer, String> strategyB = new Strategy<Integer, Integer, String>() {
+
+			@Override
+			public Integer execute(Integer request) {
+				return request + 1978;
+			}
+			@Override
+			public String getType() {
+				return "strategyB";
+			}
+		};
+		strategyContext.register(strategyA);
+		strategyContext.register(strategyB);
+		Integer aResult = strategyContext.execute("strategyA", 2);
+		Integer bResult = strategyContext.execute("strategyB", 2);
+
+		Assert.assertEquals(1976 + 2, aResult.intValue());
+		Assert.assertEquals(1978 + 2, bResult.intValue());
+	}
+
+
+	@Test
+	public void lockStrategyExecute(){
+		LockStrategyContext<Integer, Integer, String> strategyContext = new LockStrategyContext<>("add");
+
+		Strategy<Integer, Integer, String> strategyA = new Strategy<Integer, Integer, String>() {
+
+			@Override
+			public Integer execute(Integer request) {
+				return request + 1976;
+			}
+			@Override
+			public String getType() {
+				return "strategyA";
+			}
+		};
+		Strategy<Integer, Integer, String> strategyB = new Strategy<Integer, Integer, String>() {
+
+			@Override
+			public Integer execute(Integer request) {
+				return request + 1978;
+			}
+			@Override
+			public String getType() {
+				return "strategyB";
+			}
+		};
+		strategyContext.register(strategyA);
+		strategyContext.register(strategyB);
+		Integer aResult = strategyContext.execute("strategyA", 2);
+		Integer bResult = strategyContext.execute("strategyB", 2);
+
+		strategyContext.unregister(strategyA.getType());
+
+		Assert.assertThrows(IllegalArgumentException.class, () -> strategyContext.execute("strategyA", 2));
+		Assert.assertEquals(1976 + 2, aResult.intValue());
+		Assert.assertEquals(1978 + 2, bResult.intValue());
+	}
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 		<module>hutool-captcha</module>
 		<module>hutool-socket</module>
 		<module>hutool-jwt</module>
+		<module>hutool-strategy</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)
[新特性]  策略模式封装，通过泛型构造不同请求、返回值、策略类型的策略上下文，并提供读写锁实现使得可以安全取消策略类型注册

### 提交前自测
已经编写测试用例并通过