### PR TITLE
docs: 修复错字，删除意外的空格

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  * 日期时间工具类
  *
  * @author xiaoleilu
- * @see LocalDateTimeUtil java8日志工具类
+ * @see LocalDateTimeUtil java8日期工具类
  * @see DatePattern 日期常用格式工具类
  */
 public class DateUtil extends CalendarUtil {

--- a/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/LocalDateTimeUtil.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.TimeZone;
 
 /**
- * JDK8+中的{@link LocalDateTime} 工具类封装
+ * JDK8+中的{@link LocalDateTime}工具类封装
  *
  * @author looly
  * @see DatePattern 常用格式工具类


### PR DESCRIPTION
今天偶然看到有个错别字，修一下。

至于空格的话，项目里有的会在标签前后加空格，有的不加，我就随便改了