### PR TITLE
[bug修复] 因为Version.of不支持传入空串并且会报错，所以需要处理版本号为空串的场景

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/comparator/VersionComparator.java
+++ b/hutool-core/src/main/java/cn/hutool/core/comparator/VersionComparator.java
@@ -57,9 +57,9 @@ public class VersionComparator implements Comparator<String>, Serializable {
 		}
 		if (version1 == null && version2 == null) {
 			return 0;
-		} else if (version1 == null) {// null视为最小版本，排在前
+		} else if (version1 == null || "".equals(version1)) {// null或""视为最小版本，排在前
 			return -1;
-		} else if (version2 == null) {
+		} else if (version2 == null || "".equals(version2)) {
 			return 1;
 		}
 


### PR DESCRIPTION


### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 因为Version.of不支持传入空串并且会报错，所以需要处理版本号为空串的场景