### PR TITLE
V5 dev

### DIFF
--- a/hutool-extra/pom.xml
+++ b/hutool-extra/pom.xml
@@ -468,5 +468,11 @@
 			<scope>compile</scope>
 			<optional>true</optional>
 		</dependency>
+		<!-- plantuml -->
+		<dependency>
+			<groupId>net.sourceforge.plantuml</groupId>
+			<artifactId>plantuml</artifactId>
+			<version>1.2024.6</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/hutool-extra/src/main/java/cn/hutool/extra/plantuml/DrawUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/plantuml/DrawUtil.java
@@ -8,7 +8,7 @@ import java.util.Base64;
 
 /**
  * <p>PlantUML 代码图表生成工具类，提供多种生成方式：Base64、OutputStream、本地文件。</p>
- * <p>通过传入PlantUML语法代码，生成相应的图标</p>
+ * <p>通过传入PlantUML语法代码，生成相应的图表</p>
  * @author LGXTvT
  */
 public class DrawUtil {

--- a/hutool-extra/src/main/java/cn/hutool/extra/plantuml/DrawUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/plantuml/DrawUtil.java
@@ -1,0 +1,111 @@
+package cn.hutool.extra.plantuml;
+
+
+import net.sourceforge.plantuml.SourceStringReader;
+import java.io.*;
+import java.nio.file.Files;
+import java.util.Base64;
+
+/**
+ * <p>PlantUML 代码图表生成工具类，提供多种生成方式：Base64、OutputStream、本地文件。</p>
+ * <p>通过传入PlantUML语法代码，生成相应的图标</p>
+ * <p>Example：</p>
+ * {@snippet :
+ * 		DrawUtil.toFile(
+ * 			"@startuml\n" +
+ * 			"autonumber\n" +
+ * 			"\n" +
+ * 			"Alice -> Bob: Authentication Request\n" +
+ * 			"Bob --> Alice: Authentication Response\n" +
+ * 			"\n" +
+ * 			"Alice -> Bob: Another authentication Request\n" +
+ * 			"Alice <-- Bob: another authentication Response\n" +
+ * 			"@enduml\n",
+ * 			new File("demo.png")
+ * 		);
+ *}
+ * @author LGXTvT
+ */
+public class DrawUtil {
+
+	/**
+	 * 将给定的 PlantUML 代码生成Base64格式图片
+	 * @param plantumlText plantuml代码
+	 * @return Base64格式图片数据
+	 */
+	public static String toBase64(String plantumlText) {
+		// 创建PlantUML对象
+		SourceStringReader reader = new SourceStringReader(plantumlText);
+		try(OutputStream os = new ByteArrayOutputStream()) {
+			// 生成并保存图片
+			reader.outputImage(os);
+			// 转换成base64
+			return convertOutputStreamToBase64Image(os, "png");
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+        }
+	}
+
+	/**
+	 * 将流转换为base64数据
+	 * @param outputStream 输出流
+	 * @param imageFormat 转换图片格式
+	 * @return base64
+	 */
+	private static String convertOutputStreamToBase64Image(OutputStream outputStream, String imageFormat) throws IOException {
+		if (outputStream instanceof ByteArrayOutputStream) {
+			ByteArrayOutputStream byteArrayOutputStream = (ByteArrayOutputStream) outputStream;
+			// 获取字节数组
+			byte[] byteArray = byteArrayOutputStream.toByteArray();
+			// 使用 Base64 编码器将字节数组编码为 Base64 字符串
+			String base64String = Base64.getEncoder().encodeToString(byteArray);
+			// 构建 Base64 图像数据 URI
+            return "data:image/" + imageFormat + ";base64," + base64String;
+		} else {
+			throw new IllegalArgumentException("OutputStream must be an instance of ByteArrayOutputStream");
+		}
+	}
+
+	/**
+	 * 将给定的 PlantUML 代码生成目标图片
+	 * @param plantumlText plantuml代码
+	 * @param targetFile 目标文件
+	 */
+	public static void toFile(String plantumlText, File targetFile) {
+		// 创建PlantUML对象
+		SourceStringReader reader = new SourceStringReader(plantumlText);
+		// 输出文件路径
+		try (OutputStream os = Files.newOutputStream(targetFile.toPath())) {
+			// 生成并保存图片
+			reader.outputImage(os);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * 将给定的 PlantUML 代码生成目标图片
+	 * @param plantumlText plantuml代码
+	 * @param path 目标文件路径
+	 */
+	public static void toFile(String plantumlText, String path) {
+		toFile(plantumlText, new File(path));
+	}
+
+	/**
+	 * 将给定的 PlantUML 代码生成图片并写入输出流。
+	 * @param plantumlText plantuml代码
+	 * @param os 输出流
+	 */
+	public static void toOutputStream(String plantumlText, OutputStream os) {
+		// 创建PlantUML对象
+		SourceStringReader reader = new SourceStringReader(plantumlText);
+		try {
+			// 生成并保存图片
+			reader.outputImage(os);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/hutool-extra/src/main/java/cn/hutool/extra/plantuml/DrawUtil.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/plantuml/DrawUtil.java
@@ -9,21 +9,6 @@ import java.util.Base64;
 /**
  * <p>PlantUML 代码图表生成工具类，提供多种生成方式：Base64、OutputStream、本地文件。</p>
  * <p>通过传入PlantUML语法代码，生成相应的图标</p>
- * <p>Example：</p>
- * {@snippet :
- * 		DrawUtil.toFile(
- * 			"@startuml\n" +
- * 			"autonumber\n" +
- * 			"\n" +
- * 			"Alice -> Bob: Authentication Request\n" +
- * 			"Bob --> Alice: Authentication Response\n" +
- * 			"\n" +
- * 			"Alice -> Bob: Another authentication Request\n" +
- * 			"Alice <-- Bob: another authentication Response\n" +
- * 			"@enduml\n",
- * 			new File("demo.png")
- * 		);
- *}
  * @author LGXTvT
  */
 public class DrawUtil {

--- a/hutool-extra/src/main/java/cn/hutool/extra/plantuml/package-info.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/plantuml/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * PlantUML代码图表生成工具类，基于PlantUML库，入口为DrawUtil
+ *
+ * @author LGXTvT
+ *
+ */
+package cn.hutool.extra.plantuml;

--- a/hutool-extra/src/test/java/cn/hutool/extra/plantuml/DrawUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/plantuml/DrawUtilTest.java
@@ -1,0 +1,96 @@
+package cn.hutool.extra.plantuml;
+
+import cn.hutool.core.lang.Console;
+import org.junit.Ignore;
+import org.junit.Test;
+import java.io.*;
+
+/**
+ * PlantUML代码图表生成工具类单元测试
+ *
+ * @author LGXTvT
+ */
+public class DrawUtilTest {
+
+	@Test
+	@Ignore
+	public void toBase64Test() {
+		String img = DrawUtil.toBase64(
+			"@startuml\n" +
+				"skinparam backgroundColor #EEEBDC\n" +
+				"skinparam handwritten true\n" +
+				"skinparam sequence {\n" +
+				"ArrowColor DeepSkyBlue\n" +
+				"ActorBorderColor DeepSkyBlue\n" +
+				"LifeLineBorderColor blue\n" +
+				"LifeLineBackgroundColor #A9DCDF\n" +
+				"ParticipantBorderColor DeepSkyBlue\n" +
+				"ParticipantBackgroundColor DodgerBlue\n" +
+				"ParticipantFontName Impact\n" +
+				"ParticipantFontSize 17\n" +
+				"ParticipantFontColor #A9DCDF\n" +
+				"ActorBackgroundColor aqua\n" +
+				"ActorFontColor DeepSkyBlue\n" +
+				"ActorFontSize 17\n" +
+				"ActorFontName Aapex\n" +
+				"}\n" +
+				"actor User\n" +
+				"participant \"First Class\" as A\n" +
+				"participant \"Second Class\" as B\n" +
+				"participant \"Last Class\" as C\n" +
+				"User -> A: DoWork\n" +
+				"activate A\n" +
+				"A -> B: Create Request\n" +
+				"activate B\n" +
+				"B -> C: DoWork\n" +
+				"activate C\n" +
+				"C --> B: WorkDone\n" +
+				"destroy C\n" +
+				"B --> A: Request Created\n" +
+				"deactivate B\n" +
+				"A --> User: Done\n" +
+				"deactivate A\n" +
+				"@enduml"
+		);
+		Console.log(img);
+	}
+
+	@Test
+	@Ignore
+	public void toFileTest() {
+		DrawUtil.toFile(
+			"@startuml\n" +
+				"autonumber\n" +
+				"\n" +
+				"Alice -> Bob: Authentication Request\n" +
+				"Bob --> Alice: Authentication Response\n" +
+				"\n" +
+				"Alice -> Bob: Another authentication Request\n" +
+				"Alice <-- Bob: another authentication Response\n" +
+				"@enduml\n",
+			new File("D://demo.png")
+		);
+	}
+
+	@Test
+	@Ignore
+	public void toOutputStreamTest() {
+		try (FileOutputStream fileOutputStream = new FileOutputStream("D://demo1.png")) {
+			DrawUtil.toOutputStream(
+				"@startuml\n" +
+					"autonumber\n" +
+					"\n" +
+					"Alice -> Bob: Authentication Request\n" +
+					"Bob --> Alice: Authentication Response\n" +
+					"\n" +
+					"Alice -> Bob: Another authentication Request\n" +
+					"Alice <-- Bob: another authentication Response\n" +
+					"@enduml\n",
+				fileOutputStream
+			);
+		} catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+	}
+
+}


### PR DESCRIPTION
### 说明

feat: 添加 PlantUML 代码图表生成工具类 DrawUtil

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  新增 cn.hutool.extra.plantuml 包下的 DrawUtil 工具类，提供多种 PlantUML 图表生成方式，包括 Base64、OutputStream 和本地文件。
  新增功能：
    - toBase64：将给定的 PlantUML 代码生成 Base64 格式图片
    - toFile：将给定的 PlantUML 代码生成目标图片文件（支持传入 File 对象和文件路径）
    - toOutputStream：将给定的 PlantUML 代码生成图片并写入输出流
