### PR TITLE
修复StrUtil.str(ByteBuffer, Charset) 方法修改入参 ByteBuffer 的 position，导致入参变化

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/StrUtil.java
@@ -261,7 +261,7 @@ public class StrUtil extends CharSequenceUtil implements StrPool {
 		if (null == charset) {
 			charset = Charset.defaultCharset();
 		}
-		return charset.decode(data).toString();
+		return charset.decode(data.duplicate()).toString();
 	}
 
 	/**

--- a/hutool-core/src/test/java/cn/hutool/core/io/BufferUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/BufferUtilTest.java
@@ -1,6 +1,7 @@
 package cn.hutool.core.io;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
@@ -62,5 +63,22 @@ public class BufferUtilTest {
 
 		// 读取剩余部分
 		assertEquals("cc", StrUtil.utf8Str(BufferUtil.readBytes(buffer)));
+	}
+
+	@Test
+	public void testByteBufferSideEffect() {
+		String originalText = "Hello";
+		ByteBuffer buffer = ByteBuffer.wrap(originalText.getBytes(StandardCharsets.UTF_8));
+		// 此时 buffer.remaining() == 5
+		assertEquals(5, buffer.remaining());
+
+		// 调用工具类转换，打印buffer内容
+		String result = StrUtil.str(buffer, StandardCharsets.UTF_8);
+		assertEquals(originalText, result);
+
+		// 预期：
+		// 工具类不应该修改原 buffer 的指针，remaining 应该依然为 5
+		// 再次调用工具类转换，输出结果应该不变
+		assertEquals(originalText, StrUtil.str(buffer, StandardCharsets.UTF_8));
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] Fix [#4152](https://github.com/chinabugotech/hutool/issues/4152)，  修复StrUtil.str(ByteBuffer, Charset) 方法修改入参 ByteBuffer 的 position，导致入参变化

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过