### PR TITLE
ArrayUtil.toArray 元素类型支持多态和泛型

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/ArrayUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/ArrayUtil.java
@@ -1302,7 +1302,7 @@ public class ArrayUtil extends PrimitiveArrayUtil {
 	 * @return 数组
 	 * @since 3.0.9
 	 */
-	public static <T> T[] toArray(Iterator<T> iterator, Class<T> componentType) {
+	public static <T> T[] toArray(Iterator<? extends T> iterator, Class<T> componentType) {
 		return toArray(CollUtil.newArrayList(iterator), componentType);
 	}
 
@@ -1315,7 +1315,7 @@ public class ArrayUtil extends PrimitiveArrayUtil {
 	 * @return 数组
 	 * @since 3.0.9
 	 */
-	public static <T> T[] toArray(Iterable<T> iterable, Class<T> componentType) {
+	public static <T> T[] toArray(Iterable<? extends T> iterable, Class<T> componentType) {
 		return toArray(CollectionUtil.toCollection(iterable), componentType);
 	}
 
@@ -1328,7 +1328,7 @@ public class ArrayUtil extends PrimitiveArrayUtil {
 	 * @return 数组
 	 * @since 3.0.9
 	 */
-	public static <T> T[] toArray(Collection<T> collection, Class<T> componentType) {
+	public static <T> T[] toArray(Collection<? extends T> collection, Class<T> componentType) {
 		return collection.toArray(newArray(componentType, 0));
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/util/ArrayUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ArrayUtilTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -331,6 +332,24 @@ public class ArrayUtilTest {
 		assertEquals("B", array[1]);
 		assertEquals("C", array[2]);
 		assertEquals("D", array[3]);
+
+		// 元素类型支持多态和泛型
+		final ArrayList<List<String>> list2 = CollUtil.newArrayList(
+			CollUtil.newArrayList("A", "B"),
+			CollUtil.newArrayList("C", "D")
+		);
+
+		List<String>[] array2 = ArrayUtil.toArray(list2.iterator(), List.class);
+		assertEquals(CollUtil.newArrayList("A", "B"), array2[0]);
+		assertEquals(CollUtil.newArrayList("C", "D"), array2[1]);
+
+		List<String>[] array3 = ArrayUtil.toArray((Iterable<List<String>>) list2, List.class);
+		assertEquals(CollUtil.newArrayList("A", "B"), array3[0]);
+		assertEquals(CollUtil.newArrayList("C", "D"), array3[1]);
+
+		List<String>[] array4 = ArrayUtil.toArray(list2, List.class);
+		assertEquals(CollUtil.newArrayList("A", "B"), array4[0]);
+		assertEquals(CollUtil.newArrayList("C", "D"), array4[1]);
 	}
 
 	@Test


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1.  [新特性]  ArrayUtil.toArray 元素类型支持多态和泛型，参考 guava 的 Iterables.toArray