### PR TITLE
feat: 增加腾讯数据库TDSQL PostgreSQL版本、TDSQL-H LibraDB、Snowflake、Teradata驱动支持

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/dialect/DialectFactory.java
+++ b/hutool-db/src/main/java/cn/hutool/db/dialect/DialectFactory.java
@@ -179,6 +179,18 @@ public class DialectFactory implements DriverNamePool {
 		} else if (nameContainsProductInfo.contains("gbase")) {
 			// 南大通用数据库 GBase 8a
 			driver = DRIVER_GBASE;
+		} else if (nameContainsProductInfo.contains("tdsql-pg")) {
+			// 腾讯数据库 TDSQL PostgreSQL 版本，见：https://cloud.tencent.com/document/product/1129/116487
+			driver = DRIVER_TDSQL_POSTGRESQL;
+		} else if (nameContainsProductInfo.contains("clickhouse")) {
+			// 腾讯数据库 TDSQL-H LibraDB，见：https://cloud.tencent.com/document/product/1488/79810
+			driver = DRIVER_TDSQL_H_LIBRADB;
+		} else if (nameContainsProductInfo.contains("snowflake")) {
+			// Snowflake，见：https://docs.snowflake.cn/zh/developer-guide/jdbc/jdbc-configure#label-jdbc-connection-string
+			driver = DRIVER_SNOWFLAKE;
+		} else if (nameContainsProductInfo.contains("teradata")) {
+			// Teradata，见：https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/frameset.html 页面 JDBC Interfaces A-L 部分
+			driver = DRIVER_TERADATA;
 		}
 
 		return driver;

--- a/hutool-db/src/main/java/cn/hutool/db/dialect/DriverNamePool.java
+++ b/hutool-db/src/main/java/cn/hutool/db/dialect/DriverNamePool.java
@@ -115,6 +115,26 @@ public interface DriverNamePool {
 	 */
 	String DRIVER_GBASE8C = "cn.gbase8c.Driver";
 	/**
+	 * JDBC 驱动 腾讯 TDSQL PostgreSQL 版本<br>
+	 * 见：https://cloud.tencent.com/document/product/1129/116487
+	 */
+	String DRIVER_TDSQL_POSTGRESQL = "com.tencentcloud.tdsql.pg.jdbc.Driver";
+	/**
+	 * JDBC 驱动 腾讯 TDSQL-H LibraDB<br>
+	 * 见：https://cloud.tencent.com/document/product/1488/79810
+	 */
+	String DRIVER_TDSQL_H_LIBRADB = "ru.yandex.clickhouse.ClickHouseDriver";
+	/**
+	 * JDBC 驱动 Snowflake<br>
+	 * 见：https://docs.snowflake.cn/zh/developer-guide/jdbc/jdbc-configure#label-jdbc-connection-string
+	 */
+	String DRIVER_SNOWFLAKE = "net.snowflake.client.jdbc.SnowflakeDriver";
+	/**
+	 * JDBC 驱动 Teradata<br>
+	 * 见：https://teradata-docs.s3.amazonaws.com/doc/connectivity/jdbc/reference/current/frameset.html 页面 JDBC Interfaces A-L 部分
+	 */
+	String DRIVER_TERADATA = "com.teradata.jdbc.TeraDriver";
+	/**
 	 * JDBC 驱动 神州数据库
 	 */
 	String DRIVER_OSCAR = "com.oscar.Driver";


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. 在 DialectFactory 中添加了对TDSQL PostgreSQL版本、TDSQL-H LibraDB、Snowflake、Teradata 的支持，并修改匹配条件顺序
2. 在 DriverNamePool 中添加了对应的驱动类名

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过