### PR TITLE
添加最低位参与位运算的支持.

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/math/BitStatusUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/math/BitStatusUtil.java
@@ -2,7 +2,7 @@ package cn.hutool.core.math;
 
 /**
  * 通过位运算表示状态的工具类<br>
- * 参数必须是 `偶数` 且 `大于等于0`！
+ * 参数必须 `大于等于0`！
  *
  * 工具实现见博客：https://blog.starxg.com/2020/11/bit-status/
  *
@@ -31,7 +31,10 @@ public class BitStatusUtil {
 	 * @return true：有
 	 */
 	public static boolean has(int states, int stat) {
-		check(states, stat);
+		check(states);
+		if(stat <= 0){
+			throw new IllegalArgumentException(stat + " 必须大于0");
+		}
 		return (states & stat) == stat;
 	}
 
@@ -43,7 +46,7 @@ public class BitStatusUtil {
 	 * @return 新的状态值
 	 */
 	public static int remove(int states, int stat) {
-		check(states, stat);
+		check(states,stat);
 		if (has(states, stat)) {
 			return states ^ stat;
 		}
@@ -72,9 +75,6 @@ public class BitStatusUtil {
 		for (int arg : args) {
 			if (arg < 0) {
 				throw new IllegalArgumentException(arg + " 必须大于等于0");
-			}
-			if ((arg & 1) == 1) {
-				throw new IllegalArgumentException(arg + " 不是偶数");
 			}
 		}
 	}

--- a/hutool-core/src/main/java/cn/hutool/core/math/BitStatusUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/math/BitStatusUtil.java
@@ -2,7 +2,7 @@ package cn.hutool.core.math;
 
 /**
  * 通过位运算表示状态的工具类<br>
- * 参数必须是 `偶数` 且 `大于等于0`！
+ * 参数必须 `大于等于0`！
  *
  * 工具实现见博客：https://blog.starxg.com/2020/11/bit-status/
  *
@@ -72,9 +72,6 @@ public class BitStatusUtil {
 		for (int arg : args) {
 			if (arg < 0) {
 				throw new IllegalArgumentException(arg + " 必须大于等于0");
-			}
-			if ((arg & 1) == 1) {
-				throw new IllegalArgumentException(arg + " 不是偶数");
 			}
 		}
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/math/BitStatusUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/BitStatusUtilTest.java
@@ -1,0 +1,35 @@
+package cn.hutool.core.math;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BitStatusUtilTest {
+
+	@Test
+	void add() {
+		assertEquals(BitStatusUtil.add(0x1100, 0x0010),0x1110);
+		assertEquals(BitStatusUtil.add(0x1101, 0x0010),0x1111);
+		assertEquals(BitStatusUtil.add(0x0000, 0x0000),0x0000);
+		assertEquals(BitStatusUtil.add(0x0010, 0x0000),0x0010);
+	}
+
+	@Test
+	void has() {
+		assertEquals(BitStatusUtil.has(0x1100, 0x0010),false);
+		assertEquals(BitStatusUtil.has(0x1101, 0x0010),false);
+		assertThrows(Exception.class,() -> BitStatusUtil.has(0x0000, 0x0000));
+	}
+
+	@Test
+	void remove() {
+		assertEquals(BitStatusUtil.remove(0x1100, 0x0010),0x1100);
+		assertEquals(BitStatusUtil.remove(0x1111, 0x0010),0x1101);
+		assertThrows(Exception.class,() -> BitStatusUtil.remove(0x0000, 0x0000));
+	}
+
+	@Test
+	void clear() {
+		assertEquals(BitStatusUtil.clear(),0);
+	}
+}


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 从逻辑上来说,最低位参与位运算不存在障碍.修复位运算工具类,不允许使用最低位存储状态的问题.
