### PR TITLE
feat: 增加南大通用数据库`GBase8c`驱动支持

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/dialect/DialectFactory.java
+++ b/hutool-db/src/main/java/cn/hutool/db/dialect/DialectFactory.java
@@ -152,9 +152,6 @@ public class DialectFactory implements DriverNamePool {
 		} else if (nameContainsProductInfo.contains("zenith")) {
 			// 华为高斯
 			driver = DRIVER_GAUSS;
-		} else if (nameContainsProductInfo.contains("gbase")) {
-			// 南大通用数据库
-			driver = DRIVER_GBASE;
 		} else if (nameContainsProductInfo.contains("oscar")) {
 			// 神州数据库
 			driver = DRIVER_OSCAR;
@@ -174,8 +171,14 @@ public class DialectFactory implements DriverNamePool {
 			// sap hana
 			driver = DRIVER_HANA;
 		} else if (nameContainsProductInfo.contains("gbasedbt-sqli")) {
-			// Gbase8s，见：https://www.gbase.cn/community/post/4029
+			// GBase 8s，见：https://www.gbase.cn/community/post/4029
 			driver = DRIVER_GBASE8S;
+		} else if (nameContainsProductInfo.contains("gbase8c")) {
+			// GBase 8c，见：https://www.gbase.cn/download/gbase-8c?category=DRIVER_PACKAGE 页面 GBase8c_JDBC.zip 中的《JDBC 使用手册_V1.0_20230818.pdf》p14
+			driver = DRIVER_GBASE8C;
+		} else if (nameContainsProductInfo.contains("gbase")) {
+			// 南大通用数据库 GBase 8a
+			driver = DRIVER_GBASE;
 		}
 
 		return driver;

--- a/hutool-db/src/main/java/cn/hutool/db/dialect/DriverNamePool.java
+++ b/hutool-db/src/main/java/cn/hutool/db/dialect/DriverNamePool.java
@@ -101,14 +101,19 @@ public interface DriverNamePool {
 	 */
 	String DRIVER_GAUSS = "com.huawei.gauss.jdbc.ZenithDriver";
 	/**
-	 * JDBC 驱动 南大通用
+	 * JDBC 驱动 南大通用 GBase 8a
 	 */
 	String DRIVER_GBASE = "com.gbase.jdbc.Driver";
 	/**
-	 * JDBC 驱动 南大通用8S<br>
+	 * JDBC 驱动 南大通用 GBase 8s<br>
 	 * 见：https://www.gbase.cn/community/post/4029
 	 */
 	String DRIVER_GBASE8S = "com.gbasedbt.jdbc.Driver";
+	/**
+	 * JDBC 驱动 南大通用 GBase 8c<br>
+	 * 见：https://www.gbase.cn/download/gbase-8c?category=DRIVER_PACKAGE 页面 GBase8c_JDBC.zip 中的《JDBC 使用手册_V1.0_20230818.pdf》p14
+	 */
+	String DRIVER_GBASE8C = "cn.gbase8c.Driver";
 	/**
 	 * JDBC 驱动 神州数据库
 	 */


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1.在 DialectFactory 中添加了对 GBase8c 的支持，并修改匹配条件顺序
2.在 DriverNamePool 中添加了对应的驱动类名

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过