### PR TITLE
fix: 修复Xml转义相关问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/escape/XmlEscape.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/escape/XmlEscape.java
@@ -22,7 +22,7 @@ public class XmlEscape extends ReplacerChain {
 	private static final long serialVersionUID = 1L;
 
 	protected static final String[][] BASIC_ESCAPE = { //
-//			{"'", "&apos;"}, // " - single-quote
+			{"'", "&apos;"}, // " - single-quote
 			{"\"", "&quot;"}, // " - double-quote
 			{"&", "&amp;"}, // & - ampersand
 			{"<", "&lt;"}, // < - less-than

--- a/hutool-core/src/main/java/cn/hutool/core/text/escape/XmlUnescape.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/escape/XmlUnescape.java
@@ -13,8 +13,6 @@ public class XmlUnescape extends ReplacerChain {
 	private static final long serialVersionUID = 1L;
 
 	protected static final String[][] BASIC_UNESCAPE  = InternalEscapeUtil.invert(XmlEscape.BASIC_ESCAPE);
-	// issue#1118
-	protected static final String[][] OTHER_UNESCAPE  = new String[][]{new String[]{"&apos;", "'"}};
 
 	/**
 	 * 构造
@@ -22,6 +20,5 @@ public class XmlUnescape extends ReplacerChain {
 	public XmlUnescape() {
 		addChain(new LookupReplacer(BASIC_UNESCAPE));
 		addChain(new NumericEntityUnescaper());
-		addChain(new LookupReplacer(OTHER_UNESCAPE));
 	}
 }

--- a/hutool-core/src/main/java/cn/hutool/core/util/XmlUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/XmlUtil.java
@@ -956,6 +956,7 @@ public class XmlUtil {
 	 * &lt; (小于) 替换为 &amp;lt;
 	 * &gt; (大于) 替换为 &amp;gt;
 	 * &quot; (双引号) 替换为 &amp;quot;
+	 * &apos; (单引号) 替换为 &amp;apos;
 	 * </pre>
 	 *
 	 * @param string 被替换的字符串
@@ -963,7 +964,7 @@ public class XmlUtil {
 	 * @since 4.0.8
 	 */
 	public static String escape(String string) {
-		return EscapeUtil.escapeHtml4(string);
+		return EscapeUtil.escapeXml(string);
 	}
 
 	/**
@@ -975,7 +976,7 @@ public class XmlUtil {
 	 * @since 5.0.6
 	 */
 	public static String unescape(String string) {
-		return EscapeUtil.unescapeHtml4(string);
+		return EscapeUtil.unescapeXml(string);
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/util/XmlUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/XmlUtilTest.java
@@ -320,6 +320,7 @@ public class XmlUtilTest {
 		final String a = "<>";
 		final String escape = XmlUtil.escape(a);
 		Console.log(escape);
+		Console.log(XmlUtil.escape("中文“双引号”"));
 	}
 
 	@Test


### PR DESCRIPTION
### 修改描述

1. [bug修复] 修复 XmlUtil 中转义/反转义方法错误调用 html4 转义/反转义方法的问题。html4 转义会将中文双引号等字符转义为 xml 无法识别的字符，从而导致解析 xml 时出现异常；
![image](https://github.com/user-attachments/assets/a59397e6-76cb-4e13-85ae-2379777b7937)
2. [bug修复] 修复 XmlEscape 未对单引号进行转义的问题