### PR TITLE
增加ContentType#get识别的准确率。

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/ContentType.java
+++ b/hutool-http/src/main/java/cn/hutool/http/ContentType.java
@@ -120,6 +120,7 @@ public enum ContentType {
 	public static ContentType get(String body) {
 		ContentType contentType = null;
 		if (StrUtil.isNotBlank(body)) {
+			body = StrUtil.trim(body);
 			char firstChar = body.charAt(0);
 			switch (firstChar) {
 				case '{':

--- a/hutool-http/src/test/java/cn/hutool/http/ContentTypeTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/ContentTypeTest.java
@@ -16,4 +16,13 @@ public class ContentTypeTest {
 		String result = ContentType.build(ContentType.JSON, CharsetUtil.CHARSET_UTF_8);
 		Assert.assertEquals("application/json;charset=UTF-8", result);
 	}
+
+	@Test
+	public void testGetWithLeadingSpace() {
+		String json = " {\n" +
+			"     \"name\": \"hutool\"\n" +
+			" }";
+		ContentType contentType = ContentType.get(json);
+		Assert.assertEquals(ContentType.JSON, contentType);
+	}
 }


### PR DESCRIPTION


1. [bug修复] ContentType#get方法处理JSON字符串时，如果首字符为空格时无法识别

```java
        @Test
	public void testGetWithLeadingSpace() {
		String json = " {\n" +
			"     \"name\": \"hutool\"\n" +
			" }";
		ContentType contentType = ContentType.get(json);
		Assert.assertEquals(ContentType.JSON, contentType);
	}
```
