### PR TITLE
CalendarUtil在比较同一天、同一月、同一周的时候，如果两个时区不一致会导致结果不符合预期

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/CalendarUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/CalendarUtil.java
@@ -355,6 +355,11 @@ public class CalendarUtil {
 		if (cal1 == null || cal2 == null) {
 			throw new IllegalArgumentException("The date must not be null");
 		}
+
+		// 统一时区
+		cal1 = toDefaultTimeZone(cal1);
+		cal2 = toDefaultTimeZone(cal2);
+
 		return cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR) && //
 			cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) && //
 			cal1.get(Calendar.ERA) == cal2.get(Calendar.ERA);
@@ -418,6 +423,11 @@ public class CalendarUtil {
 		if (cal1 == null || cal2 == null) {
 			throw new IllegalArgumentException("The date must not be null");
 		}
+
+		// 统一时区
+		cal1 = toDefaultTimeZone(cal1);
+		cal2 = toDefaultTimeZone(cal2);
+
 		return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) && //
 			cal1.get(Calendar.MONTH) == cal2.get(Calendar.MONTH) &&
 			// issue#3011@Github
@@ -787,5 +797,18 @@ public class CalendarUtil {
 		calendar.setLenient(lenient);
 
 		return parser.parse(StrUtil.str(str), new ParsePosition(0), calendar) ? calendar : null;
+	}
+
+	/**
+	 * 转换为默认时区的Calendar
+	 *
+	 * @param cal 时间
+	 * @return 默认时区的calendar对象
+	 */
+	private static Calendar toDefaultTimeZone(Calendar cal) {
+		// 转换到统一时区，例如UTC
+		cal = (Calendar) cal.clone();
+		cal.setTimeZone(TimeZone.getDefault());
+		return cal;
 	}
 }


### PR DESCRIPTION
#### 背景

我使用ELK全家桶做一些大数据相关开发，其中时间默认都是UTC时间，我在使用DateUtil.isSameDay时发现如果读取的时间为UTC格式的时候，去和new DateTime()做比较，会出现问题。比如
```
	public static void main(String[] args) {
		String a = "2024-03-31T23:00:00.000Z";
		String b = "2024-04-01 07:00:00";
		System.out.println(isSameTime(DateUtil.parse(a), DateUtil.parse(b)));
		System.out.println(isSameDay(DateUtil.parse(a), DateUtil.parse(b)));
		System.out.println(isSameMonth(DateUtil.parse(a), DateUtil.parse(b)));
	}
```
这两个是同一个时间，但不是同一天也不是同一个月。因为DateUtil.parse解析出来的DateTime对象是带时区信息的，但是比较的时候却丢掉了时区信息

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 在CalendarUtil比较是否为同一个天/周/月的时候，先将两个时间转成默认时区在比较