### PR TITLE
feat Content-Type中存在charset时，设置字符编码

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpBase.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpBase.java
@@ -6,6 +6,7 @@ import cn.hutool.core.io.resource.Resource;
 import cn.hutool.core.map.CaseInsensitiveMap;
 import cn.hutool.core.map.MapUtil;
 import cn.hutool.core.util.CharsetUtil;
+import cn.hutool.core.util.ReUtil;
 import cn.hutool.core.util.StrUtil;
 
 import java.nio.charset.Charset;
@@ -55,6 +56,8 @@ public abstract class HttpBase<T> {
 	 * 存储主体
 	 */
 	protected Resource body;
+
+	public final static String CONTENT_TYPE_CHARSET = ";charset=(.+);?";
 
 	// ---------------------------------------------------------------- Headers start
 
@@ -120,6 +123,10 @@ public abstract class HttpBase<T> {
 				headers.put(name.trim(), valueList);
 			} else {
 				values.add(value.trim());
+			}
+
+			if (Header.CONTENT_TYPE.getValue().equals(name.trim())) {
+				charsetFromContentType(value);
 			}
 		}
 		return (T) this;
@@ -358,5 +365,17 @@ public abstract class HttpBase<T> {
 		sb.append("    ").append(StrUtil.str(this.bodyBytes(), this.charset)).append(StrUtil.CRLF);
 
 		return sb.toString();
+	}
+
+	/**
+	 * Content-Type中存在charset时，例如：application/json;charset=GB18030，设置字符编码
+	 *
+	 * @param contentType 请求体类型
+	 */
+	protected void charsetFromContentType(String contentType) {
+		String charset = ReUtil.getGroup1(CONTENT_TYPE_CHARSET, contentType);
+		if (StrUtil.isNotEmpty(charset)) {
+			this.charset(charset.trim());
+		}
 	}
 }

--- a/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
@@ -714,6 +714,7 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 	 * @return this
 	 */
 	public HttpRequest body(String body, String contentType) {
+		charsetFromContentType(contentType);
 		byte[] bytes = StrUtil.bytes(body, this.charset);
 		body(bytes);
 		this.form = null; // 当使用body时，停止form的使用

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -203,7 +203,7 @@ public class HttpRequestTest {
 	public void addInterceptorTest() {
 		HttpUtil.createGet("https://hutool.cn")
 				.addInterceptor(Console::log)
-				.addResponseInterceptor((res)-> Console.log(res.getStatus()))
+				.addResponseInterceptor((res) -> Console.log(res.getStatus()))
 				.execute();
 	}
 
@@ -216,17 +216,17 @@ public class HttpRequestTest {
 
 	@Test
 	@Ignore
-	public void getWithFormTest(){
+	public void getWithFormTest() {
 		final String url = "https://postman-echo.com/get";
 		final Map<String, Object> map = new HashMap<>();
 		map.put("aaa", "application+1@qqq.com");
-		final HttpRequest request =HttpUtil.createGet(url).form(map);
+		final HttpRequest request = HttpUtil.createGet(url).form(map);
 		Console.log(request.execute().body());
 	}
 
 	@Test
 	@Ignore
-	public void urlWithParamIfGetTest(){
+	public void urlWithParamIfGetTest() {
 		final UrlBuilder urlBuilder = new UrlBuilder();
 		urlBuilder.setScheme("https").setHost("hutool.cn");
 
@@ -238,6 +238,30 @@ public class HttpRequestTest {
 	@Ignore
 	public void issueI5Y68WTest() {
 		final HttpResponse httpResponse = HttpRequest.get("http://82.157.17.173:8100/app/getAddress").execute();
+		Console.log(httpResponse.body());
+	}
+
+
+	@Test
+	@Ignore
+	public void headerWithCharsetTest() {
+		HttpResponse httpResponse = HttpRequest.post("https://hutool.cn")
+				.header("Content-Type", "application/json;charset=GBK")
+				.body("{\n" +
+						"    \"name\":\"测试\"\n" +
+						"}")
+				.execute();
+		Console.log(httpResponse.body());
+	}
+
+	@Test
+	@Ignore
+	public void bodyWithCharsetTest() {
+		HttpResponse httpResponse = HttpRequest.get("https://hutool.cn/")
+				.body("{\n" +
+						"    \"name\":\"测试\"\n" +
+						"}", "application/json;charset=GBK")
+				.execute();
 		Console.log(httpResponse.body());
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  Content-Type中存在charset时，设置字符编码，[okhttp](https://github.com/square/okhttp)支持这样设置字符编码

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过