### PR TITLE
fix(Money): currency scaling bug(币种小数位硬编码)

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/math/Money.java
+++ b/hutool-core/src/main/java/cn/hutool/core/math/Money.java
@@ -294,7 +294,7 @@ public class Money implements Serializable, Comparable<Money> {
 	 */
 	public void setAmount(BigDecimal amount) {
 		if (amount != null) {
-			cent = rounding(amount.movePointRight(2), DEFAULT_ROUNDING_MODE);
+			cent = rounding(amount.movePointRight(currency.getDefaultFractionDigits()), DEFAULT_ROUNDING_MODE);
 		}
 	}
 

--- a/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/math/MoneyTest.java
@@ -2,6 +2,8 @@ package cn.hutool.core.math;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import java.util.Currency;
 
 public class MoneyTest {
 
@@ -20,4 +22,12 @@ public class MoneyTest {
 
 		assertEquals(1234.56D, MathUtil.centToYuan(123456), 0);
 	}
+
+	@Test
+	public void currencyScalingTest() {
+		Money jpyMoney = new Money(0, Currency.getInstance("JPY"));
+		jpyMoney.setAmount(BigDecimal.ONE);
+		assertEquals(1, jpyMoney.getCent());
+	}
+
 }


### PR DESCRIPTION
#### 说明

- [x] 确认提交的PR是到'v5-dev'分支。
- [x] 确认没有更改代码风格（如tab缩进）
- [x] 针对该bug添加对应Junit测试用例

### 修改描述

**[bug修复]** Money类的`setAmount`方法没有获取当前币种的小数位数而是使用的默认小数位: 2，在遇到非2小数位的币种(如日元使用 0 位)会导致金额设置错误
```java
Money yen = new Money(1000, Currency.getInstance("JPY"));
yen.setAmount(BigDecimal.ONE); // 期望 1 JPY， 实际 100 JPY
```
