### PR TITLE
修复Validator.isBetween方法在高精度Number类型下存在精度丢失问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/lang/Validator.java
+++ b/hutool-core/src/main/java/cn/hutool/core/lang/Validator.java
@@ -9,6 +9,7 @@ import cn.hutool.core.util.ReUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.core.util.IdcardUtil;
 
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -1123,8 +1124,11 @@ public class Validator {
 		Assert.notNull(value);
 		Assert.notNull(min);
 		Assert.notNull(max);
-		final double doubleValue = value.doubleValue();
-		return (doubleValue >= min.doubleValue()) && (doubleValue <= max.doubleValue());
+		// 通过 NumberUtil 转换为 BigDecimal，使用 BigDecimal 进行比较以保留精度
+		BigDecimal valBd = NumberUtil.toBigDecimal(value);
+		BigDecimal minBd = NumberUtil.toBigDecimal(min);
+		BigDecimal maxBd = NumberUtil.toBigDecimal(max);
+		return valBd.compareTo(minBd) >= 0 && valBd.compareTo(maxBd) <= 0;
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/lang/ValidatorTest.java
@@ -227,6 +227,19 @@ public class ValidatorTest {
 		assertTrue(Validator.isBetween(0.19, 0.1, 0.2));
 	}
 
+
+	@Test
+	public void isBetweenPrecisionLossTest() {
+		// 使用超过 double 精度的值
+		long base = 10000000000000000L;
+		long min = base + 1;
+		long max = base + 2;
+
+		// 在 double 转换下，base、min 和 max 是完全相等的，因为 double 精度不够
+		// 预期结果为false，但是因为double 精度不够，导致输出为true
+		assertFalse(Validator.isBetween(base, min, max));
+	}
+
 	@Test
 	public void isCarVinTest() {
 		assertTrue(Validator.isCarVin("LSJA24U62JG269225"));


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] Fix issue [4135](https://github.com/chinabugotech/hutool/issues/4135)，原有的 Validator.isBetween 方法通过 value.doubleValue() 将数字转换为 double 进行比较。当参数为大整数或高精度 BigDecimal 时，double 转换会导致精度丢失，从而导致 isBetween 判断结果错误。

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过