### PR TITLE
feat: Add cleanEmptyTag method for HtmlUtil

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HtmlUtil.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HtmlUtil.java
@@ -24,6 +24,7 @@ public class HtmlUtil {
 	public static final String GT = StrUtil.HTML_GT;
 
 	public static final String RE_HTML_MARK = "(<[^<]*?>)|(<[\\s]*?/[^<]*?>)|(<[^<]*?/[\\s]*?>)";
+	public static final String RE_HTML_EMPTY_MARK = "<(\\w+)([^>]*)>\\s*</\\1>";
 	public static final String RE_SCRIPT = "<[\\s]*?script[^>]*?>.*?<[\\s]*?\\/[\\s]*?script[\\s]*?>";
 
 	private static final char[][] TEXT = new char[256][];
@@ -84,6 +85,17 @@ public class HtmlUtil {
 	 */
 	public static String cleanHtmlTag(String content) {
 		return content.replaceAll(RE_HTML_MARK, "");
+	}
+
+	/**
+	 * 清除所有HTML空标签<br>
+	 * 例如：&lt;p&gt;&lt;/p&gt;
+	 *
+	 * @param content 文本
+	 * @return 清除空标签后的文本
+	 */
+	public static String cleanEmptyTag(String content) {
+		return content.replaceAll(RE_HTML_EMPTY_MARK, "");
 	}
 
 	/**

--- a/hutool-http/src/test/java/cn/hutool/http/HtmlUtilTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HtmlUtilTest.java
@@ -78,6 +78,29 @@ public class HtmlUtilTest {
 	}
 
 	@Test
+	public void cleanEmptyTag() {
+		String str = "<p></p><div></div>";
+		String result = HtmlUtil.cleanEmptyTag(str);
+		assertEquals("", result);
+
+		str = "<p>TEXT</p><div></div>";
+		result = HtmlUtil.cleanEmptyTag(str);
+		assertEquals("<p>TEXT</p>", result);
+
+		str = "<p></p><div>TEXT</div>";
+		result = HtmlUtil.cleanEmptyTag(str);
+		assertEquals("<div>TEXT</div>", result);
+
+		str = "<p>TEXT</p><div>TEXT</div>";
+		result = HtmlUtil.cleanEmptyTag(str);
+		assertEquals("<p>TEXT</p><div>TEXT</div>", result);
+
+		str = "TEXT<p></p><div></div>TEXT";
+		result = HtmlUtil.cleanEmptyTag(str);
+		assertEquals("TEXTTEXT", result);
+	}
+
+	@Test
 	public void unwrapHtmlTagTest() {
 		//非闭合标签
 		String str = "pre<img src=\"xxx/dfdsfds/test.jpg\">";


### PR DESCRIPTION
### 修改描述

[新特性] 为 HtmlUtil 添加 cleanEmptyTag 方法，用于清理空标签（内容为空或空白字符的闭合标签）

例如

```html
<p></p>
<div></div>
<script></script>
<p> </p>
<div> </div>
<script> </script>
```