### PR TITLE
fix 栗子 to 例子

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanPath.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanPath.java
@@ -20,7 +20,7 @@ import java.util.*;
  * <li>[]表达式，可以获取集合等对象中对应index的值</li>
  * </ol>
  * <p>
- * 表达式栗子：
+ * 表达式例子：
  *
  * <pre>
  * persion
@@ -53,7 +53,7 @@ public class BeanPath implements Serializable {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion

--- a/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileUtil.java
@@ -1665,7 +1665,7 @@ public class FileUtil extends PathUtil {
 	 * <li>4. .. 和 . 转换为绝对路径，当..多于已有路径时，直接返回根路径</li>
 	 * </ol>
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * "/foo//" =》 "/foo/"
@@ -1775,7 +1775,7 @@ public class FileUtil extends PathUtil {
 	/**
 	 * 获得相对子路径
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * dirPath: d:/aaa/bbb    filePath: d:/aaa/bbb/ccc     =》    ccc
@@ -1797,7 +1797,7 @@ public class FileUtil extends PathUtil {
 	/**
 	 * 获得相对子路径，忽略大小写
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * dirPath: d:/aaa/bbb    filePath: d:/aaa/bbb/ccc     =》    ccc

--- a/hutool-core/src/main/java/cn/hutool/core/lang/Dict.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Dict.java
@@ -519,7 +519,7 @@ public class Dict extends LinkedHashMap<String, Object> implements BasicTypeGett
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion
@@ -546,7 +546,7 @@ public class Dict extends LinkedHashMap<String, Object> implements BasicTypeGett
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion

--- a/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
@@ -2482,7 +2482,7 @@ public class CharSequenceUtil {
 	/**
 	 * 截取指定字符串中间部分，不包括标识字符串<br>
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * CharSequenceUtil.subBetween("wx[b]yz", "[", "]") = "b"
@@ -2525,7 +2525,7 @@ public class CharSequenceUtil {
 	/**
 	 * 截取指定字符串中间部分，不包括标识字符串<br>
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * CharSequenceUtil.subBetween(null, *)            = null
@@ -2548,7 +2548,7 @@ public class CharSequenceUtil {
 	/**
 	 * 截取指定字符串多段中间部分，不包括标识字符串<br>
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * CharSequenceUtil.subBetweenAll("wx[b]y[z]", "[", "]") 		= ["b","z"]
@@ -2603,7 +2603,7 @@ public class CharSequenceUtil {
 	/**
 	 * 截取指定字符串多段中间部分，不包括标识字符串<br>
 	 * <p>
-	 * 栗子：
+	 * 例子：
 	 *
 	 * <pre>
 	 * CharSequenceUtil.subBetweenAll(null, *)          			= []

--- a/hutool-core/src/main/java/cn/hutool/core/util/PhoneUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/PhoneUtil.java
@@ -97,7 +97,7 @@ public class PhoneUtil {
 
 	/**
 	 * 隐藏手机号前7位  替换字符为"*"
-	 * 栗子
+	 * 例子
 	 *
 	 * @param phone 手机号码
 	 * @return 替换后的字符串

--- a/hutool-json/src/main/java/cn/hutool/json/JSON.java
+++ b/hutool-json/src/main/java/cn/hutool/json/JSON.java
@@ -31,7 +31,7 @@ public interface JSON extends Cloneable, Serializable, IJSONTypeConverter {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion
@@ -56,7 +56,7 @@ public interface JSON extends Cloneable, Serializable, IJSONTypeConverter {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion
@@ -77,7 +77,7 @@ public interface JSON extends Cloneable, Serializable, IJSONTypeConverter {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion
@@ -104,7 +104,7 @@ public interface JSON extends Cloneable, Serializable, IJSONTypeConverter {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion

--- a/hutool-json/src/main/java/cn/hutool/json/JSONUtil.java
+++ b/hutool-json/src/main/java/cn/hutool/json/JSONUtil.java
@@ -537,7 +537,7 @@ public class JSONUtil {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion
@@ -562,7 +562,7 @@ public class JSONUtil {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion
@@ -601,7 +601,7 @@ public class JSONUtil {
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>
 	 * </ol>
 	 * <p>
-	 * 表达式栗子：
+	 * 表达式例子：
 	 *
 	 * <pre>
 	 * persion


### PR DESCRIPTION
修复注释中的文本错误，原错误文本【栗子】，修复后为【例子】