### PR TITLE
Update EnumUtil.java

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/EnumUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/EnumUtil.java
@@ -482,4 +482,35 @@ public class EnumUtil {
 		}
 		return CACHE.computeIfAbsent(enumClass, (k) -> enumClass.getEnumConstants());
 	}
+	 /**
+     * 获取指定枚举类的所有枚举常量。
+     *
+     * <p>该方法会调用 {@link Class#getEnumConstants()} 来获取枚举常量。
+     * 如果传入的 class 不是枚举类型，返回值为 {@code null}，这里为了安全返回一个空列表。</p>
+     *
+     * <p>示例：</p>
+     * <pre>{@code
+     * enum Color {
+     *     RED, GREEN, BLUE
+     * }
+     *
+     * List<Color> colors = EnumUtils.getAll(Color.class);
+     * System.out.println(colors); // 输出 [RED, GREEN, BLUE]
+     * }</pre>
+     *
+     * @param clazz 枚举类的 Class 对象，必须是 {@link Enum} 的子类，不能为 {@code null}
+     * @param <E>   枚举类型的泛型参数，例如 Color、DayOfWeek 等
+     * @return 包含所有枚举常量的不可修改列表，如果 clazz 为 {@code null} 或不是枚举类，则返回空列表
+     */
+    public static <E extends Enum<E>> List<E> getAll(Class<E> clazz) {
+        if (clazz == null) {
+            return Collections.emptyList();
+        }
+        E[] constants = clazz.getEnumConstants();
+        if (constants == null) {
+            // clazz 不是枚举类型时 getEnumConstants() 返回 null
+            return Collections.emptyList();
+        }
+        return Arrays.asList(constants);
+    }
 }


### PR DESCRIPTION
feat(util): add EnumUtils.getAll with full Javadoc

- 新增通用方法 getAll(Class<E>)，用于获取指定枚举类的所有枚举常量
- 支持空安全处理，当传入 null 或非枚举类时返回空列表
- 添加完整的 Javadoc，包括示例、参数、返回值和注意事项说明

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过