### PR TITLE
fix: java.net包下请求头相同key问题

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
@@ -221,9 +221,9 @@ public class HttpConnection {
 			String name;
 			for (Entry<String, List<String>> entry : headerMap.entrySet()) {
 				name = entry.getKey();
-				for (String value : entry.getValue()) {
-					this.header(name, StrUtil.nullToEmpty(value), isOverride);
-				}
+				List<String> values = entry.getValue();
+				String headValues = StrUtil.join(",", values);
+				this.header(name, StrUtil.nullToEmpty(headValues), isOverride);
 			}
 		}
 		return this;

--- a/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
@@ -1247,7 +1247,7 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 			// issue#3462 自定义body长度
 			.setFixedLengthStreamingMode(this.fixedContentLength)
 			// 覆盖默认Header
-			.header(this.headers, false);
+			.header(this.headers, true);
 
 		if (null != this.cookie) {
 			// 当用户自定义Cookie时，全局Cookie自动失效

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -270,4 +270,16 @@ public class HttpRequestTest {
 		HttpRequest request = HttpRequest.get("http://localhost:9999/qms/bus/qmsBusReportCenterData/getReportDataList?reportProcessNo=A00&goodsName=工业硫酸98%&conReportTypeId=1010100000000000007&measureDateStr=2024-07-01");
 		request.execute();
 	}
+
+	@Test
+	public void testHttpHead(){
+		Map<String,String> map = new HashMap<>();
+		map.put("test","test");
+		HttpRequest httpRequest = HttpRequest.post("http://127.0.0.1:8080/testHttpHead")
+			.header("test","test1")
+			.headerMap(map,false);
+		System.out.println(httpRequest.headers());
+		HttpResponse execute = httpRequest.execute();
+		System.out.println(execute.body());
+	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/SimpleHttpServer.java
+++ b/hutool-http/src/test/java/cn/hutool/http/SimpleHttpServer.java
@@ -1,0 +1,81 @@
+package cn.hutool.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 一个简单的http服务器示例代码；
+ * 用于打印出接收到的请求头和简单的post-json的请求体数据来测试
+ *
+ * @author ZhangWeinan
+ * @date 2025/2/23 15:32
+ */
+public class SimpleHttpServer {
+
+	public static void main(String[] args) throws IOException {
+		int port = 8080;
+		ServerSocket serverSocket = new ServerSocket(port);
+		System.out.println("Server started on port " + port);
+
+		while (true) {
+			Socket clientSocket = serverSocket.accept();
+			new Thread(() -> handleClient(clientSocket)).start();
+		}
+	}
+
+	private static void handleClient(Socket clientSocket) {
+		try (BufferedReader in = new BufferedReader(
+			new InputStreamReader(clientSocket.getInputStream()));
+			 OutputStream out = clientSocket.getOutputStream()) {
+			String requestLine = in.readLine();
+			if (requestLine == null) return;
+
+			String[] parts = requestLine.split(" ");
+			String method = parts[0];
+
+			Map<String, String> headers = new HashMap<>();
+			String line;
+			System.out.println("\n=== Headers ===");
+			while (!(line = in.readLine()).isEmpty()) {
+				int colonIndex = line.indexOf(':');
+				if (colonIndex > 0) {
+					String key = line.substring(0, colonIndex).trim();
+					String value = line.substring(colonIndex + 1).trim();
+					headers.put(key, value);
+					System.out.println(key + ": " + value);
+				}
+			}
+			if ("POST".equalsIgnoreCase(method)) {
+				int contentLength = Integer.parseInt(headers.getOrDefault("Content-Length", "0"));
+				if (contentLength > 0) {
+					char[] body = new char[contentLength];
+					in.read(body, 0, contentLength);
+					String jsonBody = new String(body);
+					System.out.println("\n=== JSON Body ===");
+					System.out.println(jsonBody);
+				}
+			}
+			String response = "HTTP/1.1 200 OK\r\n" +
+				"Content-Type: text/plain\r\n" +
+				"Content-Length: 16\r\n\r\n" +
+				"Request received";
+			out.write(response.getBytes(StandardCharsets.UTF_8));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			try {
+				clientSocket.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}


### PR DESCRIPTION
[bug修复] java.net包下请求头相同key问题

我测试了从jdk8到jdk21，虽然java.net包下支持addRequestProperty方法，但是并不能实现将请求头中相同key的值聚合为","拼接的形式发送至服务器，而是采用了重复发送的形式，以下是测试截图（测试类已添加至test目录下）：
![2025_02_23_15_22_12](https://github.com/user-attachments/assets/f8ff355d-954d-4d20-989c-82c6ce4163cf)

应在cn.hutool.http.HttpConnection#header(java.util.Map<java.lang.String,java.util.List<java.lang.String>>, boolean)方法中手动拼接完成后再交由下层处理