### PR TITLE
Assert新增断言给定集合为空的方法以及单元测试用例

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/Assert.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Assert.java
@@ -540,6 +540,68 @@ public class Assert {
 	}
 
 	/**
+	 * 断言给定集合为空
+	 * 并使用指定的函数获取错误信息返回
+	 * <pre class="code">
+	 * Assert.empty(collection, ()-&gt;{
+	 *      // to query relation message
+	 *      return new IllegalArgumentException("relation message to return");
+	 *  });
+	 * </pre>
+	 *
+	 * @param <E>           集合元素类型
+	 * @param <T>           集合类型
+	 * @param <X>           异常类型
+	 * @param collection    被检查的集合
+	 * @param errorSupplier 错误抛出异常附带的消息生产接口
+	 * @throws X if the collection is not {@code null} or has elements
+	 * @see CollUtil#isEmpty(Iterable)
+	 * @since 5.8.39
+	 */
+	public static <E, T extends Iterable<E>, X extends Throwable> void empty(T collection, Supplier<X> errorSupplier) throws X {
+		if (CollUtil.isNotEmpty(collection)) {
+			throw errorSupplier.get();
+		}
+	}
+
+
+	/**
+	 * 断言给定集合为空
+	 *
+	 * <pre class="code">
+	 * Assert.empty(collection, "Collection must have no elements");
+	 * </pre>
+	 *
+	 * @param <E>              集合元素类型
+	 * @param <T>              集合类型
+	 * @param collection       被检查的集合
+	 * @param errorMsgTemplate 异常时的消息模板
+	 * @param params           参数列表
+	 * @throws IllegalArgumentException if the collection is not {@code null} or has elements
+	 * @since 5.8.39
+	 */
+	public static <E, T extends Iterable<E>> void empty(T collection, String errorMsgTemplate, Object... params) throws IllegalArgumentException {
+		empty(collection, () -> new IllegalArgumentException(StrUtil.format(errorMsgTemplate, params)));
+	}
+
+	/**
+	 * 断言给定集合为空
+	 *
+	 * <pre class="code">
+	 * Assert.empty(collection);
+	 * </pre>
+	 *
+	 * @param <E>        集合元素类型
+	 * @param <T>        集合类型
+	 * @param collection 被检查的集合
+	 * @throws IllegalArgumentException if the collection is not {@code null} or has elements
+	 * @since 5.8.39
+	 */
+	public static <E, T extends Iterable<E>> void empty(T collection) throws IllegalArgumentException {
+		empty(collection, "[Assertion failed] - this collection must be empty");
+	}
+
+	/**
 	 * 断言给定集合非空
 	 * 并使用指定的函数获取错误信息返回
 	 * <pre class="code">

--- a/hutool-core/src/test/java/cn/hutool/core/lang/AssertTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/AssertTest.java
@@ -4,6 +4,9 @@ import cn.hutool.core.util.StrUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class AssertTest {
 
 	@Test
@@ -66,6 +69,15 @@ public class AssertTest {
 		//Assert.notEquals(c,d,"{}等于{}",c,d);
 		Assert.notEquals(c, d, () -> new RuntimeException(StrUtil.format("{}和{}相等", c, d)));
 
+	}
+
+	@Test
+	public void emptyCollectionTest() {
+		List<Object> testList = new ArrayList<>();
+		Assertions.assertDoesNotThrow(() -> Assert.empty(null));
+		Assertions.assertDoesNotThrow(() -> Assert.empty(testList));
+		testList.add(new Object());
+		Assertions.assertThrows(IllegalArgumentException.class, () -> Assert.empty(testList));
 	}
 
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  Assert新增断言给定集合为空的方法以及单元测试用例

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过