### PR TITLE
Fix issue 4129

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/VersionUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/VersionUtil.java
@@ -54,7 +54,7 @@ public class VersionUtil {
 	/**
 	 * 当前版本大于待比较版本
 	 *
-	 * @param currentVersion 当前本本
+	 * @param currentVersion 当前版本
 	 * @param compareVersion 待比较版本
 	 * @return true  当前版本大于待比较版本
 	 */
@@ -65,7 +65,7 @@ public class VersionUtil {
 	/**
 	 * 当前版本大于等于待比较版本
 	 *
-	 * @param currentVersion 当前本本
+	 * @param currentVersion 当前版本
 	 * @param compareVersion 待比较版本
 	 * @return true  当前版本大于等于待比较版本
 	 */
@@ -76,7 +76,7 @@ public class VersionUtil {
 	/**
 	 * 当前版本小于待比较版本
 	 *
-	 * @param currentVersion 当前本本
+	 * @param currentVersion 当前版本
 	 * @param compareVersion 待比较版本
 	 * @return true  当前版本小于待比较版本
 	 */
@@ -87,7 +87,7 @@ public class VersionUtil {
 	/**
 	 * 当前版本小于等于待比较版本
 	 *
-	 * @param currentVersion 当前本本
+	 * @param currentVersion 当前版本
 	 * @param compareVersion 待比较版本
 	 * @return true  当前版本小于等于待比较版本
 	 */
@@ -105,9 +105,9 @@ public class VersionUtil {
 	 *     matchEl("1.0.2", "1.0.0-1.1.1") == true
 	 * }</pre>
 	 *
-	 * @param currentVersion 当前本本
+	 * @param currentVersion 当前版本
 	 * @param versionEl      版本表达式
-	 * @return true  当前版本小于等于待比较版本
+	 * @return true  当前版本是否满足版本表达式
 	 */
 	public static boolean matchEl(String currentVersion, String versionEl) {
 		return matchEl(currentVersion, versionEl, defaultVersionsDelimiter);
@@ -123,7 +123,7 @@ public class VersionUtil {
 	 *     matchEl("1.0.2", "1.0.1,1.0.2-1.1.1", ",") == true
 	 * }</pre>
 	 *
-	 * @param currentVersion    当前本本
+	 * @param currentVersion    当前版本
 	 * @param versionEl         版本表达式（可以匹配多个条件，使用指定的分隔符（默认;）分隔）,
 	 *                          {@code '-'}表示范围包含左右版本,如果 {@code '-'}的左边没有，表示小于等于某个版本号， 右边表示大于等于某个版本号。
 	 *                          支持比较符号{@code '>'},{@code '<'}, {@code '>='},{@code '<='}，{@code '≤'}，{@code '≥'}
@@ -133,7 +133,7 @@ public class VersionUtil {
 	 *                          <li>{@code >=2.0.0, 1.9.8} 表示版本号 大于等于{@code 2.0.0}或 版本{@code 1.9.8}</li>
 	 *                          </ul>
 	 * @param versionsDelimiter 多表达式分隔符
-	 * @return true  当前版本小于等于待比较版本
+	 * @return true  当前版本是否满足版本表达式
 	 */
 	public static boolean matchEl(String currentVersion, String versionEl, String versionsDelimiter) {
 		if (StrUtil.isBlank(versionsDelimiter)
@@ -185,9 +185,9 @@ public class VersionUtil {
 						return false;
 				}
 			} else if (StrUtil.contains(el, "-")) {
-				String[] pair = el.split("-");
-				String left = StrUtil.blankToDefault(StrUtil.trim(pair[0]), "");
-				String right = StrUtil.blankToDefault(StrUtil.trim(pair[1]), "");
+				int index = el.indexOf('-');
+				String left = StrUtil.blankToDefault(StrUtil.trim(el.substring(0, index)), "");
+				String right = StrUtil.blankToDefault(StrUtil.trim(el.substring(index + 1)), "");
 
 				boolean leftMatch = StrUtil.isBlank(left) || StrUtil.compareVersion(left, trimmedVersion) <= 0;
 				boolean rightMatch = StrUtil.isBlank(right) || StrUtil.compareVersion(right, trimmedVersion) >= 0;

--- a/hutool-core/src/test/java/cn/hutool/core/util/VersionUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/VersionUtilTest.java
@@ -76,4 +76,32 @@ class VersionUtilTest {
 	@Test
 	void testMatchEl() {
 	}
+
+	/**
+	 * 测试版本范围表达式边界情况
+	 * 1. 左边界为空的情况: "-1.0.3" 应该匹配小于等于1.0.3的版本
+	 * 2. 右边界为空的情况: "1.0.0-" 应该匹配大于等于1.0.0的版本
+	 * 3. 双边界为空的情况: "-" 应该匹配所有版本
+	 * 验证 VersionUtil.matchEl 方法对边界值的正确处理
+	 */
+	@Test
+	void matchEl_rangeBoundaryCases() {
+		String currentVersion = "1.0.2";
+
+		// 测试左边界为空的情况: "-1.0.3" 应该匹配小于等于1.0.3的版本
+		assertTrue(VersionUtil.matchEl(currentVersion, "-1.0.3"));
+		assertTrue(VersionUtil.matchEl(currentVersion, "-1.0.2"));
+		assertFalse(VersionUtil.matchEl(currentVersion, "-1.0.0"));
+
+		// 测试右边界为空的情况: "1.0.0-" 应该匹配大于等于1.0.0的版本
+		assertTrue(VersionUtil.matchEl(currentVersion, "1.0.0-"));
+		assertTrue(VersionUtil.matchEl(currentVersion, "1.0.2-"));
+		assertFalse(VersionUtil.matchEl(currentVersion, "1.0.3-"));
+
+		// 测试双边为空的情况: "-" 应该匹配所有版本
+		assertTrue(VersionUtil.matchEl(currentVersion, "-"));
+		assertTrue(VersionUtil.matchEl("0.0.1", "-"));
+		assertTrue(VersionUtil.matchEl("999.999.999", "-"));
+	}
+
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复]  Fix issue 4129，修复在使用VersionUtil类的matchEl(String currentVersion, String versionEl)方法判断当前版本是否满足版本表达式时，如果输入的版本范围表达式右边界为空时，会抛出数组越界访问错误的问题，，并添加对应的测试案例。

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过