### PR TITLE
feat:修复PasswdStrength.check方法检测密码强度等级逻辑有误问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/PasswdStrength.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/PasswdStrength.java
@@ -15,7 +15,7 @@ public class PasswdStrength {
 	 * 密码等级枚举
 	 */
 	public enum PASSWD_LEVEL {
-		EASY, MIDIUM, STRONG, VERY_STRONG, EXTREMELY_STRONG
+		EASY, MEDIUM, STRONG, VERY_STRONG, EXTREMELY_STRONG
 	}
 
 	/**
@@ -124,14 +124,16 @@ public class PasswdStrength {
 			}
 		}
 
-		// decrease points
-		if ("abcdefghijklmnopqrstuvwxyz".indexOf(passwd) > 0 || "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(passwd) > 0) {
+		// 判断passwd是否为连续字母（a-z/A-Z）的完整子串
+		if ("abcdefghijklmnopqrstuvwxyz".contains(passwd) || "ABCDEFGHIJKLMNOPQRSTUVWXYZ".contains(passwd)) {
 			level--;
 		}
-		if ("qwertyuiop".indexOf(passwd) > 0 || "asdfghjkl".indexOf(passwd) > 0 || "zxcvbnm".indexOf(passwd) > 0) {
+		// 判断passwd是否为键盘连续序列的完整子串
+		if ("qwertyuiop".contains(passwd) || "asdfghjkl".contains(passwd) || "zxcvbnm".contains(passwd)) {
 			level--;
 		}
-		if (StrUtil.isNumeric(passwd) && ("01234567890".indexOf(passwd) > 0 || "09876543210".indexOf(passwd) > 0)) {
+		// 判断passwd是否为纯数字弱密码（升序或降序）的完整子串
+		if (StrUtil.isNumeric(passwd) && ("01234567890".contains(passwd) || "09876543210".contains(passwd))) {
 			level--;
 		}
 
@@ -172,8 +174,9 @@ public class PasswdStrength {
 			}
 		}
 
+		// 检测密码是否为简单密码字典中的弱密码或包含字典弱密码片段
 		for (String s : DICTIONARY) {
-			if (passwd.equals(s) || s.contains(passwd)) {
+			if (passwd.equals(s) || passwd.contains(s)) {
 				level--;
 				break;
 			}
@@ -201,7 +204,7 @@ public class PasswdStrength {
 	}
 
 	/**
-	 * Get password strength level, includes easy, midium, strong, very strong, extremely strong
+	 * 获取密码强度等级, 包括 easy, medium, strong, very strong, extremely strong
 	 *
 	 * @param passwd 密码
 	 * @return 密码等级枚举
@@ -217,7 +220,7 @@ public class PasswdStrength {
 			case 4:
 			case 5:
 			case 6:
-				return PASSWD_LEVEL.MIDIUM;
+				return PASSWD_LEVEL.MEDIUM;
 			case 7:
 			case 8:
 			case 9:
@@ -232,8 +235,7 @@ public class PasswdStrength {
 	}
 
 	/**
-	 * Check character's type, includes num, capital letter, small letter and other character.
-	 * 检查字符类型
+	 * 检查字符类型，包括数字、大写字母、小写字母及其他字符
 	 *
 	 * @param c 字符
 	 * @return 类型

--- a/hutool-core/src/test/java/cn/hutool/core/text/PasswdStrengthTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/PasswdStrengthTest.java
@@ -15,4 +15,25 @@ public class PasswdStrengthTest {
 		String passwd = "9999999999999";
 		assertEquals(0, PasswdStrength.check(passwd));
 	}
+
+	@Test
+	public void consecutiveLettersTest() {
+		// 测试连续小写字母会被降级
+		assertEquals(0, PasswdStrength.check("abcdefghijklmn"));
+		// 测试连续大写字母会被降级
+		assertEquals(0, PasswdStrength.check("ABCDEFGHIJKLMN"));
+	}
+
+	@Test
+	public void dictionaryWeakPasswordTest() {
+		// 测试包含简单密码字典中的弱密码
+		assertEquals(0, PasswdStrength.check("password"));
+		assertEquals(2, PasswdStrength.check("password2"));
+	}
+
+	@Test
+	public void numericSequenceTest() {
+		assertEquals(0, PasswdStrength.check("01234567890"));
+		assertEquals(0, PasswdStrength.check("09876543210"));
+	}
 }


### PR DESCRIPTION
### 问题描述及原因

1. 在`PasswdStrength.check()`方法中，针对密码强度等级判断使用
```
if ("abcdefghijklmnopqrstuvwxyz".indexOf(passwd) > 0 || "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(passwd) > 0) {
    level--;
}
```
会遗漏`.indexOf(passwd) == 0`的情况(如`abcdefghijklmn`)，导致密码等级判断不符合预期。
2.`PasswdStrength.check()`方法中，检测密码是否包含简单密码字典中的弱密码时，`s.contains(passwd) `的逻辑为：字典项是否包含密码，但应当检测密码中是否包含字典项。
3.密码等级枚举`PASSWD_LEVEL`中拼写有误。

### 修改描述(bug修复)

1. 在`PasswdStrength.check()`方法中，采用`"abcdefghijklmnopqrstuvwxyz".contains(passwd)`进行判断，`String.contains()`底层代码逻辑就是`indexOf(s.toString()) >= 0`。
2. 检查简单密码字典中的弱密码时，采用`passwd.contains(s)`判断密码中是否包含字典项。
3. 将密码等级枚举`PASSWD_LEVEL`中的`MIDIUM`修改为`MEDIUM`。
4. 在`PasswdStrengthTest`测试类中增加对应的测试案例

### 验证
新增3个单元测试：
* `consecutiveLettersTest` ：验证连续大、小写字母会被降级（以index = 0开始的子串）的情况
* `dictionaryWeakPasswordTest` ：验证包含简单密码字典中的弱密码会被降级的情况
* `numericSequenceTest` ：验证连续数字（升序和降序）会被降级的情况
* 修复前测试结果：
![image1](https://github.com/sunshineflymeat/images/blob/main/hutool/PasswdStrengthTest1.png?raw=true)
* 修复后测试结果：
![image1](https://github.com/sunshineflymeat/images/blob/main/hutool/PasswdStrengthTest2.png?raw=true)