### PR TITLE
修复JSONUtil.toBean方法中，实体类对象有字段类型为Class时会报错的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/ConverterRegistry.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/ConverterRegistry.java
@@ -153,7 +153,8 @@ public class ConverterRegistry implements Serializable {
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> Converter<T> getDefaultConverter(Type type) {
-		return (null == defaultConverterMap) ? null : (Converter<T>) defaultConverterMap.get(TypeUtil.getClass(type));
+		Class<?> key = TypeUtil.getClass(type);
+		return (null == defaultConverterMap || null == key) ? null : (Converter<T>) defaultConverterMap.get(key);
 	}
 
 	/**

--- a/hutool-json/src/main/java/cn/hutool/json/JSONUtil.java
+++ b/hutool-json/src/main/java/cn/hutool/json/JSONUtil.java
@@ -796,6 +796,11 @@ public class JSONUtil {
 				return object.toString();
 			}
 
+			// Class类型保存类名
+			if (object instanceof Class<?>) {
+				return ((Class<?>) object).getName();
+			}
+
 			// Java内部类不做转换
 			if (ClassUtil.isJdkClass(object.getClass())) {
 				return object.toString();

--- a/hutool-json/src/test/java/cn/hutool/json/Issue3504Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue3504Test.java
@@ -1,0 +1,26 @@
+package cn.hutool.json;
+
+import lombok.Data;
+import org.junit.Test;
+
+/**
+ * https://github.com/dromara/hutool/issues/3504
+ */
+public class Issue3504Test {
+
+	@Test
+	public void test3504() {
+		JsonBean jsonBean = new JsonBean();
+		jsonBean.setName("test");
+		jsonBean.setClasses(new Class[]{String.class});
+		String huToolJsonStr = JSONUtil.toJsonStr(jsonBean);
+		System.out.println("hutool json str-------" + huToolJsonStr);
+		System.out.println(JSONUtil.toBean(huToolJsonStr, JsonBean.class));
+	}
+
+	@Data
+	public static class JsonBean {
+		private String name;
+		private Class<?>[] classes;
+	}
+}

--- a/hutool-json/src/test/java/cn/hutool/json/Issue3506Test.java
+++ b/hutool-json/src/test/java/cn/hutool/json/Issue3506Test.java
@@ -1,0 +1,30 @@
+package cn.hutool.json;
+
+import lombok.Data;
+import org.junit.Test;
+
+/**
+ * https://github.com/dromara/hutool/issues/3506
+ */
+public class Issue3506Test {
+
+	@Test
+	public void test3506() {
+		Languages languages = new Languages();
+		languages.setLanguageType(Java.class);
+		String hutoolJSONString = JSONUtil.toJsonStr(languages);
+		System.out.println(hutoolJSONString);
+		System.out.println(JSONUtil.toBean(hutoolJSONString, Languages.class));
+	}
+
+	@Data
+	public static class Languages {
+		private Class<? extends Language> languageType;
+	}
+
+	public interface Language {
+	}
+
+	public static class Java implements Language {
+	}
+}


### PR DESCRIPTION
Bug详情见issue#3506