### PR TITLE
Fix issue 4066

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/DialectRunner.java
+++ b/hutool-db/src/main/java/cn/hutool/db/DialectRunner.java
@@ -14,6 +14,8 @@ import cn.hutool.db.sql.SqlBuilder;
 import cn.hutool.db.sql.SqlExecutor;
 import cn.hutool.db.sql.SqlUtil;
 import cn.hutool.db.sql.Wrapper;
+import cn.hutool.log.Log;
+import cn.hutool.log.LogFactory;
 
 import java.io.Serializable;
 import java.sql.Connection;
@@ -30,6 +32,7 @@ import java.util.regex.Pattern;
  */
 public class DialectRunner implements Serializable {
 	private static final long serialVersionUID = 1L;
+	private final static Log log = LogFactory.get();
 
 	private Dialect dialect;
 	/**
@@ -103,9 +106,9 @@ public class DialectRunner implements Serializable {
 	 */
 	public int upsert(Connection conn, Entity record, String... keys) throws SQLException {
 		PreparedStatement ps = null;
-		try{
+		try {
 			ps = getDialect().psForUpsert(conn, record, keys);
-		}catch (SQLException ignore){
+		} catch (SQLException ignore) {
 			// 方言不支持，使用默认
 		}
 		if (null != ps) {
@@ -278,16 +281,41 @@ public class DialectRunner implements Serializable {
 		String selectSql = sqlBuilder.build();
 
 		// 去除order by 子句
-		final Pattern pattern = PatternPool.get("(.*?)[\\s]order[\\s]by[\\s][^\\s]+\\s(asc|desc)?", Pattern.CASE_INSENSITIVE);
-		final Matcher matcher = pattern.matcher(selectSql);
-		if (matcher.matches()) {
-			selectSql = matcher.group(1);
-		}
+		selectSql = removeOuterOrderBy(selectSql);
 
 		return SqlExecutor.queryAndClosePs(dialect.psForCount(conn,
 				SqlBuilder.of(selectSql).addParams(sqlBuilder.getParamValueArray())),
-				new NumberHandler()).longValue();
+			new NumberHandler()).longValue();
 	}
+
+	/**
+	 * 移除 SQL中的 ORDER BY 子句
+	 *
+	 * @param sql 原始 SQL
+	 * @return 移除 ORDER BY 子句后的 SQL
+	 */
+	public String removeOuterOrderBy(String sql) {
+		if (StrUtil.isBlank(sql)) {
+			return sql;
+		}
+
+		try {
+			String upperSql = sql.toUpperCase();
+
+			// 确定ORDER BY的位置
+			int orderByPos = upperSql.lastIndexOf(" ORDER BY ");
+
+			if (orderByPos != -1) {
+				// 返回 ORDER BY 之前的部分
+				return sql.substring(0, orderByPos).trim();
+			}
+		} catch (Exception e) {
+			log.error(e);
+		}
+
+		return sql;
+	}
+
 
 	/**
 	 * 分页查询<br>

--- a/hutool-db/src/test/java/cn/hutool/db/DialectRunnerTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/DialectRunnerTest.java
@@ -1,0 +1,40 @@
+package cn.hutool.db;
+
+import org.junit.jupiter.api.Test;
+import cn.hutool.db.dialect.Dialect;
+import cn.hutool.db.dialect.DialectFactory;
+import static org.junit.jupiter.api.Assertions.*;
+
+class DialectRunnerTest {
+    /**
+     * 基础测试：简单的 ORDER BY 语句
+     */
+    @Test
+    public void removeOuterOrderByTest1() {
+
+        Dialect dialect = DialectFactory.newDialect("com.mysql.jdbc.Driver");
+        DialectRunner dialectRunner = new DialectRunner(dialect);
+
+        // 测试基本的ORDER BY移除
+        String sql = "SELECT * FROM users ORDER BY name";
+        String result = dialectRunner.removeOuterOrderBy(sql);
+
+        assertEquals("SELECT * FROM users", result);
+    }
+
+    /**
+     * 多字段 ORDER BY 测试：包含多个排序字段的复杂 ORDER BY语句
+     */
+    @Test
+    public void removeOuterOrderByTest2() {
+
+        Dialect dialect = DialectFactory.newDialect("com.mysql.jdbc.Driver");
+        DialectRunner dialectRunner = new DialectRunner(dialect);
+
+        // 测试多字段ORDER BY移除
+        String sql = "SELECT id, name, age FROM users WHERE status = 'active' ORDER BY name ASC, age DESC, created_date";
+        String result = dialectRunner.removeOuterOrderBy(sql);
+
+        assertEquals("SELECT id, name, age FROM users WHERE status = 'active'", result);
+    }
+}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] Fix issue 4066，修复在使用DialectRunner类的count(Connection conn, SqlBuilder sqlBuilder)方法，在去除SQL语句中包含多个字段的order by子句时，正则表达式匹配失败导致去除order by子句功能失效的问题，并添加对应的测试案例。

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过