### PR TITLE
fix:SqlUtil#removeOuterOrderBy处理没有order by的语句导致异常

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/sql/SqlUtil.java
+++ b/hutool-db/src/main/java/cn/hutool/db/sql/SqlUtil.java
@@ -270,7 +270,8 @@ public class SqlUtil {
 	 */
 	public static String removeOuterOrderBy(final String selectSql) {
 		// 去除order by 子句
-		return ReUtil.getGroup1(PATTERN_ORDER_BY, selectSql);
+		String sql = ReUtil.getGroup1(PATTERN_ORDER_BY, selectSql);
+		return sql == null ? selectSql : sql;
 	}
 
 	/**

--- a/hutool-db/src/test/java/cn/hutool/db/sql/Issue4066Test.java
+++ b/hutool-db/src/test/java/cn/hutool/db/sql/Issue4066Test.java
@@ -28,4 +28,15 @@ public class Issue4066Test {
 
 		assertEquals("SELECT id, name, age FROM users WHERE status = 'active'", result);
 	}
+
+	/**
+	 * 测试不含Order by的语句
+	 */
+	@Test
+	public void removeOuterOrderByTest3() {
+		final String sql = "SELECT * FROM users";
+		final String result = SqlUtil.removeOuterOrderBy(sql);
+
+		assertEquals("SELECT * FROM users", result);
+	}
 }


### PR DESCRIPTION
Db.use().count("select * from user")出错

现象：
测试用例 cn.hutool.db.DbTest#countTest 失败，生成的SQL如下语法错误
[SQL] -> SELECT
        count(*) 
    from
        () hutool_alias_count_
        
原因：
cn.hutool.db.sql.SqlUtil#removeOuterOrderBy中调用ReUtil.getGroup1，当sql中没有group by语句时，会返回null导致了异常（有group by时不会报错）

解决办法：
public static String removeOuterOrderBy(final String selectSql) {
		// 去除order by 子句
		String sql = ReUtil.getGroup1(PATTERN_ORDER_BY, selectSql);
		return sql == null ? selectSql : sql;
	}
	
修改后SQL结果：
[SQL] -> SELECT
        count(*) 
    from
        (select
            * 
        from
            user) hutool_alias_count_