### PR TITLE
某些数据库的getParameterMetaData 会返回 NULL，然后导致报错，也需要规避这种情况

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/StatementUtil.java
+++ b/hutool-db/src/main/java/cn/hutool/db/StatementUtil.java
@@ -301,6 +301,9 @@ public class StatementUtil {
 		final ParameterMetaData pmd;
 		try {
 			pmd = ps.getParameterMetaData();
+			if (pmd == null) {
+				return sqlType;
+			}
 			sqlType = pmd.getParameterType(paramIndex);
 		} catch (SQLException ignore) {
 			// ignore


### PR DESCRIPTION
### 修改描述

1. 修复某些数据库的getParameterMetaData 会返回 NULL，导致空指针的问题。#3935
