### PR TITLE
LatchUtils是CountDownLatch工具类，它封装了 CountDownLatch 的实例化与 countDown() 和 await() 方法调用，将业务逻辑与并发控制解耦，让线程协同更安全、更清晰

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/thread/LatchUtils.java
+++ b/hutool-core/src/main/java/cn/hutool/core/thread/LatchUtils.java
@@ -1,0 +1,73 @@
+package cn.hutool.core.thread;
+
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * CountDownLatch 工具类，实现对CountDownLatch类的创建以及 countDown 和 await方法的封装
+ * 实现对业务代码和CountDownLatch相关操作的隔离，避免业务代码与CountDownLatch的耦合，增加线程并行等待的安全性
+ * @author wwwzzzggg
+ */
+public class LatchUtils {
+
+	private static final ThreadLocal<List<TaskInfo>> THREADLOCAL = ThreadLocal.withInitial(LinkedList::new);
+
+	private static final class TaskInfo {
+		private Executor executor;
+		private Runnable runnable;
+
+		public TaskInfo(Executor executor, Runnable runnable) {
+			this.executor = executor;
+			this.runnable = runnable;
+		}
+	}
+
+	public static void submitTask(Executor executor, Runnable runnable) {
+		THREADLOCAL.get().add(new TaskInfo(executor, runnable));
+	}
+
+	private static List<TaskInfo> popTask() {
+		List<TaskInfo> taskInfos = THREADLOCAL.get();
+		THREADLOCAL.remove();
+		return taskInfos;
+	}
+
+	public static boolean waitFor(Long timeout, TimeUnit timeUnit) {
+		List<TaskInfo> taskInfos = popTask();
+		if (taskInfos.isEmpty()) {
+			return true;
+		}
+
+		CountDownLatch latch = new CountDownLatch(taskInfos.size());
+		for (TaskInfo taskInfo : taskInfos) {
+			Executor executor = taskInfo.executor;
+			Runnable runnable = taskInfo.runnable;
+			executor.execute(() -> {
+				try {
+					runnable.run();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		boolean await = false;
+		try {
+			if (timeout != null) {
+				await = latch.await(timeout, timeUnit != null ? timeUnit : TimeUnit.SECONDS);
+			} else {
+				latch.await();
+				await = true;
+			}
+		} catch (Exception e) {
+
+		}
+
+		return await;
+	}
+
+}

--- a/hutool-core/src/test/java/cn/hutool/core/thread/LatchUtilsTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/thread/LatchUtilsTest.java
@@ -1,0 +1,34 @@
+package cn.hutool.core.thread;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * LatchUtils 相关单元测试
+ */
+class LatchUtilsTest {
+
+	private ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+	@Test
+	void testSubmitTask1() {
+		LatchUtils.submitTask(executorService, () -> {
+			System.out.println("task1");
+		});
+		LatchUtils.submitTask(executorService, () -> {
+			System.out.println("task2");
+
+		});
+		LatchUtils.submitTask(executorService, () -> {
+			System.out.println("task3");
+
+		});
+		assertTrue(LatchUtils.waitFor(1L, TimeUnit.SECONDS
+		));
+	}
+}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 
2. [新特性] 新增LatchUtils是CountDownLatch工具类，它封装了 CountDownLatch 的实例化与 countDown() 和 await() 方法调用，将业务逻辑与并发控制解耦，让线程协同更安全、更清晰

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过