### PR TITLE
修复 StrSplitter 在空字符串情况下依然进行分割的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/StrSplitter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/StrSplitter.java
@@ -188,7 +188,7 @@ public class StrSplitter {
 	 */
 	public static <R> List<R> split(CharSequence text, char separator, int limit, boolean ignoreEmpty,
 									boolean ignoreCase, Function<String, R> mapping) {
-		if (null == text) {
+		if (CharSequenceUtil.isEmpty(text)) {
 			return new ArrayList<>(0);
 		}
 		final SplitIter splitIter = new SplitIter(text, new CharFinder(separator, ignoreCase), limit, ignoreEmpty);


### PR DESCRIPTION
<img width="630" alt="image" src="https://github.com/user-attachments/assets/1a447853-2205-4e9d-b97f-dfba524b9e32" />

1. [bug修复] 修复 StrSplitter 在空字符串情况下依然进行分割的问题

