### PR TITLE
throw JWTException when parsing json failed

### DIFF
--- a/hutool-jwt/src/main/java/cn/hutool/jwt/JWT.java
+++ b/hutool-jwt/src/main/java/cn/hutool/jwt/JWT.java
@@ -8,6 +8,7 @@ import cn.hutool.core.lang.Assert;
 import cn.hutool.core.util.CharUtil;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.StrUtil;
+import cn.hutool.json.JSONException;
 import cn.hutool.json.JSONObject;
 import cn.hutool.jwt.signers.AlgorithmUtil;
 import cn.hutool.jwt.signers.JWTSigner;
@@ -95,8 +96,12 @@ public class JWT implements RegisteredPayload<JWT> {
 		Assert.notBlank(token, "Token String must be not blank!");
 		final List<String> tokens = splitToken(token);
 		this.tokens = tokens;
-		this.header.parse(tokens.get(0), this.charset);
-		this.payload.parse(tokens.get(1), this.charset);
+		try {
+			this.header.parse(tokens.get(0), this.charset);
+			this.payload.parse(tokens.get(1), this.charset);
+		} catch (JSONException e) {
+			throw new JWTException("Invalid token: JSON parse error!");
+		}
 		return this;
 	}
 

--- a/hutool-jwt/src/test/java/cn/hutool/jwt/InvalidTokenTest.java
+++ b/hutool-jwt/src/test/java/cn/hutool/jwt/InvalidTokenTest.java
@@ -1,0 +1,17 @@
+package cn.hutool.jwt;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InvalidTokenTest {
+	@Test
+	public void test() {
+		String s = "1eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.1eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoyNTE2MjM5MDIyfQ.kggx5ylVTJWq_-c7mW8hRehry-ikLBQNNeW33k8nKbQ";
+
+		Exception e = Assert.assertThrows(JWTException.class, () -> {
+			JWT.of(s);
+		});
+
+		Assert.assertEquals("Invalid token: JSON parse error!", e.getMessage());
+	}
+}


### PR DESCRIPTION
当 token 被破坏时，会抛出 JSONException。此 pr 将其转化为 JWTException

see https://github.com/dromara/Sa-Token/issues/631

