### PR TITLE
✨ feat(BeanPath): BeanPath支持使用反斜杠转义冒号、逗号和单引号作为键名

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanPath.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanPath.java
@@ -41,6 +41,15 @@ public class BeanPath implements Serializable {
 	 */
 	private static final char[] EXP_CHARS = {CharUtil.DOT, CharUtil.BRACKET_START, CharUtil.BRACKET_END};
 
+	/**
+	 * 转义字符映射：转义后的字符 -> 占位符（使用Unicode私有区末尾字符，更不常用）
+	 */
+	private static final char[][] ESCAPE_CHARS = {
+		{'\'', '\uF8FF'},  // \' -> '\uF8FF'
+		{':', '\uF8FE'},    // \: -> '\uF8FE'
+		{',', '\uF8FD'}     // \, -> '\uF8FD'
+	};
+
 	private boolean isStartWith = false;
 	protected List<String> patternParts;
 
@@ -147,7 +156,8 @@ public class BeanPath implements Serializable {
 			subBean = this.get(patternParts, bean, true);
 		}
 
-		final Object newSubBean = BeanUtil.setFieldValue(subBean, patternParts.get(patternParts.size() - 1), value);
+		final Object newSubBean = BeanUtil.setFieldValue(subBean, 
+				restoreEscapes(patternParts.get(patternParts.size() - 1)), value);
 		if(newSubBean != subBean){
 			// 对象变更，重新加入
 			this.set(bean, getParentParts(patternParts), nextNumberPart, newSubBean);
@@ -301,11 +311,44 @@ public class BeanPath implements Serializable {
 				}
 			}
 		} else {
-			// 数字或普通字符串
-			return BeanUtil.getFieldValue(bean, expression);
+			// 数字或普通字符串，还原转义占位符
+			final String realExpression = restoreEscapes(expression);
+			return BeanUtil.getFieldValue(bean, realExpression);
 		}
 
 		return null;
+	}
+
+	/**
+	 * 还原转义占位符为真实字符
+	 *
+	 * @param str 包含占位符的字符串
+	 * @return 还原后的字符串
+	 */
+	private static String restoreEscapes(final String str) {
+		if (str == null) {
+			return null;
+		}
+		String result = str;
+		for (final char[] escape : ESCAPE_CHARS) {
+			result = result.replace(escape[1], escape[0]);
+		}
+		return result;
+	}
+
+	/**
+	 * 查找转义字符对应的占位符
+	 *
+	 * @param c 被转义的字符
+	 * @return 占位符，未找到返回0
+	 */
+	private static char getEscapePlaceholder(final char c) {
+		for (final char[] escape : ESCAPE_CHARS) {
+			if (escape[0] == c) {
+				return escape[1];
+			}
+		}
+		return 0;
 	}
 
 	/**
@@ -327,6 +370,18 @@ public class BeanPath implements Serializable {
 				// 忽略开头的$符，表示当前对象
 				isStartWith = true;
 				continue;
+			}
+
+			// 统一处理转义字符：\' \: \,
+			if ('\\' == c && i + 1 < length) {
+				final char nextChar = expression.charAt(i + 1);
+				final char placeholder = getEscapePlaceholder(nextChar);
+				if (placeholder != 0) {
+					// 转义字符转换为占位符
+					builder.append(placeholder);
+					i++; // 跳过下一个字符
+					continue;
+				}
 			}
 
 			if ('\'' == c) {

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanPathTest.java
@@ -149,6 +149,181 @@ public class BeanPathTest {
 		assertEquals("[1, 2, 3]", result.toString());
 	}
 
+	/**
+	 * 测试key中包含冒号（使用转义）
+	 */
+	@Test
+	public void keyWithColonTest() {
+		final Map<String, Object> map = new HashMap<>();
+		map.put("a:b", "value1");
+		map.put("time:12:30", "value2");
+
+		// 使用 \: 转义冒号
+		BeanPath beanPath = BeanPath.create("a\\:b");
+		assertEquals("value1", beanPath.get(map));
+
+		beanPath = BeanPath.create("time\\:12\\:30");
+		assertEquals("value2", beanPath.get(map));
+	}
+
+	/**
+	 * 测试key中包含逗号（使用转义）
+	 */
+	@Test
+	public void keyWithCommaTest() {
+		final Map<String, Object> map = new HashMap<>();
+		map.put("a,b", "value1");
+		map.put("x,y,z", "value2");
+
+		// 使用 \, 转义逗号
+		BeanPath beanPath = BeanPath.create("a\\,b");
+		assertEquals("value1", beanPath.get(map));
+
+		beanPath = BeanPath.create("x\\,y\\,z");
+		assertEquals("value2", beanPath.get(map));
+	}
+
+	/**
+	 * 测试key中包含转义单引号
+	 */
+	@Test
+	public void keyWithEscapedQuoteTest() {
+		final Map<String, Object> map = new HashMap<>();
+		map.put("it's", "value1");
+		map.put("test'key", "value2");
+
+		// 使用 \' 转义单引号
+		BeanPath beanPath = BeanPath.create("['it\\'s']");
+		assertEquals("value1", beanPath.get(map));
+
+		beanPath = BeanPath.create("['test\\'key']");
+		assertEquals("value2", beanPath.get(map));
+	}
+
+	/**
+	 * 测试嵌套使用包含特殊字符的key
+	 */
+	@Test
+	public void nestedSpecialKeyTest() {
+		final Map<String, Object> map = new HashMap<>();
+		final Map<String, Object> inner = new HashMap<>();
+		inner.put("key:1", "innerValue");
+		map.put("outer,key", inner);
+
+		// 嵌套访问包含特殊字符的key（使用转义）
+		BeanPath beanPath = BeanPath.create("outer\\,key.key\\:1");
+		assertEquals("innerValue", beanPath.get(map));
+	}
+
+	/**
+	 * 测试切片表达式仍然正常工作
+	 */
+	@Test
+	public void sliceExpressionTest() {
+		final List<String> list = new ArrayList<>();
+		list.add("a");
+		list.add("b");
+		list.add("c");
+		list.add("d");
+		list.add("e");
+
+		final Map<String, Object> map = new HashMap<>();
+		map.put("items", list);
+
+		// 切片表达式仍然有效
+		BeanPath beanPath = BeanPath.create("items[1:3]");
+		Object result = beanPath.get(map);
+		assertEquals("[b, c]", result.toString());
+	}
+
+	/**
+	 * 测试多选索引表达式仍然正常工作
+	 */
+	@Test
+	public void multiIndexExpressionTest() {
+		final List<String> list = new ArrayList<>();
+		list.add("a");
+		list.add("b");
+		list.add("c");
+		list.add("d");
+
+		final Map<String, Object> map = new HashMap<>();
+		map.put("items", list);
+
+		// 多选索引表达式仍然有效
+		BeanPath beanPath = BeanPath.create("items[0,2]");
+		Object result = beanPath.get(map);
+		assertEquals("[a, c]", result.toString());
+	}
+
+	/**
+	 * 测试set方法支持包含冒号的key
+	 */
+	@Test
+	public void setKeyWithColonTest() {
+		final Map<String, Object> map = new HashMap<>();
+
+		// 使用转义冒号的key进行set
+		BeanPath beanPath = BeanPath.create("a\\:b");
+		beanPath.set(map, "value1");
+		assertEquals("value1", map.get("a:b"));
+
+		// 再次验证get
+		assertEquals("value1", beanPath.get(map));
+	}
+
+	/**
+	 * 测试set方法支持包含逗号的key
+	 */
+	@Test
+	public void setKeyWithCommaTest() {
+		final Map<String, Object> map = new HashMap<>();
+
+		// 使用转义逗号的key进行set
+		BeanPath beanPath = BeanPath.create("x\\,y\\,z");
+		beanPath.set(map, "value2");
+		assertEquals("value2", map.get("x,y,z"));
+
+		// 再次验证get
+		assertEquals("value2", beanPath.get(map));
+	}
+
+	/**
+	 * 测试set方法支持包含单引号的key
+	 */
+	@Test
+	public void setKeyWithQuoteTest() {
+		final Map<String, Object> map = new HashMap<>();
+
+		// 使用转义单引号的key进行set
+		BeanPath beanPath = BeanPath.create("it\\'s");
+		beanPath.set(map, "value3");
+		assertEquals("value3", map.get("it's"));
+
+		// 再次验证get
+		assertEquals("value3", beanPath.get(map));
+	}
+
+	/**
+	 * 测试set方法支持嵌套特殊字符key
+	 */
+	@Test
+	public void setNestedSpecialKeyTest() {
+		final Map<String, Object> map = new HashMap<>();
+
+		// 嵌套设置包含特殊字符的key
+		BeanPath beanPath = BeanPath.create("outer\\,key.inner\\:key");
+		beanPath.set(map, "nestedValue");
+
+		// 验证结构
+		@SuppressWarnings("unchecked")
+		Map<String, Object> outer = (Map<String, Object>) map.get("outer,key");
+		assertEquals("nestedValue", outer.get("inner:key"));
+
+		// 再次验证get
+		assertEquals("nestedValue", beanPath.get(map));
+	}
+
 	@Data
 	static class MyUser {
 		private String[] hobby;


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [新特性]  BeanPath支持使用反斜杠转义冒号、逗号和单引号作为键名

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过