### PR TITLE
 处理在请求头为单个值时保持单文本形式

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
@@ -226,7 +226,7 @@ public class HttpConnection {
 					this.header(name, StrUtil.nullToEmpty(values.get(0)), true);
 					continue;
 				}
-				for (String value : entry.getValue()) {
+				for (String value : values) {
 					this.header(name, StrUtil.nullToEmpty(value), isOverride);
 				}
 			}

--- a/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
@@ -221,6 +221,11 @@ public class HttpConnection {
 			String name;
 			for (Entry<String, List<String>> entry : headerMap.entrySet()) {
 				name = entry.getKey();
+				List<String> values = entry.getValue();
+				if (values.size() == 1){
+					this.header(name, StrUtil.nullToEmpty(values.get(0)), true);
+					continue;
+				}
 				for (String value : entry.getValue()) {
 					this.header(name, StrUtil.nullToEmpty(value), isOverride);
 				}

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -270,4 +270,11 @@ public class HttpRequestTest {
 		HttpRequest request = HttpRequest.get("http://localhost:9999/qms/bus/qmsBusReportCenterData/getReportDataList?reportProcessNo=A00&goodsName=工业硫酸98%&conReportTypeId=1010100000000000007&measureDateStr=2024-07-01");
 		request.execute();
 	}
+
+	@Test
+	public void testHttpHead(){
+		//测试不传入请求头时是否会报空指针异常
+		HttpRequest httpRequest = HttpRequest.post("http://127.0.0.1:8080/testHttpHead");
+		HttpResponse execute = httpRequest.execute();
+	}
 }


### PR DESCRIPTION
 [bug修复] 处理在请求头为单个值时保持单文本形式而不是["application/json"]数组形式