### PR TITLE
Fix: 修复 IPv4 转换后的 IPv6 地址转为大整数失败

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/net/NetUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/net/NetUtil.java
@@ -95,6 +95,9 @@ public class NetUtil {
 			if (address instanceof Inet6Address) {
 				return new BigInteger(1, address.getAddress());
 			}
+			if (address instanceof Inet4Address) {
+				return new BigInteger(1, address.getAddress());
+			}
 		} catch (UnknownHostException ignore) {
 		}
 		return null;

--- a/hutool-core/src/test/java/cn/hutool/core/net/NetUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/net/NetUtilTest.java
@@ -136,4 +136,15 @@ public class NetUtilTest {
 		String ipv6Address = NetUtil.bigIntegerToIPv6(bigInteger);
 		Assertions.assertEquals("0:115:85f1:5eb3:c74d:a870:11c6:7eea", ipv6Address);
 	}
+
+	@Test
+	void ipv6ToBigIntegerTest() {
+		BigInteger bigInteger = new BigInteger("21987654321098765432109876543210", 10);
+		BigInteger ipv6Address = NetUtil.ipv6ToBigInteger("0:115:85f1:5eb3:c74d:a870:11c6:7eea");
+		Assertions.assertEquals(bigInteger, ipv6Address);
+
+		bigInteger = new BigInteger("2886729738", 10);
+		ipv6Address = NetUtil.ipv6ToBigInteger("::ffff:ac10:000a");
+		Assertions.assertEquals(bigInteger, ipv6Address);
+	}
 }


### PR DESCRIPTION
### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 当 NetUtil.ipv6ToBigInteger 方法传入 IPv4 转换后的 IPv6 地址时（如 "::ffff:ac10:000a"），返回 null，不符合预期。原因：```InetAddress.getByName("::ffff:ac10:000a")``` 返回的是 Inet4Address 类型
<img width="1078" height="656" alt="NetUtil" src="https://github.com/user-attachments/assets/958783b2-bfd5-45bc-bec8-b233da6a4d77" />

