### PR TITLE
设置jsch登录认证方式，跳过Kerberos身份验证

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/ssh/JschUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ssh/JschUtil.java
@@ -294,6 +294,9 @@ public class JschUtil {
 		// 设置第一次登录的时候提示，可选值：(ask | yes | no)
 		session.setConfig("StrictHostKeyChecking", "no");
 
+		// 设置登录认证方式，跳过Kerberos身份验证
+		session.setConfig("PreferredAuthentications","publickey,keyboard-interactive,password");
+
 		return session;
 	}
 


### PR DESCRIPTION
现象：当ssh连接的服务器设置了Kerberos身份验证，后端部署后报错com.jcraft.jsch.JSchException: Auth fail
原因：本地测试时发现使用jsch进行ssh登录时终端会提示输入用户名及口令进行Kerberos验证
改动：设置jsch登录认证方式，跳过Kerberos身份验证