### PR TITLE
fix:12小时制ceiling和round问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateModifier.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateModifier.java
@@ -73,13 +73,13 @@ public class DateModifier {
 				case ROUND:
 					int min = isAM ? 0 : 12;
 					int max = isAM ? 11 : 23;
-					int href = (max - min) / 2 + 1;
+					int href = min + (max - min) / 2 + 1;
 					int value = calendar.get(Calendar.HOUR_OF_DAY);
 					calendar.set(Calendar.HOUR_OF_DAY, (value < href) ? min : max);
 					break;
 			}
 			// 处理下一级别字段
-			return modify(calendar, dateField + 1, modifyType);
+			return modify(calendar, dateField + 1, modifyType, truncateMillisecond);
 		}
 
 		final int endField = truncateMillisecond ? Calendar.SECOND : Calendar.MILLISECOND;

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
@@ -131,6 +131,33 @@ public class DateUtilTest {
 	}
 
 	@Test
+	public void cellingAmPmTest(){
+		final String dateStr2 = "2020-02-29 10:59:34";
+		final Date date2 = DateUtil.parse(dateStr2);
+
+
+		DateTime dateTime = DateUtil.ceiling(date2, DateField.AM_PM);
+		assertEquals("2020-02-29 11:59:59.999", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+
+		dateTime = DateUtil.ceiling(date2, DateField.AM_PM, true);
+		assertEquals("2020-02-29 11:59:59.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+	}
+
+	@Test void roundAmPmTest() {
+		final String dateStr = "2020-02-29 13:59:34";
+		final Date date = DateUtil.parse(dateStr);
+
+		DateTime dateTime = DateUtil.round(date, DateField.AM_PM);
+		assertEquals("2020-02-29 12:59:59.000", dateTime.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+
+		final String dateStr2 = "2020-02-29 18:59:34";
+		final Date date2 = DateUtil.parse(dateStr2);
+
+		DateTime dateTime2 = DateUtil.round(date2, DateField.AM_PM);
+		assertEquals("2020-02-29 23:59:59.000", dateTime2.toString(DatePattern.NORM_DATETIME_MS_PATTERN));
+	}
+
+	@Test
 	public void ceilingDayTest() {
 		final String dateStr2 = "2020-02-29 12:59:34";
 		final Date date2 = DateUtil.parse(dateStr2);


### PR DESCRIPTION
### 说明
1. 12小时制下午在ROUND模式下永远都是23点
2. 12小时制ceiling的truncateMillisecond未被传递导致参数失效