### PR TITLE
修复FileNameUtil.extName 方法对特殊后缀判断逻辑过于宽松导致误判

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
@@ -238,7 +238,7 @@ public class FileNameUtil {
 			// issue#I4W5FS@Gitee
 			final int secondToLastIndex = fileName.substring(0, index).lastIndexOf(StrUtil.DOT);
 			final String substr = fileName.substring(secondToLastIndex == -1 ? index : secondToLastIndex + 1);
-			if (StrUtil.containsAny(substr, SPECIAL_SUFFIX)) {
+			if (StrUtil.equalsAny(substr, SPECIAL_SUFFIX)) {
 				return substr;
 			}
 

--- a/hutool-core/src/test/java/cn/hutool/core/io/file/FileNameUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/file/FileNameUtilTest.java
@@ -19,4 +19,12 @@ public class FileNameUtilTest {
 		final String s = FileNameUtil.mainName("abc.tar.gz");
 		assertEquals("abc", s);
 	}
+
+	@Test
+	public void extNameAndMainNameBugTest() {
+		// 正确，输出前缀为 "app-v2.3.1-star"
+		assertEquals("app-v2.3.1-star",FileNameUtil.mainName("app-v2.3.1-star.gz"));
+		// 当前代码会失败，预期后缀结果 "gz"，但是输出 "star.gz"
+		assertEquals("gz", FileNameUtil.extName("app-v2.3.1-star.gz"));
+	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 修复FileNameUtil.extName 方法对特殊后缀判断逻辑过于宽松导致误判
将StrUtil.containsAny(substr, SPECIAL_SUFFIX)改为StrUtil.equalsAny(substr, SPECIAL_SUFFIX)

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
3. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
4. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
5. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
6. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过