### PR TITLE
issue-issues/4022（无冲突）

### DIFF
--- a/hutool-cache/src/main/java/cn/hutool/cache/impl/AbstractCache.java
+++ b/hutool-cache/src/main/java/cn/hutool/cache/impl/AbstractCache.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -37,6 +38,16 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
 	 * 写的时候每个key一把锁，降低锁的粒度
 	 */
 	protected final SafeConcurrentHashMap<K, Lock> keyLockMap = new SafeConcurrentHashMap<>();
+
+	/**
+	 * 记录 key 当前的持有线程
+	 */
+	private final ConcurrentHashMap<K, Thread> ownerMap = new ConcurrentHashMap<>();
+
+	/**
+	 * 记录等待关系：thread -> 被哪个线程阻塞
+	 */
+	private final ConcurrentHashMap<Thread, Thread> waitForMap = new ConcurrentHashMap<>();
 
 	/**
 	 * 返回缓存容量，{@code 0}表示无大小限制
@@ -131,38 +142,63 @@ public abstract class AbstractCache<K, V> implements Cache<K, V> {
 	@Override
 	public V get(K key, boolean isUpdateLastAccess, long timeout, Func0<V> supplier) {
 		V v = get(key, isUpdateLastAccess);
-		if (null == v && null != supplier) {
-			// 在尝试加锁前，检查当前线程是否已经在加载这个 key，见：issue#4022
-			// 如果是，则说明发生了循环依赖。
-			if (loadingKeys.get().contains(key)) {
-				throw new IllegalStateException("Circular dependency detected for key: " + key);
-			}
-
-			//每个key单独获取一把锁，降低锁的粒度提高并发能力，see pr#1385@Github
-			final Lock keyLock = keyLockMap.computeIfAbsent(key, k -> new ReentrantLock());
-			keyLock.lock();
-			try {
-				// 双重检查锁，防止在竞争锁的过程中已经有其它线程写入
-				// issue#3686 由于这个方法内的加锁是get独立锁，不和put锁互斥，而put和pruneCache会修改cacheMap，导致在pruneCache过程中get会有并发问题
-				// 因此此处需要使用带全局锁的get获取值
-				v = get(key, isUpdateLastAccess);
-				if (null == v) {
-					loadingKeys.get().add(key);
-					// supplier的创建是一个耗时过程，此处创建与全局锁无关，而与key锁相关，这样就保证每个key只创建一个value，且互斥
-					try {
-						v = supplier.callWithRuntimeException();
-						put(key, v, timeout);
-					} finally {
-						// 无论 supplier 执行成功还是失败，都必须在 finally 块中移除标记
-						loadingKeys.get().remove(key);
-					}
-				}
-			} finally {
-				keyLock.unlock();
-				keyLockMap.remove(key);
+		if (v != null || supplier == null) {
+			return v;
+		}
+		//每个key单独获取一把锁，降低锁的粒度提高并发能力，see pr#1385@Github
+		final Lock keyLock = keyLockMap.computeIfAbsent(key, k -> new ReentrantLock());
+		Thread current = Thread.currentThread();
+		Thread owner = ownerMap.get(key);
+		// 如果 key 已经被其他线程持有，先登记等待关系并检测是否形成环
+		if (owner != null && owner != current) {
+			waitForMap.put(current, owner);
+			if (detectCycle(current)) {
+				waitForMap.remove(current);
+				String msg = "Detected potential deadlock: thread=" + current.getName() + " is waiting for key=" + key;
+				throw new IllegalStateException(msg);
 			}
 		}
+		keyLock.lock();
+		try {
+			// 加锁成功：key被当前线程持有
+			ownerMap.put(key, current);
+			waitForMap.remove(current);
+			// 双重检查锁，防止在竞争锁的过程中已经有其它线程写入
+			// issue#3686 由于这个方法内的加锁是get独立锁，不和put锁互斥，而put和pruneCache会修改cacheMap，导致在pruneCache过程中get会有并发问题
+			// 因此此处需要使用带全局锁的get获取值
+			v = get(key, isUpdateLastAccess);
+			if (v == null) {
+				// supplier的创建是一个耗时过程，此处创建与全局锁无关，而与key锁相关，这样就保证每个key只创建一个value，且互斥
+				v = supplier.callWithRuntimeException();
+				put(key, v, timeout);
+			}
+		} finally {
+			ownerMap.remove(key);
+			keyLock.unlock();
+			keyLockMap.remove(key);
+		}
 		return v;
+	}
+
+	/**
+	 * 检测是否形成等待环（死锁）
+	 * @param start 等待环开启的线程
+	 * @return boolean
+	 * @since 5.8.40
+	 */
+	protected boolean detectCycle(Thread start) {
+		Thread slow = start;
+		Thread fast = waitForMap.get(start);
+
+		while (fast != null) {
+			if (fast == slow) {
+				return true; // 检测到环
+			}
+			// 判圈算法：慢指针走一步，快指针走两步
+			slow = waitForMap.get(slow);
+			fast = waitForMap.get(waitForMap.get(fast));
+		}
+		return false;
 	}
 
 	/**

--- a/hutool-cache/src/test/java/cn/hutool/cache/CacheConcurrentTest.java
+++ b/hutool-cache/src/test/java/cn/hutool/cache/CacheConcurrentTest.java
@@ -11,7 +11,11 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicInteger;
-
+import cn.hutool.core.lang.func.Func0;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 /**
  * 缓存单元测试
  *
@@ -103,5 +107,59 @@ public class CacheConcurrentTest {
 		long interval = concurrencyTester.getInterval();
 		// 总耗时应与单次操作耗时在同一个数量级
 		assertTrue(interval < delay * 2);
+	}
+	/**
+	 * 测试嵌套get调用可能导致的死锁：https://github.com/chinabugotech/hutool/issues/4022
+	 */
+	@Test
+	public  void nestedGetDeadlockTest() throws Exception {
+		final Cache<String, String> cache = new LRUCache<>(100);
+
+		final String key1 = "key1";
+		final String key2 = "key2";
+
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		CountDownLatch latch = new CountDownLatch(2);
+		// 线程1：key1 -> key2
+		executor.submit(() -> {
+			try {
+				String result = cache.get(key1, new Func0<String>() {
+					@Override
+					public String call() throws Exception {
+						Thread.sleep(100);
+						return cache.get(key2, () -> "value2") + "-nested";
+					}
+				});
+			} catch (Exception e) {
+				System.err.println("线程1异常: " + e);
+			}
+			finally {
+				latch.countDown();
+			}
+		});
+
+		// 线程2：key2 -> key1
+		executor.submit(() -> {
+			try {
+				String result = cache.get(key2, new Func0<String>() {
+					@Override
+					public String call() throws Exception {
+						Thread.sleep(100);
+						return cache.get(key1, () -> "value1") + "-nested";
+					}
+				});
+			} catch (Exception e) {
+				System.err.println("线程2异常: " + e);
+			} finally {
+				latch.countDown();
+			}
+		});
+
+		// 设置超时检测死锁
+		if (!latch.await(5, TimeUnit.SECONDS)) {
+			System.out.println("检测到可能的死锁!");
+		}
+		executor.shutdown();
+
 	}
 }


### PR DESCRIPTION
说明
请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
请确认没有更改代码风格（如tab缩进）
新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例
修改描述(包括说明bug修复或者添加新特性)

[bug修复]
一、新增两个映射
ownerMap：记录每个 key 当前的持有线程。
waitForMap：记录线程等待的关系（thread -> 它在等待哪个线程）。
二、在尝试加锁之前检测环
如果 key 被别的线程持有，则在 waitForMap 中登记依赖关系。
调用 detectCycle 检查是否有环，若有-> 抛异常。
三、加锁成功后更新 ownerMap 并清除 waitForMap，线程拿到锁以后，已经不再等待别人了。
四、解锁时清理 ownerMap

修改核心代码如下

```
public abstract class AbstractCache<K, V> implements Cache<K, V> {
         /**
	 * 记录 key 当前的持有线程
	 */
	private final ConcurrentHashMap<K, Thread> ownerMap = new ConcurrentHashMap<>();

	/**
	 * 记录等待关系：thread -> 被哪个线程阻塞
	 */
	private final ConcurrentHashMap<Thread, Thread> waitForMap = new ConcurrentHashMap<>();
        @Override
	public V get(K key, boolean isUpdateLastAccess, long timeout, Func0<V> supplier) {
		V v = get(key, isUpdateLastAccess);
		if (v != null || supplier == null) {
			return v;
		}
		//每个key单独获取一把锁，降低锁的粒度提高并发能力，see pr#1385@Github
		final Lock keyLock = keyLockMap.computeIfAbsent(key, k -> new ReentrantLock());
		Thread current = Thread.currentThread();
		Thread owner = ownerMap.get(key);
		// 如果 key 已经被其他线程持有，先登记等待关系并检测是否形成环
		if (owner != null && owner != current) {
			waitForMap.put(current, owner);
			if (detectCycle(current)) {
				waitForMap.remove(current);
				String msg = "Detected potential deadlock: thread=" + current.getName() + " is waiting for key=" + key;
				throw new IllegalStateException(msg);
			}
		}
		keyLock.lock();
		try {
			// 加锁成功：我是 key 的 owner
			ownerMap.put(key, current);
			waitForMap.remove(current);
			// 双重检查锁，防止在竞争锁的过程中已经有其它线程写入
			// issue#3686 由于这个方法内的加锁是get独立锁，不和put锁互斥，而put和pruneCache会修改cacheMap，导致在pruneCache过程中get会有并发问题
			// 因此此处需要使用带全局锁的get获取值
			v = get(key, isUpdateLastAccess);
			if (v == null) {
				// supplier的创建是一个耗时过程，此处创建与全局锁无关，而与key锁相关，这样就保证每个key只创建一个value，且互斥
				v = supplier.callWithRuntimeException();
				put(key, v, timeout);
			}
		} finally {
			ownerMap.remove(key);
			keyLock.unlock();
			keyLockMap.remove(key);
		}
		return v;
	}

	/**
	 * 检测是否形成等待环（死锁）
	 * @param start 等待环开启的线程
	 * @return boolean
	 * @since 5.8.40
	 */
	protected boolean detectCycle(Thread start) {
		Thread slow = start;
		Thread fast = waitForMap.get(start);

		while (fast != null) {
			if (fast == slow) {
				return true; // 检测到环
			}
			// 判圈算法：慢指针走一步，快指针走两步
			slow = waitForMap.get(slow);
			fast = waitForMap.get(waitForMap.get(fast));
		}
		return false;
	}
}
```
提交前自测
执行CacheConcurrentTest.nestedGetDeadlockTest()方法

修复AbstrachCache.get(K key, Func0 supplier) 方法桥套调用时候出现死锁 issues/4022