### PR TITLE
feat:优化NamedSql对行构造器的处理

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/sql/NamedSql.java
+++ b/hutool-db/src/main/java/cn/hutool/db/sql/NamedSql.java
@@ -138,8 +138,8 @@ public class NamedSql {
 		if(paramMap.containsKey(nameStr)) {
 			// 有变量对应值（值可以为null），替换占位符为?，变量值放入相应index位置
 			final Object paramValue = paramMap.get(nameStr);
-			if(ArrayUtil.isArray(paramValue) && SqlUtil.isInClause(sqlBuilder)){
-				// 可能为select in (xxx)语句，则拆分参数为多个参数，变成in (?,?,?)
+			if(ArrayUtil.isArray(paramValue)){
+				// 若参数为数组，则拆分参数为多个参数，类似in (?,?,?)
 				final int length = ArrayUtil.length(paramValue);
 				for (int i = 0; i < length; i++) {
 					if(0 != i){

--- a/hutool-db/src/test/java/cn/hutool/db/NamedSqlTest.java
+++ b/hutool-db/src/test/java/cn/hutool/db/NamedSqlTest.java
@@ -5,9 +5,7 @@ import cn.hutool.db.sql.NamedSql;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -88,6 +86,31 @@ public class NamedSqlTest {
 	}
 
 	@Test
+	public void parseAnyTest(){
+		final HashMap<String, Object> paramMap = MapUtil.of("number", new int[]{1, 2, 3});
+
+		NamedSql namedSql = new NamedSql("select case when 2 = any(ARRAY[:number]) and 1 in (1) then 1 else 0 end;", paramMap);
+		assertEquals("select case when 2 = any(ARRAY[?,?,?]) and 1 in (1) then 1 else 0 end;", namedSql.getSql());
+		assertEquals(1, namedSql.getParams()[0]);
+		assertEquals(2, namedSql.getParams()[1]);
+		assertEquals(3, namedSql.getParams()[2]);
+	}
+
+	@Test
+	public void parseInsertMultiRowTest() {
+		// 多行 INSERT 语句
+		final Map<String, Object> paramMap = new LinkedHashMap<>();
+		paramMap.put("user1", new Object[]{1, "looly"});
+		paramMap.put("user2", new Object[]{2, "xxxtea"});
+
+		String sql = "INSERT INTO users (id, name) VALUES (:user1), (:user2)";
+		NamedSql namedSql = new NamedSql(sql, paramMap);
+
+		assertEquals("INSERT INTO users (id, name) VALUES (?,?), (?,?)", namedSql.getSql());
+		assertArrayEquals(new Object[]{1, "looly", 2, "xxxtea"}, namedSql.getParams());
+	}
+
+	@Test
 	public void queryTest() throws SQLException {
 		Map<String, Object> paramMap = MapUtil
 				.builder("name1", (Object)"王五")
@@ -109,9 +132,9 @@ public class NamedSqlTest {
 		final HashMap<String, Object> paramMap = MapUtil.of("info", new int[]{10, 20});
 
 		final NamedSql namedSql = new NamedSql(sql, paramMap);
-		// sql语句不包含IN子句，不会展开数组
-		assertEquals("select * from information where info_data = ?", namedSql.getSql());
-		assertArrayEquals(new int[]{10, 20}, (int[]) namedSql.getParams()[0]);
+		assertEquals("select * from information where info_data = ?,?", namedSql.getSql());
+		assertEquals(10, namedSql.getParams()[0]);
+		assertEquals(20, namedSql.getParams()[1]);
 	}
 
 	@Test
@@ -121,8 +144,8 @@ public class NamedSqlTest {
 		final HashMap<String, Object> paramMap = MapUtil.of("id", new int[]{5, 6});
 
 		final NamedSql namedSql = new NamedSql(sql, paramMap);
-		// sql语句不包含IN子句，不会展开数组
-		assertEquals("select * from user where comment = 'include in text' and id = ?", namedSql.getSql());
-		assertArrayEquals(new int[]{5, 6}, (int[]) namedSql.getParams()[0]);
+		assertEquals("select * from user where comment = 'include in text' and id = ?,?", namedSql.getSql());
+		assertEquals(5, namedSql.getParams()[0]);
+		assertEquals(6, namedSql.getParams()[1]);
 	}
 }


### PR DESCRIPTION
当前 NamedSql 对数组参数的处理逻辑依赖于两个条件：
1. 入参为数组或集合；
2. SQL 中包含 IN 关键字。
仅当这两个条件同时满足时，才会将命名参数（如 :ids）展开为多个 ? 占位符（即 ?, ?, ? 形式）。但是逻辑存在一定的局限性，无法兼容PgSQL的“ANY(ARRAY[1,2,3])”语法，同时也难以支持 INSERT 语句中多行 VALUES 的场景（如 VALUES (:a, :b), (:c, :d)）

优化方案：
只要入参为数组或集合类型，无论 SQL 中是否包含 IN，均将其展开为 ?, ?, ? 的形式。SQL 语义的正确性由使用者保证。这样可以兼容多种数据库语法（与 Spring 的 NamedParameterJdbcTemplate 和 NamedParameterUtils 一致）
