### PR TITLE
修改README.md中的疑似中英文符号错误，将。/hutool.sh安装 修改为 ./hutool.sh安装，即。改为.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ implementation 'cn.hutool.v7:hutool-all:7.0.0-M3'
 下载整个项目源码（v6-master或v6-dev分支都可）然后进入Hutool项目目录执行：
 
 ```sh
-./hutool.sh install   。/ hutool.sh安装
+./hutool.sh install   ./ hutool.sh安装
 ```
 
 然后就可以使用Maven引入了。


### PR DESCRIPTION
问题描述：
。/hutool.sh安装 
疑似出现中英文。.切换错误
见截图
<img width="647" height="230" alt="image" src="https://github.com/user-attachments/assets/24bf4d25-535e-41c0-bc49-f8d1e53402a5" />


