### PR TITLE
fix(dfa): 修复WordTree.addWord在关键词以停顿词结尾时词尾标记错误的问题

### DIFF
--- a/hutool-dfa/src/main/java/cn/hutool/dfa/WordTree.java
+++ b/hutool-dfa/src/main/java/cn/hutool/dfa/WordTree.java
@@ -102,23 +102,22 @@ public class WordTree extends HashMap<Character, WordTree> {
 		WordTree parent = null;
 		WordTree current = this;
 		WordTree child;
-		char currentChar = 0;
+		Character lastAcceptedChar = null;
+
 		final int length = word.length();
 		for (int i = 0; i < length; i++) {
-			currentChar = word.charAt(i);
+			char currentChar = word.charAt(i);
 			if (charFilter.accept(currentChar)) {//只处理合法字符
-				child = current.get(currentChar);
-				if (child == null) {
-					//无子类，新建一个子节点后存放下一个字符
-					child = new WordTree();
-					current.put(currentChar, child);
-				}
+				child = current.computeIfAbsent(currentChar, c -> new WordTree());
 				parent = current;
 				current = child;
+				lastAcceptedChar = currentChar;
 			}
 		}
+		// 仅当存在父节点且存在非停顿词时，才设置词尾标记
+		// 当 null != parent 条件成立时，lastAcceptedChar != null 必然成立，故也可以省去
 		if (null != parent) {
-			parent.setEnd(currentChar);
+			parent.setEnd(lastAcceptedChar);
 		}
 		return this;
 	}

--- a/hutool-dfa/src/test/java/cn/hutool/dfa/DfaTest.java
+++ b/hutool-dfa/src/test/java/cn/hutool/dfa/DfaTest.java
@@ -118,12 +118,12 @@ public class DfaTest {
 
 	/**
 	 * Github Issue #4091
-	 * 测试当关键词以停顿词（如括号）结尾时，其合法前缀是否能被正确匹配
+	 * 测试当关键词以停顿词结尾时，其合法前缀是否能被正确匹配
 	 */
 	@Test
 	public void addWordWithTrailingFilteredCharTest() {
 		WordTree tree = new WordTree();
-		tree.addWord("hello "); // 以被过滤字符结尾
+		tree.addWord("hello("); // 以停顿词 '(' 结尾
 
 		List<String> matches = tree.matchAll("hello", -1);
 		assertEquals(1, matches.size());
@@ -137,7 +137,7 @@ public class DfaTest {
 	@Test
 	public void addWordWithMiddleFilteredCharTest() {
 		WordTree tree = new WordTree();
-		tree.addWord("he llo"); // 中间 '(' 被过滤
+		tree.addWord("he(llo"); // 中间 '(' 被过滤
 
 		List<String> matches = tree.matchAll("hello", -1);
 		assertEquals(1, matches.size());

--- a/hutool-dfa/src/test/java/cn/hutool/dfa/DfaTest.java
+++ b/hutool-dfa/src/test/java/cn/hutool/dfa/DfaTest.java
@@ -116,6 +116,34 @@ public class DfaTest {
 		assertEquals(all, CollUtil.newArrayList("t-io"));
 	}
 
+	/**
+	 * Github Issue #4091
+	 * 测试当关键词以停顿词（如括号）结尾时，其合法前缀是否能被正确匹配
+	 */
+	@Test
+	public void addWordWithTrailingFilteredCharTest() {
+		WordTree tree = new WordTree();
+		tree.addWord("hello "); // 以被过滤字符结尾
+
+		List<String> matches = tree.matchAll("hello", -1);
+		assertEquals(1, matches.size());
+		assertEquals("hello", matches.get(0));
+	}
+
+	/**
+	 * Github Issue #4091
+	 * 测试关键词中间包含停顿词的情况
+	 */
+	@Test
+	public void addWordWithMiddleFilteredCharTest() {
+		WordTree tree = new WordTree();
+		tree.addWord("he llo"); // 中间 '(' 被过滤
+
+		List<String> matches = tree.matchAll("hello", -1);
+		assertEquals(1, matches.size());
+		assertEquals("hello", matches.get(0));
+	}
+
 	@Test
 	public void aTest(){
 		WordTree tree = new WordTree();


### PR DESCRIPTION
Fixes #4091

### 问题描述

当使用 `WordTree.addWord("hh(")` 添加一个以停顿词（如 `'('`）结尾的关键词时，该关键词的合法前缀（如 `"hh"`）无法被 `matchAll` 正确匹配，返回空列表。

### 根本原因

`addWord` 方法在循环结束后，使用原始字符串的最后一个字符（`currentChar`）调用 `parent.setEnd(currentChar)`。如果该字符被 `charFilter` 过滤，则 `setEnd` 会设置一个无效的结束标记（因为该字符并未真正插入到 `WordTree` 中）。

### 修复方案

引入 `lastAcceptedChar` 变量，仅在字符被 `charFilter` 接受时更新它，并在最后使用该变量调用 `setEnd`，确保结束标记始终基于合法字符。

### 验证

新增两个单元测试：
- `addWordWithTrailingFilteredCharTest`：验证结尾带过滤字符的情况。
- `addWordWithMiddleFilteredCharTest`：验证中间带过滤字符的情况。

已通过相关测试。