### PR TITLE
feat: 添加中兴数据库GoldenDB的url识别jdbc-driver逻辑

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/dialect/DialectFactory.java
+++ b/hutool-db/src/main/java/cn/hutool/db/dialect/DialectFactory.java
@@ -45,7 +45,8 @@ public class DialectFactory implements DriverNamePool {
 	 */
 	private static Dialect internalNewDialect(String driverName) {
 		if (StrUtil.isNotBlank(driverName)) {
-			if (DRIVER_MYSQL.equalsIgnoreCase(driverName) || DRIVER_MYSQL_V6.equalsIgnoreCase(driverName)) {
+			if (DRIVER_MYSQL.equalsIgnoreCase(driverName) || DRIVER_MYSQL_V6.equalsIgnoreCase(driverName)
+				|| DRIVER_GOLDENDB.equalsIgnoreCase(driverName)) {
 				return new MysqlDialect();
 			} else if (DRIVER_ORACLE.equalsIgnoreCase(driverName) || DRIVER_ORACLE_OLD.equalsIgnoreCase(driverName)) {
 				return new OracleDialect();
@@ -164,6 +165,9 @@ public class DialectFactory implements DriverNamePool {
 		} else if (nameContainsProductInfo.contains("opengauss")) {
 			// OpenGauss
 			driver = DRIVER_OPENGAUSS;
+		} else if (nameContainsProductInfo.contains("goldendb")) {
+			// GoldenDB
+			driver = DRIVER_GOLDENDB;
 		}
 
 		return driver;

--- a/hutool-db/src/main/java/cn/hutool/db/dialect/DriverNamePool.java
+++ b/hutool-db/src/main/java/cn/hutool/db/dialect/DriverNamePool.java
@@ -116,4 +116,8 @@ public interface DriverNamePool {
 	 * JDBC 驱动 OpenGauss
 	 */
 	String DRIVER_OPENGAUSS = "org.opengauss.Driver";
+	/**
+	 * JDBC 驱动 GoldenDB
+	 */
+	String DRIVER_GOLDENDB = "com.goldendb.jdbc.Driver";
 }

--- a/hutool-db/src/test/java/cn/hutool/db/dialect/DialectFactoryTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/dialect/DialectFactoryTest.java
@@ -42,6 +42,7 @@ public class DialectFactoryTest {
 		map.put("oscar",DRIVER_OSCAR);
 		map.put("sybase",DRIVER_SYBASE);
 		map.put("mariadb",DRIVER_MARIADB);
+		map.put("goldendb",DRIVER_GOLDENDB);
 
 
 		map.forEach((k,v) -> assertEquals(v,


### PR DESCRIPTION
#### 说明

- [x] 1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。

- [x] 2. 请确认没有更改代码风格（如tab缩进）

- [x] 3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  支持中兴数据 GoldenDB 的 url 识别 jdbc 驱动

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

- [x] 1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
- [x] 2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
- [x] 3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
- [x] 4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
- [x] 5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过

### 对PR的描述

前阵子工作遇到了，这次恰好翻到了这块儿的代码，想着可以混个PR，看具体是否需要吧，不需要就直接关了吧。
驱动特征参考自[官方文档的配置样例](https://goldendb.com/#/docsIndex/docs/GoldenDB/v6.1.03.10/developmentSupport_databaseConnection)。
选择 MySQL 方言的原因是[官方描述](https://goldendb.com/#/docsIndex/docs/GoldenDB/v6.1.03.10/aboutGoldenDB_MySQLCompatibility)完全支持 MySQL特性