### PR TITLE
feat(hutool-http): 控制请求头是否聚合

### DIFF
--- a/hutool-http/src/main/java/cn/hutool/http/HttpBase.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpBase.java
@@ -40,6 +40,10 @@ public abstract class HttpBase<T> {
 	public static final String HTTP_1_1 = "HTTP/1.1";
 
 	/**
+	 * 是否聚合重复请求头
+	 */
+	protected boolean isHeaderAggregated = false;
+	/**
 	 * 存储头信息
 	 */
 	protected Map<String, List<String>> headers = new HashMap<>();
@@ -275,6 +279,26 @@ public abstract class HttpBase<T> {
 	public T clearHeaders() {
 		this.headers.clear();
 		return (T) this;
+	}
+
+	/**
+	 * 设置是否需要聚合重复的请求头，将重复的请求头聚合为,拼接
+	 *
+	 * @param aggregate 是否需要聚合
+	 * @return this
+	 */
+	public T headerAggregation(boolean aggregate) {
+		this.isHeaderAggregated = aggregate;
+		return (T) this;
+	}
+
+	/**
+	 * 获取是否需要聚合请求头状态
+	 *
+	 * @return isHeaderAggregated 请求头聚合状态
+	 */
+	public boolean isHeaderAggregated() {
+		return isHeaderAggregated;
 	}
 	// ---------------------------------------------------------------- Headers end
 

--- a/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpConnection.java
@@ -230,6 +230,31 @@ public class HttpConnection {
 	}
 
 	/**
+	 * 设置请求头<br>
+	 * 不覆盖原有请求头并判断是否需要聚合请求头
+	 *
+	 * @param headerMap 请求头
+	 * @param isOverride 是否覆盖
+	 * @param isHeaderAggregated 是否聚合
+	 * @return this
+	 */
+	public HttpConnection header(Map<String, List<String>> headerMap, boolean isOverride, boolean isHeaderAggregated) {
+		if (!isHeaderAggregated){
+			return header(headerMap,isOverride);
+		}
+		if (MapUtil.isNotEmpty(headerMap)) {
+			String name;
+			for (Entry<String, List<String>> entry : headerMap.entrySet()) {
+				name = entry.getKey();
+				List<String> values = entry.getValue();
+				String headValues = StrUtil.join(",", values);
+				this.header(name, StrUtil.nullToEmpty(headValues), true);
+			}
+		}
+		return this;
+	}
+
+	/**
 	 * 获取Http请求头
 	 *
 	 * @param name Header名

--- a/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
+++ b/hutool-http/src/main/java/cn/hutool/http/HttpRequest.java
@@ -1247,7 +1247,7 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 			// issue#3462 自定义body长度
 			.setFixedLengthStreamingMode(this.fixedContentLength)
 			// 覆盖默认Header
-			.header(this.headers, false);
+			.header(this.headers, false, this.isHeaderAggregated);
 
 		if (null != this.cookie) {
 			// 当用户自定义Cookie时，全局Cookie自动失效

--- a/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
+++ b/hutool-http/src/test/java/cn/hutool/http/HttpRequestTest.java
@@ -270,4 +270,17 @@ public class HttpRequestTest {
 		HttpRequest request = HttpRequest.get("http://localhost:9999/qms/bus/qmsBusReportCenterData/getReportDataList?reportProcessNo=A00&goodsName=工业硫酸98%&conReportTypeId=1010100000000000007&measureDateStr=2024-07-01");
 		request.execute();
 	}
+
+	@Test
+	public void testHttpHead(){
+		Map<String,String> map = new HashMap<>();
+		map.put("test","test");
+		HttpRequest httpRequest = HttpRequest.post("http://127.0.0.1:8080/testHttpHead")
+			.header("test","test1")
+			.headerMap(map,false)
+			.headerAggregation(true);
+		System.out.println(httpRequest.headers());
+		HttpResponse execute = httpRequest.execute();
+		System.out.println(execute.body());
+	}
 }

--- a/hutool-http/src/test/java/cn/hutool/http/SimpleHttpServer.java
+++ b/hutool-http/src/test/java/cn/hutool/http/SimpleHttpServer.java
@@ -1,0 +1,81 @@
+package cn.hutool.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 一个简单的http服务器示例代码；
+ * 用于打印出接收到的请求头和简单的post-json的请求体数据来测试
+ *
+ * @author ZhangWeinan
+ * @date 2025/2/23 15:32
+ */
+public class SimpleHttpServer {
+
+	public static void main(String[] args) throws IOException {
+		int port = 8080;
+		ServerSocket serverSocket = new ServerSocket(port);
+		System.out.println("Server started on port " + port);
+
+		while (true) {
+			Socket clientSocket = serverSocket.accept();
+			new Thread(() -> handleClient(clientSocket)).start();
+		}
+	}
+
+	private static void handleClient(Socket clientSocket) {
+		try (BufferedReader in = new BufferedReader(
+			new InputStreamReader(clientSocket.getInputStream()));
+			 OutputStream out = clientSocket.getOutputStream()) {
+			String requestLine = in.readLine();
+			if (requestLine == null) return;
+
+			String[] parts = requestLine.split(" ");
+			String method = parts[0];
+
+			Map<String, String> headers = new HashMap<>();
+			String line;
+			System.out.println("\n=== Headers ===");
+			while (!(line = in.readLine()).isEmpty()) {
+				int colonIndex = line.indexOf(':');
+				if (colonIndex > 0) {
+					String key = line.substring(0, colonIndex).trim();
+					String value = line.substring(colonIndex + 1).trim();
+					headers.put(key, value);
+					System.out.println(key + ": " + value);
+				}
+			}
+			if ("POST".equalsIgnoreCase(method)) {
+				int contentLength = Integer.parseInt(headers.getOrDefault("Content-Length", "0"));
+				if (contentLength > 0) {
+					char[] body = new char[contentLength];
+					in.read(body, 0, contentLength);
+					String jsonBody = new String(body);
+					System.out.println("\n=== JSON Body ===");
+					System.out.println(jsonBody);
+				}
+			}
+			String response = "HTTP/1.1 200 OK\r\n" +
+				"Content-Type: text/plain\r\n" +
+				"Content-Length: 16\r\n\r\n" +
+				"Request received";
+			out.write(response.getBytes(StandardCharsets.UTF_8));
+
+		} catch (Exception e) {
+			e.printStackTrace();
+		} finally {
+			try {
+				clientSocket.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}


### PR DESCRIPTION
[新特性]  新增用户控制是否需要聚合请求头为,拼接

根据 HTTP 标准（RFC 7230），对于用户自定义请求头，发送方通常不应发送多个具有相同名称的头，除非其值被定义为逗号分隔列表，但自定义头通常未定义此行为。

我查阅了相关文档，规范中并未对用户自定义的请求做规范；在实践中有服务端支持也有服务端无法支持需要借用插件来完成。

所以增加一个用户可选的是否聚合请求头的操作，用户可选择适配不同服务器，增强 hutool 的实用性，默认为不聚合请求头。