### PR TITLE
Fix 4006

### DIFF
--- a/hutool-cron/src/main/java/cn/hutool/cron/pattern/matcher/BoolArrayMatcher.java
+++ b/hutool-cron/src/main/java/cn/hutool/cron/pattern/matcher/BoolArrayMatcher.java
@@ -18,6 +18,10 @@ public class BoolArrayMatcher implements PartMatcher {
 	 * 用户定义此字段的最小值
 	 */
 	private final int minValue;
+	/**
+	 * 用户定义此字段的最大值
+	 */
+	private final int maxValue;
 	private final boolean[] bValues;
 
 	/**
@@ -29,13 +33,15 @@ public class BoolArrayMatcher implements PartMatcher {
 		Assert.isTrue(CollUtil.isNotEmpty(intValueList), "Values must be not empty!");
 		bValues = new boolean[Collections.max(intValueList) + 1];
 		int min = Integer.MAX_VALUE;
+		int max = Integer.MIN_VALUE;
 		for (Integer value : intValueList) {
 			min = Math.min(min, value);
+			max = Math.max(max, value);
 			bValues[value] = true;
 		}
 		this.minValue = min;
+		this.maxValue = max;
 	}
-
 	@Override
 	public boolean match(Integer value) {
 		if (null == value || value >= bValues.length) {
@@ -68,6 +74,14 @@ public class BoolArrayMatcher implements PartMatcher {
 	 */
 	public int getMinValue() {
 		return this.minValue;
+	}
+	/**
+	 * 获取表达式定义的最大值
+	 *
+	 * @return 最大值
+	 */
+	public int getMaxValue() {
+		return this.maxValue;
 	}
 
 	@Override

--- a/hutool-cron/src/main/java/cn/hutool/cron/pattern/matcher/DayOfMonthMatcher.java
+++ b/hutool-cron/src/main/java/cn/hutool/cron/pattern/matcher/DayOfMonthMatcher.java
@@ -50,8 +50,19 @@ public class DayOfMonthMatcher extends BoolArrayMatcher {
 		return value == Month.getLastDay(month - 1, isLeapYear);
 	}
 
+	@Deprecated
 	public boolean isLast() {
 		return match(31);
+	}
+
+	/**
+	 * 检查value是否大于等于这个月的最大天
+	 * @param value 被检查的值
+	 * @return
+	 */
+	public boolean isLastDay(int value) {
+		if(value>=getMaxValue()) return  true;
+		return  false;
 	}
 
 }

--- a/hutool-cron/src/main/java/cn/hutool/cron/pattern/matcher/PatternMatcher.java
+++ b/hutool-cron/src/main/java/cn/hutool/cron/pattern/matcher/PatternMatcher.java
@@ -192,7 +192,7 @@ public class PatternMatcher {
 			// pr#1189
 			if (i == Part.DAY_OF_MONTH.ordinal()
 				&& matchers[i] instanceof DayOfMonthMatcher
-				&& ((DayOfMonthMatcher) matchers[i]).isLast()) {
+				&& ((DayOfMonthMatcher) matchers[i]).isLastDay(values[i])) {
 				int newMonth = newValues[Part.MONTH.ordinal()];
 				int newYear = newValues[Part.YEAR.ordinal()];
 				nextValue = getLastDay(newMonth, newYear);
@@ -226,7 +226,7 @@ public class PatternMatcher {
 					continue;
 				} else if (i == Part.DAY_OF_MONTH.ordinal()
 					&& matchers[i] instanceof DayOfMonthMatcher
-					&& ((DayOfMonthMatcher) matchers[i]).isLast()) {
+					&& ((DayOfMonthMatcher) matchers[i]).isLastDay(values[i])) {
 					int newMonth = newValues[Part.MONTH.ordinal()];
 					int newYear = newValues[Part.YEAR.ordinal()];
 					nextValue = getLastDay(newMonth, newYear);
@@ -259,7 +259,7 @@ public class PatternMatcher {
 			part = Part.of(i);
 			if (part == Part.DAY_OF_MONTH
 				&& get(part) instanceof DayOfMonthMatcher
-				&& ((DayOfMonthMatcher) get(part)).isLast()) {
+				&& ((DayOfMonthMatcher) get(part)).isLastDay(values[i])) {
 				int newMonth = values[Part.MONTH.ordinal()];
 				int newYear = values[Part.YEAR.ordinal()];
 				values[i] = getLastDay(newMonth, newYear);

--- a/hutool-cron/src/test/java/cn/hutool/cron/pattern/Issue4006Test.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/pattern/Issue4006Test.java
@@ -1,0 +1,20 @@
+package cn.hutool.cron.pattern;
+
+import cn.hutool.core.date.DateTime;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+public class Issue4006Test {
+	@Test
+	void testCron() {
+//        String cron = "0 0 0 */1 * ?";
+		String cron = "0 0 0 */1 * ? *";
+		DateTime judgeTime = DateTime.of(new Date());
+		CronPattern cronPattern = new CronPattern(cron);
+
+		System.out.println("cronPattern = " + cronPattern);
+		Date nextDate = CronPatternUtil.nextDateAfter(cronPattern, judgeTime, true);
+		System.out.println("nextDate = " + nextDate);
+	}
+}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复]
   修复4006，问题原因：当使用*/1 时，数组下标为31的恒为true，导致一直得到31天
3. [新特性]  新增方法isLastDay()来判断是否是最后一天取代isLast()

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过