### PR TITLE
feat: Add stripAll and fix strip issue

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
@@ -707,7 +707,7 @@ public class CharSequenceUtil {
 		}
 
 		boolean isStartWith = str.toString()
-				.regionMatches(ignoreCase, 0, prefix.toString(), 0, prefix.length());
+			.regionMatches(ignoreCase, 0, prefix.toString(), 0, prefix.length());
 
 		if (isStartWith) {
 			return (false == ignoreEquals) || (false == equals(str, prefix, ignoreCase));
@@ -842,7 +842,7 @@ public class CharSequenceUtil {
 
 		final int strOffset = str.length() - suffix.length();
 		boolean isEndWith = str.toString()
-				.regionMatches(ignoreCase, strOffset, suffix.toString(), 0, suffix.length());
+			.regionMatches(ignoreCase, strOffset, suffix.toString(), 0, suffix.length());
 
 		if (isEndWith) {
 			return (false == ignoreEquals) || (false == equals(str, suffix, ignoreCase));
@@ -1280,7 +1280,7 @@ public class CharSequenceUtil {
 			}
 		}
 		return new StrFinder(searchStr, ignoreCase)
-				.setText(text).setNegative(true).start(from);
+			.setText(text).setNegative(true).start(from);
 	}
 
 	/**
@@ -1548,6 +1548,12 @@ public class CharSequenceUtil {
 	/**
 	 * 去除两边的指定字符串
 	 *
+	 * <pre>{@code
+	 * "aaa_STRIPPED_bbb", "a"  -> "aa_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", ""  -> "aaa_STRIPPED_bbb"
+	 * }
+	 * </pre>
+	 *
 	 * @param str            被处理的字符串
 	 * @param prefixOrSuffix 前缀或后缀
 	 * @return 处理后的字符串
@@ -1563,6 +1569,19 @@ public class CharSequenceUtil {
 
 	/**
 	 * 去除两边的指定字符串
+	 *
+	 * <pre>{@code
+	 * "aa_STRIPPED_bb", "a", "b"  -> "aa_STRIPPED_bb"
+	 * "aaa_STRIPPED_bbb", null, null  -> "aaa_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "", ""  -> "aaa_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "", "b"  -> "aaa_STRIPPED_bb"
+	 * "aaa_STRIPPED_bbb", null, "b"  -> "aaa_STRIPPED_bb"
+	 * "aaa_STRIPPED_bbb", "a", ""  -> "aa_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "a", null  -> "aa_STRIPPED_bbb"
+	 *
+	 * "a", "a", "a"  -> ""
+	 * }
+	 * </pre>
 	 *
 	 * @param str    被处理的字符串
 	 * @param prefix 前缀
@@ -1586,7 +1605,76 @@ public class CharSequenceUtil {
 			to -= suffix.length();
 		}
 
-		return str2.substring(Math.min(from, to), Math.max(from, to));
+		if (from <= to) {
+			return str2.substring(from, to);
+		} else {
+			return EMPTY;
+		}
+	}
+
+
+	/**
+	 * 去除两边<u><b>所有</b></u>的指定字符串
+	 *
+	 * <pre>{@code
+	 * "aaa_STRIPPED_bbb", "a"  -> "_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "a", "b"  -> "_STRIPPED_"
+	 * "aaa_STRIPPED_bbb", ""  -> "aaa_STRIPPED_bbb"
+	 * }
+	 * </pre>
+	 *
+	 * @param str            被处理的字符串
+	 * @param prefixOrSuffix 前缀或后缀
+	 * @return 处理后的字符串
+	 * @since 5.8.29+ 不包含 5.8.29
+	 */
+	public static String stripAll(CharSequence str, CharSequence prefixOrSuffix) {
+		if (equals(str, prefixOrSuffix)) {
+			return EMPTY;
+		}
+		return stripAll(str, prefixOrSuffix, prefixOrSuffix);
+	}
+
+	/**
+	 * 去除两边<u><b>所有</b></u>的指定字符串
+	 *
+	 * <pre>{@code
+	 * "aaa_STRIPPED_bbb", "a", "b"  -> "_STRIPPED_"
+	 * "aaa_STRIPPED_bbb", null, null  -> "aaa_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "", ""  -> "aaa_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "", "b"  -> "aaa_STRIPPED_"
+	 * "aaa_STRIPPED_bbb", null, "b"  -> "aaa_STRIPPED_"
+	 * "aaa_STRIPPED_bbb", "a", ""  -> "_STRIPPED_bbb"
+	 * "aaa_STRIPPED_bbb", "a", null  -> "_STRIPPED_bbb"
+	 *
+	 * // special test
+	 * "aaaaaabbb", "aaa", null  -> "bbb"
+	 * "aaaaaaabbb", "aa", null  -> "abbb"
+	 *
+	 * "aaaaaaaaa", "aaa", "aa"  -> ""
+	 * "a", "a", "a"  -> ""
+	 * }
+	 * </pre>
+	 *
+	 * @param str    被处理的字符串
+	 * @param prefix 前缀
+	 * @param suffix 后缀
+	 * @return 处理后的字符串
+	 * @since 5.8.29+ 不包含 5.8.29
+	 */
+	public static String stripAll(CharSequence str, CharSequence prefix, CharSequence suffix) {
+		if (isEmpty(str)) {
+			return str(str);
+		}
+
+		String result = str.toString();
+		while ((isNotEmpty(prefix) && startWith(result, prefix)) ||
+			(isNotEmpty(suffix) && endWith(result, suffix))
+		) {
+			result = strip(result, prefix, suffix);
+		}
+
+		return result;
 	}
 
 	/**
@@ -2387,8 +2475,8 @@ public class CharSequenceUtil {
 	 */
 	public static String[] subBetweenAll(CharSequence str, CharSequence prefix, CharSequence suffix) {
 		if (hasEmpty(str, prefix, suffix) ||
-				// 不包含起始字符串，则肯定没有子串
-				false == contains(str, prefix)) {
+			// 不包含起始字符串，则肯定没有子串
+			false == contains(str, prefix)) {
 			return new String[0];
 		}
 
@@ -4450,8 +4538,8 @@ public class CharSequenceUtil {
 		final int preLength = suffixLength + (maxLength - 3) % 2; // suffixLength 或 suffixLength + 1
 		final String str2 = str.toString();
 		return format("{}...{}",
-				str2.substring(0, preLength),
-				str2.substring(strLength - suffixLength));
+			str2.substring(0, preLength),
+			str2.substring(strLength - suffixLength));
 	}
 
 	/**
@@ -4535,16 +4623,16 @@ public class CharSequenceUtil {
 		final StringBuilder strBuilder = new StringBuilder(len);
 		if (moveLength > 0) {
 			int endAfterMove = Math.min(endExclude + moveLength, str.length());
-			strBuilder.append(str.subSequence(0, startInclude))//
-					.append(str.subSequence(endExclude, endAfterMove))//
-					.append(str.subSequence(startInclude, endExclude))//
-					.append(str.subSequence(endAfterMove, str.length()));
+			strBuilder.append(str.subSequence(0, startInclude))
+				.append(str.subSequence(endExclude, endAfterMove))
+				.append(str.subSequence(startInclude, endExclude))
+				.append(str.subSequence(endAfterMove, str.length()));
 		} else if (moveLength < 0) {
 			int startAfterMove = Math.max(startInclude + moveLength, 0);
-			strBuilder.append(str.subSequence(0, startAfterMove))//
-					.append(str.subSequence(startInclude, endExclude))//
-					.append(str.subSequence(startAfterMove, startInclude))//
-					.append(str.subSequence(endExclude, str.length()));
+			strBuilder.append(str.subSequence(0, startAfterMove))
+				.append(str.subSequence(startInclude, endExclude))
+				.append(str.subSequence(startAfterMove, startInclude))
+				.append(str.subSequence(endExclude, str.length()));
 		} else {
 			return str(str);
 		}

--- a/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/CharSequenceUtilTest.java
@@ -126,7 +126,7 @@ public class CharSequenceUtilTest {
 	}
 
 	@Test
-	public void removePrefixIgnoreCaseTest(){
+	public void removePrefixIgnoreCaseTest() {
 		Assert.assertEquals("de", CharSequenceUtil.removePrefixIgnoreCase("ABCde", "abc"));
 		Assert.assertEquals("de", CharSequenceUtil.removePrefixIgnoreCase("ABCde", "ABC"));
 		Assert.assertEquals("de", CharSequenceUtil.removePrefixIgnoreCase("ABCde", "Abc"));
@@ -138,7 +138,7 @@ public class CharSequenceUtilTest {
 	}
 
 	@Test
-	public void removeSuffixIgnoreCaseTest(){
+	public void removeSuffixIgnoreCaseTest() {
 		Assert.assertEquals("AB", CharSequenceUtil.removeSuffixIgnoreCase("ABCde", "cde"));
 		Assert.assertEquals("AB", CharSequenceUtil.removeSuffixIgnoreCase("ABCde", "CDE"));
 		Assert.assertEquals("AB", CharSequenceUtil.removeSuffixIgnoreCase("ABCde", "Cde"));
@@ -149,8 +149,60 @@ public class CharSequenceUtilTest {
 		Assert.assertNull(CharSequenceUtil.removeSuffixIgnoreCase(null, "ABCdef"));
 	}
 
+	/**
+	 * 由于被测试类的方法众多，建议单元测试里面的顺序，也按照被测试类来写。这样方便查找和阅读。
+	 */
 	@Test
-	public void trimToNullTest(){
+	public void stripTest() {
+
+		final String SOURCE_STRING = "aaa_STRIPPED_bbb";
+
+		// ---------------------------- test strip ----------------------------
+
+		// Normal test
+		Assert.assertEquals("aa_STRIPPED_bbb", CharSequenceUtil.strip(SOURCE_STRING, "a"));
+		Assert.assertEquals(SOURCE_STRING, CharSequenceUtil.strip(SOURCE_STRING, ""));
+		Assert.assertEquals("aa_STRIPPED_bb", CharSequenceUtil.strip(SOURCE_STRING, "a", "b"));
+
+		// test null param
+		Assert.assertEquals(SOURCE_STRING, CharSequenceUtil.strip(SOURCE_STRING, null, null));
+		Assert.assertEquals(SOURCE_STRING, CharSequenceUtil.strip(SOURCE_STRING, "", ""));
+		Assert.assertEquals("aaa_STRIPPED_bb", CharSequenceUtil.strip(SOURCE_STRING, "", "b"));
+		Assert.assertEquals("aaa_STRIPPED_bb", CharSequenceUtil.strip(SOURCE_STRING, null, "b"));
+		Assert.assertEquals("aa_STRIPPED_bbb", CharSequenceUtil.strip(SOURCE_STRING, "a", ""));
+		Assert.assertEquals("aa_STRIPPED_bbb", CharSequenceUtil.strip(SOURCE_STRING, "a", null));
+		// 本次提交前无法通过的 case
+		Assert.assertEquals("", CharSequenceUtil.strip("a", "a", "a"));
+
+		// ---------------------------- test stripAll ----------------------------
+
+		// Normal test
+		Assert.assertEquals("_STRIPPED_bbb", CharSequenceUtil.stripAll(SOURCE_STRING, "a"));
+		Assert.assertEquals(SOURCE_STRING, CharSequenceUtil.stripAll(SOURCE_STRING, ""));
+
+		// test null param
+		Assert.assertEquals("_STRIPPED_", CharSequenceUtil.stripAll(SOURCE_STRING, "a", "b"));
+		Assert.assertEquals(SOURCE_STRING, CharSequenceUtil.stripAll(SOURCE_STRING, null, null));
+		Assert.assertEquals(SOURCE_STRING, CharSequenceUtil.stripAll(SOURCE_STRING, "", ""));
+		Assert.assertEquals("aaa_STRIPPED_", CharSequenceUtil.stripAll(SOURCE_STRING, "", "b"));
+		Assert.assertEquals("aaa_STRIPPED_", CharSequenceUtil.stripAll(SOURCE_STRING, null, "b"));
+		Assert.assertEquals("_STRIPPED_bbb", CharSequenceUtil.stripAll(SOURCE_STRING, "a", ""));
+		Assert.assertEquals("_STRIPPED_bbb", CharSequenceUtil.stripAll(SOURCE_STRING, "a", null));
+
+		// special test
+		Assert.assertEquals("bbb", CharSequenceUtil.stripAll("aaaaaabbb", "aaa", null));
+		Assert.assertEquals("abbb", CharSequenceUtil.stripAll("aaaaaaabbb", "aa", null));
+
+		// aaaaaaaaa (9个a) 可以被看为 aaa_aaaa_aa
+		Assert.assertEquals("", CharSequenceUtil.stripAll("aaaaaaaaa", "aaa", "aa"));
+		// 第二次迭代后会出现 from 比 to 大的情况，原本代码是强行交换，但是回导致无法去除前后缀
+		Assert.assertEquals("", CharSequenceUtil.stripAll("a", "a", "a"));
+
+	}
+
+
+	@Test
+	public void trimToNullTest() {
 		String a = "  ";
 		Assert.assertNull(CharSequenceUtil.trimToNull(a));
 
@@ -162,7 +214,7 @@ public class CharSequenceUtilTest {
 	}
 
 	@Test
-	public void commonPrefixTest() throws Exception{
+	public void commonPrefixTest() throws Exception {
 
 		// -------------------------- None match -----------------------
 
@@ -194,7 +246,7 @@ public class CharSequenceUtilTest {
 	}
 
 	@Test
-	public void commonSuffixTest() throws Exception{
+	public void commonSuffixTest() throws Exception {
 
 		// -------------------------- None match -----------------------
 


### PR DESCRIPTION
Current codes：

1. wrap and unwrap method will remove chars in pair.
2. strip will remove chars once

In this PR:

1. add stripAll method to remove all prefixes and suffixes.
2. fix a bug:
```java
Assert.assertEquals("", CharSequenceUtil.strip("a", "a", "a"))
```
In current version `CharSequenceUtil.strip("a", "a", "a")` will return `"a"`.

