### PR TITLE
fix: 修复 ClassUtil#getTypeArgument() 获取不到继承接口泛型的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/TypeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/TypeUtil.java
@@ -328,6 +328,13 @@ public class TypeUtil {
 			for (final Type genericInterface : genericInterfaces) {
 				if (genericInterface instanceof ParameterizedType) {
 					result.add((ParameterizedType) genericInterface);
+					continue;
+				}
+
+				// 继承接口泛型参数
+				final ParameterizedType parameterizedType = toParameterizedType(genericInterface);
+				if (parameterizedType != null) {
+					result.add(parameterizedType);
 				}
 			}
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/util/Issue3516Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/Issue3516Test.java
@@ -1,0 +1,39 @@
+package cn.hutool.core.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+/**
+ * Description: https://github.com/dromara/hutool/issues/3516
+ * Create by 张文涛 on 2024/3/18 15:51:59
+ */
+public class Issue3516Test {
+
+	@Test
+	public void getTypeArgumentTest() {
+		// 获取继承接口泛型参数
+		Class<?> typeArgument = ClassUtil.getTypeArgument(Demo.class, 0);
+		Assert.assertEquals(typeArgument, B.class);
+	}
+
+	public class Demo implements A2B {
+		@Override
+		public A apply(B arg0) {
+			A a = new A();
+			return a;
+		}
+	}
+
+	class A {
+		private String name;
+	}
+
+	class B {
+		private String name;
+	}
+
+	interface A2B extends Function<B, A> {
+	}
+}


### PR DESCRIPTION
#### 说明

1. 已在 src/test/java下添加Issue3516Test

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] #3516  修复 ClassUtil#getTypeArgument() 获取不到继承接口泛型的问题
