### PR TITLE
fix(Word07Writer): strip alpha channel from color and update tests

### DIFF
--- a/hutool-poi/src/main/java/cn/hutool/poi/word/Word07Writer.java
+++ b/hutool-poi/src/main/java/cn/hutool/poi/word/Word07Writer.java
@@ -14,11 +14,7 @@ import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFRun;
 
 import java.awt.*;
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 
 /**
  * Word docx生成器
@@ -156,7 +152,8 @@ public class Word07Writer implements Closeable {
 					run.setItalic(font.isItalic());
 				}
 				if (null != color) {
-					String hexColor = String.format("%02X", color.getRGB());
+					// setColor expects a pure RGB hex string (no alpha channel)
+					String hexColor = String.format("%06X", color.getRGB() & 0xFFFFFF);
 					run.setColor(hexColor);
 				}
 			}

--- a/hutool-poi/src/test/java/cn/hutool/poi/word/WordWriterTest.java
+++ b/hutool-poi/src/test/java/cn/hutool/poi/word/WordWriterTest.java
@@ -5,6 +5,8 @@ import cn.hutool.core.collection.ListUtil;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.lang.Console;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.apache.poi.xwpf.usermodel.XWPFRun;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +16,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class WordWriterTest {
 
@@ -95,5 +99,18 @@ public class WordWriterTest {
 		list2.add(list);
 		word07Writer.addTable(list);
 		word07Writer.close();
+	}
+
+	@Test
+	public void addTextShouldStripAlphaAndUseRgbHex() {
+		final Word07Writer writer = new Word07Writer();
+		final Color colorWithAlpha = new Color(0x12, 0x34, 0x56, 0x7F);
+
+		writer.addText(new Font("宋体", Font.PLAIN, 12), colorWithAlpha, "带颜色的段落");
+
+		final XWPFParagraph paragraph = writer.getDoc().getParagraphArray(0);
+		final XWPFRun run = paragraph.getRuns().get(0);
+		assertEquals("123456", run.getColor());
+		writer.close();
 	}
 }


### PR DESCRIPTION
修复 run.setColor() 的颜色十六进制转换逻辑。

原实现使用 String.format("%02X", color.getRGB())，存在以下问题：
- %02X 仅输出 2 位十六进制，导致 32 位 ARGB 值被截断
- Color.getRGB() 包含 alpha 通道（ARGB），会生成无效颜色值

本次提交通过去除 alpha 通道并格式化为标准 6 位 RGB：
String.format("%06X", color.getRGB() & 0xFFFFFF)

确保 run.setColor() 始终获得有效的 RRGGBB 颜色字符串。