### PR TITLE
IdcardUtil 新增对新版外国人永久居留身份证（18位）的支持

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/IdcardUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/IdcardUtil.java
@@ -278,8 +278,8 @@ public class IdcardUtil {
 			return false;
 		}
 
-		// 省份
-		final String proCode = idcard.substring(0, 2);
+		// 截取省份代码。新版外国人永久居留身份证以9开头，第二三位是受理地代码
+		final String proCode = idcard.startsWith("9") ? idcard.substring(1, 3): idcard.substring(0, 2);
 		if (null == CITY_CODES.get(proCode)) {
 			return false;
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/util/IdcardUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/IdcardUtilTest.java
@@ -14,6 +14,10 @@ import org.junit.Test;
 public class IdcardUtilTest {
 
 	private static final String ID_18 = "321083197812162119";
+	/**
+	 * 新版外国人永久居留身份证号码
+	 */
+	private static final String FOREIGN_ID_18 = "932682198501010017";
 	private static final String ID_15 = "150102880730303";
 
 	@Test
@@ -23,6 +27,8 @@ public class IdcardUtilTest {
 
 		boolean valid15 = IdcardUtil.isValidCard(ID_15);
 		Assert.assertTrue(valid15);
+
+		Assert.assertTrue(IdcardUtil.isValidCard(FOREIGN_ID_18));
 
 		// 无效
 		String idCard = "360198910283844";
@@ -58,6 +64,7 @@ public class IdcardUtilTest {
 
 		int age = IdcardUtil.getAgeByIdCard(ID_18, date);
 		Assert.assertEquals(age, 38);
+		Assert.assertEquals(IdcardUtil.getAgeByIdCard(FOREIGN_ID_18, date), 32);
 
 		int age2 = IdcardUtil.getAgeByIdCard(ID_15, date);
 		Assert.assertEquals(age2, 28);
@@ -126,6 +133,10 @@ public class IdcardUtilTest {
 
 		// 台湾人在大陆身份证
 		isValidCard18 = IdcardUtil.isValidCard18("830000200209060065");
+		Assert.assertTrue(isValidCard18);
+
+		// 新版外国人永久居留身份证
+		isValidCard18 = IdcardUtil.isValidCard18("932682198501010017");
 		Assert.assertTrue(isValidCard18);
 	}
 


### PR DESCRIPTION
政策文件：https://www.nia.gov.cn/20231013/2.pdf

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  IdcardUtil 新增对新版外国人永久居留身份证（18位）的支持

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过