### PR TITLE
Fix issue 4167

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/split/SplitIter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/split/SplitIter.java
@@ -71,29 +71,28 @@ public class SplitIter extends ComputeIter<String> implements Serializable {
 			return text.substring(offset);
 		}
 
-		final int start = finder.start(offset);
-		// 无分隔符，结束
-		if (start < 0) {
-			// 如果不再有分隔符，但是遗留了字符，则单独作为一个段
-			if (offset <= text.length()) {
-				final String result = text.substring(offset);
-				if (false == ignoreEmpty || false == result.isEmpty()) {
-					// 返回非空串
-					offset = Integer.MAX_VALUE;
-					return result;
+		String result = null;
+		int start;
+		do {
+			start = finder.start(offset);
+			// 无分隔符，结束
+			if (start < 0) {
+				// 如果不再有分隔符，但是遗留了字符，则单独作为一个段
+				if (offset <= text.length()) {
+					result = text.substring(offset);
+					if (!ignoreEmpty || !result.isEmpty()) {
+						// 返回非空串
+						offset = Integer.MAX_VALUE;
+						return result;
+					}
 				}
+				return null;
 			}
-			return null;
-		}
 
-		// 找到新的分隔符位置
-		final String result = text.substring(offset, start);
-		offset = finder.end(start);
-
-		if (ignoreEmpty && result.isEmpty()) {
-			// 发现空串且需要忽略时，跳过之
-			return computeNext();
-		}
+			// 找到新的分隔符位置
+			result = text.substring(offset, start);
+			offset = finder.end(start);
+		} while (ignoreEmpty && result.isEmpty()); // 空串则继续循环
 
 		count++;
 		return result;

--- a/hutool-core/src/main/java/cn/hutool/core/util/HexUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/HexUtil.java
@@ -379,15 +379,24 @@ public class HexUtil {
 	 * @return 格式化后的字符串
 	 */
 	public static String format(final String hexStr, String prefix) {
+		if (StrUtil.isEmpty(hexStr)) {
+			return StrUtil.EMPTY;
+		}
 		if (null == prefix) {
 			prefix = StrUtil.EMPTY;
 		}
 
 		final int length = hexStr.length();
 		final StringBuilder builder = StrUtil.builder(length + length / 2 + (length / 2 * prefix.length()));
-		builder.append(prefix).append(hexStr.charAt(0)).append(hexStr.charAt(1));
-		for (int i = 2; i < length - 1; i += 2) {
-			builder.append(CharUtil.SPACE).append(prefix).append(hexStr.charAt(i)).append(hexStr.charAt(i + 1));
+
+		for (int i = 0; i < length; i++) {
+			if (i % 2 == 0) {
+				if (i != 0) {
+					builder.append(CharUtil.SPACE);
+				}
+				builder.append(prefix);
+			}
+			builder.append(hexStr.charAt(i));
 		}
 		return builder.toString();
 	}

--- a/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
@@ -6,6 +6,8 @@ import cn.hutool.core.text.finder.PatternFinder;
 import cn.hutool.core.text.finder.StrFinder;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -152,5 +154,19 @@ public class SplitIterTest {
 			final List<String> strings = splitIter.toList(false);
 			assertEquals(1, strings.size());
 		});
+	}
+
+	@Test
+	public void issue4169Test() {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 20000; i++) { // 1万次连续分隔符，模拟递归深度风险场景
+			sb.append(",");
+		}
+		sb.append("test");
+
+		SplitIter iter = new SplitIter(sb.toString(), new StrFinder(",",false), 0, true);
+		List<String> result = iter.toList(false);
+
+		assertEquals(Collections.singletonList("test"), result);
 	}
 }

--- a/hutool-core/src/test/java/cn/hutool/core/util/HexUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/HexUtilTest.java
@@ -116,4 +116,35 @@ public class HexUtilTest {
 		final String hex3 = "#FF";
 		assertEquals(new BigInteger("FF", 16), HexUtil.toBigInteger(hex3));
 	}
+
+	@Test
+	public void testFormatEmpty() {
+		String result = HexUtil.format("");
+		assertEquals("", result);
+	}
+
+	@Test
+	public void testFormatSingleChar() {
+		String result = HexUtil.format("1");
+		assertEquals("1", result);
+	}
+
+	@Test
+	public void testFormatOddLength() {
+		String result = HexUtil.format("123");
+		assertEquals("12 3", result);
+	}
+
+	@Test
+	public void testFormatWithPrefixSingleChar() {
+		String result = HexUtil.format("1", "0x");
+		assertEquals("0x1", result);
+	}
+
+	@Test
+	public void testFormatWithPrefixOddLength() {
+		String result = HexUtil.format("123", "0x");
+		assertEquals("0x12 0x3", result);
+	}
+
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)
#4167 
1. [bug修复] 修复HexUtil类的format方法在处理长度小于2的字符串会抛异常，在处理长度为奇数的字符串时最后一个字符会被忽略的问题；同时补充相关的测试用例。

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

已包含测试用例，并验证通过

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过