### PR TITLE
[Fix issue#4077] 并发场景下 Sftp.close 报 ConcurrentModificationException

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/SimpleCache.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/SimpleCache.java
@@ -190,4 +190,22 @@ public class SimpleCache<K, V> implements Iterable<Map.Entry<K, V>>, Serializabl
 			}
 		});
 	}
+
+	// ===================== 新增方法 =====================
+
+	/**
+	 * 获取读锁
+	 * 外部可用于迭代时加锁，防止并发修改异常
+	 */
+	public Lock readLock() {
+		return this.lock.readLock();
+	}
+
+	/**
+	 * 获取写锁
+	 * 外部可用于迭代+修改时加锁
+	 */
+	public Lock writeLock() {
+		return this.lock.writeLock();
+	}
 }

--- a/hutool-extra/src/main/java/cn/hutool/extra/ssh/JschSessionPool.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/ssh/JschSessionPool.java
@@ -7,6 +7,7 @@ import com.jcraft.jsch.Session;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map.Entry;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Jsch会话池
@@ -106,7 +107,12 @@ public enum JschSessionPool {
 	 * @since 4.1.15
 	 */
 	public void remove(Session session) {
-		if (null != session) {
+		if(null == session)  return;
+
+		// 使用 SimpleCache 的写锁保证迭代安全
+		Lock writeLock = this.cache.writeLock();
+		writeLock.lock();
+		try {
 			final Iterator<Entry<String, Session>> iterator = this.cache.iterator();
 			Entry<String, Session> entry;
 			while (iterator.hasNext()) {
@@ -116,6 +122,8 @@ public enum JschSessionPool {
 					break;
 				}
 			}
+		}finally {
+			writeLock.unlock();
 		}
 	}
 


### PR DESCRIPTION
### 问题描述
在多线程环境下，使用 Sftp.close() 关闭会话时，会抛出：
java.util.ConcurrentModificationException
at JschSessionPool.remove(JschSessionPool.java:115)
原因：在迭代 HashMap 时未加锁，导致并发修改异常。

### 修改方案
1. SimpleCache.java
   - 增加 readLock() / writeLock() 方法；
   - 保留原有锁和 key 级别锁，保证原有性能优化。
2. JschSessionPool.java
   - remove(Session) 方法加写锁包裹迭代操作，避免 ConcurrentModificationException。
3. 保持原有缓存逻辑和接口不变。

### 测试
- 多线程下 Sftp.close() 多次调用，未再出现异常。
- 单线程下行为保持一致。

### 影响
- 仅对并发 SFTP session 移除操作有影响。
- 向下兼容原有 API。
