### PR TITLE
Db添加FetchSize的全局设置，用户可以根据内存性能自主调节JDBC每次结果集获取的记录数量，海量数据加载时可提高性能

### DIFF
--- a/hutool-db/pom.xml
+++ b/hutool-db/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>cn.hutool</groupId>
 		<artifactId>hutool-parent</artifactId>
-		<version>5.8.39-SNAPSHOT</version>
+		<version>5.8.38</version>
 	</parent>
 
 	<artifactId>hutool-db</artifactId>

--- a/hutool-db/src/main/java/cn/hutool/db/DbUtil.java
+++ b/hutool-db/src/main/java/cn/hutool/db/DbUtil.java
@@ -251,4 +251,12 @@ public final class DbUtil {
 	public static void setDbSettingPathGlobal(String dbSettingPath) {
 		GlobalDbConfig.setDbSettingPath(dbSettingPath);
 	}
+
+	/**
+	 * 设置构造结果集时每次从数据库取到的行数
+	 * @param fetchSize 每一轮网络请求获取的行数
+	 */
+	public static void setStatementFetchSizeGlobal(Integer fetchSize){
+		GlobalDbConfig.setStatementFetchSize(fetchSize);
+	}
 }

--- a/hutool-db/src/main/java/cn/hutool/db/GlobalDbConfig.java
+++ b/hutool-db/src/main/java/cn/hutool/db/GlobalDbConfig.java
@@ -36,6 +36,10 @@ public class GlobalDbConfig {
 	 * @since 5.8.0
 	 */
 	private static String dbSettingPath = null;
+	/**
+	 * 自定义构造结果集时每次从数据库取的行数
+	 */
+	protected static Integer statementFetchSize=null;
 
 	/**
 	 * 设置全局是否在结果中忽略大小写<br>
@@ -118,5 +122,13 @@ public class GlobalDbConfig {
 	 */
 	public static void setShowSql(boolean isShowSql, boolean isFormatSql, boolean isShowParams, Level level) {
 		SqlLog.INSTANCE.init(isShowSql, isFormatSql, isShowParams, level);
+	}
+
+	/**
+	 * 设置构造结果集时每次从数据库取到的行数
+	 * @param statementFetchSize 每一轮网络请求获取的行数
+	 */
+	public static void setStatementFetchSize(Integer statementFetchSize) {
+		GlobalDbConfig.statementFetchSize = statementFetchSize;
 	}
 }

--- a/hutool-db/src/main/java/cn/hutool/db/StatementUtil.java
+++ b/hutool-db/src/main/java/cn/hutool/db/StatementUtil.java
@@ -151,6 +151,7 @@ public class StatementUtil {
 		} else {
 			ps = conn.prepareStatement(sql);
 		}
+		setFetchSize(ps);
 		return fillParams(ps, params);
 	}
 
@@ -189,6 +190,7 @@ public class StatementUtil {
 			fillParams(ps, new ArrayIter<>(params), nullTypeMap);
 			ps.addBatch();
 		}
+		setFetchSize(ps);
 		return ps;
 	}
 
@@ -215,6 +217,7 @@ public class StatementUtil {
 			fillParams(ps, CollUtil.valuesOfKeys(entity, fields), nullTypeMap);
 			ps.addBatch();
 		}
+		setFetchSize(ps);
 		return ps;
 	}
 
@@ -391,6 +394,16 @@ public class StatementUtil {
 
 		// 其它参数类型
 		ps.setObject(paramIndex, param);
+	}
+
+	/**
+	 * 为{@link PreparedStatement} 设置FetchSize
+	 * @param ps {@link PreparedStatement}
+	 * @throws SQLException SQL异常
+	 */
+	private static void setFetchSize(PreparedStatement ps) throws SQLException {
+		if(GlobalDbConfig.statementFetchSize!=null)
+			ps.setFetchSize(GlobalDbConfig.statementFetchSize);
 	}
 	//--------------------------------------------------------------------------------------------- Private method end
 }


### PR DESCRIPTION
[新特性]

Db添加FetchSize的全局设置，用户可以根据内存性能自主调节JDBC每次结果集获取的记录数量，海量数据加载时可提高性能