### PR TITLE
优化ExcelWriter中使用比较器writer的方法，只对第一条数据进行排序

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/excel/ExcelWriter.java
@@ -865,11 +865,20 @@ public class ExcelWriter extends ExcelBase<ExcelWriter> {
 		boolean isFirstRow = true;
 		Map<?, ?> map;
 		for (Object obj : data) {
-			if (obj instanceof Map) {
-				map = new TreeMap<>(comparator);
-				map.putAll((Map) obj);
+			// 只第一行使用比较器排序
+			if (isFirstRow) {
+				if (obj instanceof Map) {
+					map = new TreeMap<>(comparator);
+					map.putAll((Map) obj);
+				} else {
+					map = BeanUtil.beanToMap(obj, new TreeMap<>(comparator), false, false);
+				}
 			} else {
-				map = BeanUtil.beanToMap(obj, new TreeMap<>(comparator), false, false);
+				if (obj instanceof Map) {
+					map = (Map) obj;
+				} else {
+					map = BeanUtil.beanToMap(obj, new HashMap<>(), false, false);
+				}
 			}
 			writeRow(map, isFirstRow);
 			if (isFirstRow) {

--- a/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/excel/ExcelWriteTest.java
@@ -2,6 +2,7 @@ package cn.hutool.poi.excel;
 
 import cn.hutool.core.collection.CollUtil;
 import cn.hutool.core.collection.ListUtil;
+import cn.hutool.core.comparator.IndexedComparator;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
@@ -901,6 +902,77 @@ public class ExcelWriteTest {
 		try (BigExcelWriter writer = new BigExcelWriter(file2)) {
 			writer.writeRow(map, true);
 			writer.autoSizeColumnAll(2f);
+		}
+	}
+
+	@Test
+	@Disabled
+	public void writeWithComparatorTest() {
+		// 生成测试数据, 10w行50列
+		List<Map<String, Object>> dataList = new ArrayList<>();
+		for (int i = 1; i <= 100000; i++) {
+			Map<String, Object> map = new HashMap<>();
+			map.put("test11", "test11_" + i);
+			map.put("test12", "test12_" + i);
+			map.put("test13", "test13_" + i);
+			map.put("test14", "test14_" + i);
+			map.put("test15", "test15_" + i);
+			map.put("test16", "test16_" + i);
+			map.put("test17", "test17_" + i);
+			map.put("test18", "test18_" + i);
+			map.put("test19", "test19_" + i);
+			map.put("test1", "test1_" + i);
+			map.put("test2", "test2_" + i);
+			map.put("test3", "test3_" + i);
+			map.put("test4", "test4_" + i);
+			map.put("test5", "test5_" + i);
+			map.put("test6", "test6_" + i);
+			map.put("test7", "test7_" + i);
+			map.put("test8", "test8_" + i);
+			map.put("test9", "test9_" + i);
+			map.put("test10", "test10_" + i);
+			map.put("test20", "test20_" + i);
+			map.put("test21", "test21_" + i);
+			map.put("test22", "test22_" + i);
+			map.put("test23", "test23_" + i);
+			map.put("test24", "test24_" + i);
+			map.put("test25", "test25_" + i);
+			map.put("test26", "test26_" + i);
+			map.put("test27", "test27_" + i);
+			map.put("test28", "test28_" + i);
+			map.put("test29", "test29_" + i);
+			map.put("test30", "test30_" + i);
+			map.put("test41", "test41_" + i);
+			map.put("test42", "test42_" + i);
+			map.put("test43", "test43_" + i);
+			map.put("test44", "test44_" + i);
+			map.put("test45", "test45_" + i);
+			map.put("test46", "test46_" + i);
+			map.put("test47", "test47_" + i);
+			map.put("test48", "test48_" + i);
+			map.put("test49", "test49_" + i);
+			map.put("test50", "test50_" + i);
+			map.put("test31", "test31_" + i);
+			map.put("test32", "test32_" + i);
+			map.put("test33", "test33_" + i);
+			map.put("test34", "test34_" + i);
+			map.put("test35", "test35_" + i);
+			map.put("test36", "test36_" + i);
+			map.put("test37", "test37_" + i);
+			map.put("test38", "test38_" + i);
+			map.put("test39", "test39_" + i);
+			map.put("test40", "test40_" + i);
+			dataList.add(map);
+		}
+		// 使用比较器写出
+		try (BigExcelWriter excelWriter = ExcelUtil.getBigWriter("d:/writeWithComparatorTest.xlsx")) {
+			excelWriter.write(dataList, new IndexedComparator<>(
+				"test1", "test2", "test3", "test4", "test5", "test6", "test7", "test8", "test9", "test10",
+				"test11", "test12", "test13", "test14", "test15", "test16", "test17", "test18", "test19", "test20",
+				"test21", "test22", "test23", "test24", "test25", "test26", "test27", "test28", "test29", "test30",
+				"test31", "test32", "test33", "test34", "test35", "test36", "test37", "test38", "test39", "test40",
+				"test41", "test42", "test43", "test44", "test45", "test46", "test47", "test48", "test49", "test50"
+			));
 		}
 	}
 


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [性能优化] 
    写出的每条数据都使用比较器进行比较 -> 只第一条数据使用比较器进行比较。
    因为后续代码（ExcelWriter的1112行）会记录第一条数据的顺序，并根据第一条找对应的值写入数据，所以认为这里没必要对所有数据进行排序