### PR TITLE
Feat/bloom multi hash

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/AbstractFilter.java
+++ b/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/AbstractFilter.java
@@ -30,7 +30,7 @@ public abstract class AbstractFilter implements BloomFilter {
 	@Serial
 	private static final long serialVersionUID = 1L;
 
-	private final BitSet bitSet;
+	protected final BitSet bitSet;
 	/**
 	 * 容量
 	 */

--- a/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/AbstractFilter.java
+++ b/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/AbstractFilter.java
@@ -50,12 +50,12 @@ public abstract class AbstractFilter implements BloomFilter {
 
 	@Override
 	public boolean contains(final String str) {
-		return bitSet.get(Math.abs(hash(str)));
+		return bitSet.get(hash(str));
 	}
 
 	@Override
 	public boolean add(final String str) {
-		final int hash = Math.abs(hash(str));
+		final int hash = hash(str);
 		if (bitSet.get(hash)) {
 			return false;
 		}

--- a/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/FuncFilter.java
+++ b/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/FuncFilter.java
@@ -51,28 +51,40 @@ public class FuncFilter extends AbstractFilter {
 
 	/**
 	 * @param size     最大值
-	 * @param hashFunc Hash函数
+	 * @param hashFuncs Hash函数
 	 */
 	@SafeVarargs
-	public FuncFilter(final int size, final Function<String, Number>... hashFunc) {
+	public FuncFilter(final int size, final Function<String, Number>... hashFuncs) {
 		super(size);
-		Assert.notEmpty(hashFunc, "Hash functions must not be empty");
-		this.hashFuncs = Collections.unmodifiableList(Arrays.asList(hashFunc));
+		Assert.notEmpty(hashFuncs, "Hash functions must not be empty");
+		this.hashFuncs = Collections.unmodifiableList(Arrays.asList(hashFuncs));
 	}
 
+	/**
+	 *兼容父类，如果存在多个哈希函数，就使用第一个
+	 *
+	 * @param str 字符串
+	 */
 	@Override
 	public int hash(final String str) {
 		return hash(str, hashFuncs.get(0));
 	}
 
+	/**
+	 *
+	 * @param str 字符串
+	 * @param hashFunc 哈希函数
+	 * @return HashCode 指定哈希函数的计算结果
+	 */
 	public int hash(final String str, final Function<String, Number> hashFunc) {
-		return hashFunc.apply(str).intValue() % size;
+		// 通过位运算获取正数
+		return (hashFunc.apply(str).intValue() & 0x7FFFFFFF) % size;
 	}
 
 	@Override
 	public boolean contains(final String str) {
 		for (final Function<String, Number> hashFunc : hashFuncs) {
-			if (!bitSet.get(Math.abs(hash(str, hashFunc)))) {
+			if (!bitSet.get(hash(str, hashFunc))) {
 				return false;
 			}
 		}
@@ -83,7 +95,7 @@ public class FuncFilter extends AbstractFilter {
 	public boolean add(final String str) {
 		boolean add = false;
 		for (final Function<String, Number> hashFunc : hashFuncs) {
-			int hash = Math.abs(hash(str,  hashFunc));
+			int hash = hash(str,  hashFunc);
 			if (!bitSet.get(hash)) {
 				bitSet.set(hash);
 				add = true;

--- a/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/FuncFilter.java
+++ b/hutool-core/src/main/java/cn/hutool/v7/core/text/bloom/FuncFilter.java
@@ -16,7 +16,12 @@
 
 package cn.hutool.v7.core.text.bloom;
 
+import cn.hutool.v7.core.lang.Assert;
+
 import java.io.Serial;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -33,26 +38,57 @@ public class FuncFilter extends AbstractFilter {
 	 * 创建FuncFilter
 	 *
 	 * @param size     最大值
-	 * @param hashFunc Hash函数
+	 * @param hashFuncs Hash函数
 	 * @return FuncFilter
 	 */
-	public static FuncFilter of(final int size, final Function<String, Number> hashFunc) {
-		return new FuncFilter(size, hashFunc);
+	@SafeVarargs
+	public static FuncFilter of(final int size, final Function<String, Number>... hashFuncs) {
+		return new FuncFilter(size, hashFuncs);
 	}
 
-	private final Function<String, Number> hashFunc;
+	// 允许接收多个哈希函数
+	private final List<Function<String, Number>> hashFuncs;
 
 	/**
 	 * @param size     最大值
 	 * @param hashFunc Hash函数
 	 */
-	public FuncFilter(final int size, final Function<String, Number> hashFunc) {
+	@SafeVarargs
+	public FuncFilter(final int size, final Function<String, Number>... hashFunc) {
 		super(size);
-		this.hashFunc = hashFunc;
+		Assert.notEmpty(hashFunc, "Hash functions must not be empty");
+		this.hashFuncs = Collections.unmodifiableList(Arrays.asList(hashFunc));
 	}
 
 	@Override
 	public int hash(final String str) {
+		return hash(str, hashFuncs.get(0));
+	}
+
+	public int hash(final String str, final Function<String, Number> hashFunc) {
 		return hashFunc.apply(str).intValue() % size;
+	}
+
+	@Override
+	public boolean contains(final String str) {
+		for (final Function<String, Number> hashFunc : hashFuncs) {
+			if (!bitSet.get(Math.abs(hash(str, hashFunc)))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public boolean add(final String str) {
+		boolean add = false;
+		for (final Function<String, Number> hashFunc : hashFuncs) {
+			int hash = Math.abs(hash(str,  hashFunc));
+			if (!bitSet.get(hash)) {
+				bitSet.set(hash);
+				add = true;
+			}
+		}
+		return add;
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/v7/core/text/bloom/BitMapBloomFilterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/v7/core/text/bloom/BitMapBloomFilterTest.java
@@ -20,6 +20,8 @@ import cn.hutool.v7.core.codec.hash.HashUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.BitSet;
+
 public class BitMapBloomFilterTest {
 
 	@Test
@@ -35,4 +37,5 @@ public class BitMapBloomFilterTest {
 		Assertions.assertTrue(filter.contains("ddd"));
 		Assertions.assertTrue(filter.contains("123"));
 	}
+
 }

--- a/hutool-core/src/test/java/cn/hutool/v7/core/text/bloom/BitMapBloomFilterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/v7/core/text/bloom/BitMapBloomFilterTest.java
@@ -20,15 +20,14 @@ import cn.hutool.v7.core.codec.hash.HashUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.BitSet;
-
 public class BitMapBloomFilterTest {
+
+	private static final int SIZE = 2 * 1024 * 1024 * 8;
 
 	@Test
 	public void filterTest() {
-		final int size = 2 * 1024 * 1024 * 8;
 
-		final CombinedBloomFilter filter = new CombinedBloomFilter(FuncFilter.of(size, HashUtil::rsHash));
+		final CombinedBloomFilter filter = new CombinedBloomFilter(FuncFilter.of(SIZE, HashUtil::rsHash));
 		filter.add("123");
 		filter.add("abc");
 		filter.add("ddd");
@@ -37,5 +36,68 @@ public class BitMapBloomFilterTest {
 		Assertions.assertTrue(filter.contains("ddd"));
 		Assertions.assertTrue(filter.contains("123"));
 	}
+	@Test
+	public void multiHashFuncTest() {
+		final FuncFilter filter = FuncFilter.of(SIZE,
+			HashUtil::rsHash,
+			HashUtil::jsHash,
+			HashUtil::pjwHash,
+			HashUtil::elfHash,
+			HashUtil::bkdrHash,
+			HashUtil::sdbmHash,
+			HashUtil::djbHash,
+			HashUtil::dekHash,
+			HashUtil::apHash,
+			HashUtil::javaDefaultHash
+		);
 
+		filter.add("Hutool");
+		filter.add("BloomFilter");
+		filter.add("Java");
+
+		Assertions.assertTrue(filter.contains("Hutool"));
+		Assertions.assertTrue(filter.contains("BloomFilter"));
+		Assertions.assertTrue(filter.contains("Java"));
+		Assertions.assertFalse(filter.contains("Python"));
+		Assertions.assertFalse(filter.contains("Go"));
+		Assertions.assertFalse(filter.contains("hutool"));
+	}
+
+	@Test
+	public void combinedMultiHashTest() {
+		FuncFilter multiHashFuncFilter = FuncFilter.of(SIZE,
+			HashUtil::bkdrHash,
+			HashUtil::apHash,
+			HashUtil::djbHash
+		);
+		final CombinedBloomFilter filter = new CombinedBloomFilter(multiHashFuncFilter);
+		filter.add("123123WASD-WASD");
+		Assertions.assertTrue(filter.contains("123123WASD-WASD"));
+		Assertions.assertFalse(filter.contains("123123WASD-WASD-false"));
+	}
+
+	@Test
+	public void chineseStringWithThreeHashesTest() {
+		final FuncFilter filter = FuncFilter.of(SIZE,
+			HashUtil::bkdrHash,
+			HashUtil::apHash,
+			HashUtil::djbHash
+		);
+
+		String s1 = "你好世界";
+		String s2 = "双亲委派";
+		String s3 = "测试工程师";
+
+		filter.add(s1);
+		filter.add(s2);
+		filter.add(s3);
+		Assertions.assertTrue(filter.contains(s1), "应包含: " + s1);
+		Assertions.assertTrue(filter.contains(s2), "应包含: " + s2);
+		Assertions.assertTrue(filter.contains(s3), "应包含: " + s3);
+		Assertions.assertFalse(filter.contains("我好世界"), "多字");
+		Assertions.assertFalse(filter.contains("父亲委派"), "改字");
+		Assertions.assertFalse(filter.contains("测试"), "子串");
+		Assertions.assertFalse(filter.contains(""), "空串");
+		Assertions.assertFalse(filter.contains("👍"), "未添加的");
+	}
 }


### PR DESCRIPTION
## 说明

1. 提供 core 模块下的 text  中布隆过滤器的单过滤器多哈希函数支持
2. 我发现原来的 hash 方法可能会导致 indexOutOfBoundsException

### 修改描述

1. 使用可变参数允许接收多个哈希函数，重写 contains 方法和 add 方法
2. 修复 indexOutOfBoundsException，在原来的代码中，如果 hash 结果是 Integer.MIN_VALUE，调用者在尝试用 Math.abs()保证结果为正时，由于不存在对应的正数，会导致结果仍为 Integer.MIN_VALUE，使得调用 bitSet.set(hash) 时 hash 参数为负数，发生 indexOutOfBoundsException
<img width="955" height="433" alt="2f36fb93159f536b5c3716442e845f93" src="https://github.com/user-attachments/assets/afe016b6-9e0e-4f69-a027-efd462c0a5ae" />

该测试仅用于说明潜在问题，所以已在 pr 中删除
### 提交前自测
已通过`mvn javadoc:javadoc `测试
 `mvn clean test` 测试在 core 模块通过了但是在 poi 模块失败了，我不知道为什么，但我没有修改 poi 模块