### PR TITLE
支持"RSA/ECB/OAEPWithSHA-1AndMGF1Padding"的RSA加解密

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/KeyUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/KeyUtil.java
@@ -21,30 +21,12 @@ import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.Key;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.Provider;
-import java.security.PublicKey;
-import java.security.SecureRandom;
+import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.interfaces.RSAPrivateCrtKey;
-import java.security.spec.AlgorithmParameterSpec;
-import java.security.spec.ECGenParameterSpec;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.RSAPublicKeySpec;
-import java.security.spec.X509EncodedKeySpec;
+import java.security.spec.*;
 
 /**
  * 密钥工具类
@@ -647,6 +629,7 @@ public class KeyUtil {
 			return "EC";
 		}
 
+		algorithm = getMainAlgorithm(algorithm);
 		int indexOfWith = StrUtil.lastIndexOfIgnoreCase(algorithm, "with");
 		if (indexOfWith > 0) {
 			algorithm = StrUtil.subSuf(algorithm, indexOfWith + "with".length());

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/asymmetric/RSATest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/asymmetric/RSATest.java
@@ -1,11 +1,7 @@
 package cn.hutool.crypto.asymmetric;
 
 import cn.hutool.core.codec.Base64;
-import cn.hutool.core.util.ArrayUtil;
-import cn.hutool.core.util.CharsetUtil;
-import cn.hutool.core.util.HexUtil;
-import cn.hutool.core.util.RandomUtil;
-import cn.hutool.core.util.StrUtil;
+import cn.hutool.core.util.*;
 import cn.hutool.crypto.KeyUtil;
 import cn.hutool.crypto.SecureUtil;
 import org.junit.Assert;
@@ -93,6 +89,28 @@ public class RSATest {
 		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
 	}
 
+	@Test
+	public void rsaOAEPTest() {
+		final RSA rsa = new RSA("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
+
+		// 获取私钥和公钥
+		Assert.assertNotNull(rsa.getPrivateKey());
+		Assert.assertNotNull(rsa.getPrivateKeyBase64());
+		Assert.assertNotNull(rsa.getPublicKey());
+		Assert.assertNotNull(rsa.getPrivateKeyBase64());
+
+		// 公钥加密，私钥解密
+		final byte[] encrypt = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PublicKey);
+
+		final byte[] decrypt = rsa.decrypt(encrypt, KeyType.PrivateKey);
+		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt, CharsetUtil.CHARSET_UTF_8));
+
+		// 私钥加密，公钥解密
+		final byte[] encrypt2 = rsa.encrypt(StrUtil.bytes("我是一段测试aaaa", CharsetUtil.CHARSET_UTF_8), KeyType.PrivateKey);
+		final byte[] decrypt2 = rsa.decrypt(encrypt2, KeyType.PublicKey);
+		Assert.assertEquals("我是一段测试aaaa", StrUtil.str(decrypt2, CharsetUtil.CHARSET_UTF_8));
+	}
+	
 	@Test
 	public void rsaNoneTest() {
 		final RSA rsa = new RSA(AsymmetricAlgorithm.RSA_None.getValue());


### PR DESCRIPTION
### bug修复

1. [bug修复] 支持"RSA/ECB/OAEPWithSHA-1AndMGF1Padding"的RSA加解密，cn.hutool.crypto.KeyUtil#getAlgorithmAfterWith函数逻辑，获取到的算法名称在某种场景中会有问题：如果传递"RSA/ECB/OAEPWithSHA-1AndMGF1Padding"会导致加解密失败

