### PR TITLE
Fix issue 4169

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/split/SplitIter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/split/SplitIter.java
@@ -71,29 +71,28 @@ public class SplitIter extends ComputeIter<String> implements Serializable {
 			return text.substring(offset);
 		}
 
-		final int start = finder.start(offset);
-		// 无分隔符，结束
-		if (start < 0) {
-			// 如果不再有分隔符，但是遗留了字符，则单独作为一个段
-			if (offset <= text.length()) {
-				final String result = text.substring(offset);
-				if (false == ignoreEmpty || false == result.isEmpty()) {
-					// 返回非空串
-					offset = Integer.MAX_VALUE;
-					return result;
+		String result = null;
+		int start;
+		do {
+			start = finder.start(offset);
+			// 无分隔符，结束
+			if (start < 0) {
+				// 如果不再有分隔符，但是遗留了字符，则单独作为一个段
+				if (offset <= text.length()) {
+					result = text.substring(offset);
+					if (!ignoreEmpty || !result.isEmpty()) {
+						// 返回非空串
+						offset = Integer.MAX_VALUE;
+						return result;
+					}
 				}
+				return null;
 			}
-			return null;
-		}
 
-		// 找到新的分隔符位置
-		final String result = text.substring(offset, start);
-		offset = finder.end(start);
-
-		if (ignoreEmpty && result.isEmpty()) {
-			// 发现空串且需要忽略时，跳过之
-			return computeNext();
-		}
+			// 找到新的分隔符位置
+			result = text.substring(offset, start);
+			offset = finder.end(start);
+		} while (ignoreEmpty && result.isEmpty()); // 空串则继续循环
 
 		count++;
 		return result;

--- a/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/split/SplitIterTest.java
@@ -6,6 +6,7 @@ import cn.hutool.core.text.finder.PatternFinder;
 import cn.hutool.core.text.finder.StrFinder;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -152,5 +153,19 @@ public class SplitIterTest {
 			final List<String> strings = splitIter.toList(false);
 			assertEquals(1, strings.size());
 		});
+	}
+
+	@Test
+	public void issue4169Test() {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 20000; i++) { // 1万次连续分隔符，模拟递归深度风险场景
+			sb.append(",");
+		}
+		sb.append("test");
+
+		SplitIter iter = new SplitIter(sb.toString(), new StrFinder(",",false), 0, true);
+		List<String> result = iter.toList(false);
+
+		assertEquals(Collections.singletonList("test"), result);
 	}
 }


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)
#4169 
1. [bug修复] 修复SplitIter类的computeNext()方法递归调用可能导致栈溢出风险。（将computeNext()方法以最小改动从递归改为循环）

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

已自测，并提供单元测试用例issue3421Test

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过