### PR TITLE
fix-兼容NumberUtil.add方法传入整型自动类型转换为浮点类型的精度丢失问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -103,6 +103,38 @@ public class NumberUtil {
 	 * @param v1 被加数
 	 * @param v2 加数
 	 * @return 和
+	 */
+	public static double add(long v1, double v2) {
+		return add(Long.toString(v1), Double.toString(v2)).doubleValue();
+	}
+
+	/**
+	 * 提供精确的加法运算
+	 *
+	 * @param v1 被加数
+	 * @param v2 加数
+	 * @return 和
+	 */
+	public static double add(double v1, long v2) {
+		return add(Double.toString(v1), Long.toString(v2)).doubleValue();
+	}
+
+	/**
+	 * 提供精确的加法运算
+	 * @param v1 被加数
+	 * @param v2 加数
+	 * @return 和
+	 */
+	public static double add(long v1, long v2) {
+		return add(Long.toString(v1), Long.toString(v2)).doubleValue();
+	}
+
+	/**
+	 * 提供精确的加法运算
+	 *
+	 * @param v1 被加数
+	 * @param v2 加数
+	 * @return 和
 	 * @since 3.1.1
 	 */
 	public static double add(Double v1, Double v2) {

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -665,4 +665,12 @@ public class NumberUtilTest {
 		final Number number = NumberUtil.parseNumber("12,234,456");
 		assertEquals(new BigDecimal(12234456), number);
 	}
+
+	@Test
+	public void addIntAndDoubleTest() {
+		int v1 = 91007279;
+		double v2 = 0.3545;
+		final double result = NumberUtil.add(v1, v2);
+		assertEquals(91007279.3545, result, 0);
+	}
 }


### PR DESCRIPTION
兼容NumberUtil.add方法传入整型自动类型转换为浮点类型的精度丢失问题
