### PR TITLE
[issue-4188]布隆过滤器AbstractFilter 的 init 方法在 maxValue 小于 machineNum 时导致数组越界异常

### DIFF
--- a/hutool-bloomFilter/src/main/java/cn/hutool/bloomfilter/filter/AbstractFilter.java
+++ b/hutool-bloomFilter/src/main/java/cn/hutool/bloomfilter/filter/AbstractFilter.java
@@ -48,12 +48,13 @@ public abstract class AbstractFilter implements BloomFilter {
 	 */
 	public void init(long maxValue, int machineNum) {
 		this.size = Assert.checkBetween(maxValue, 1, Integer.MAX_VALUE);
+		final int capacity = (int) ((this.size + machineNum - 1) / machineNum);
 		switch (machineNum) {
 		case BitMap.MACHINE32:
-			bm = new IntMap((int) (size / machineNum));
+			bm = new IntMap(capacity);
 			break;
 		case BitMap.MACHINE64:
-			bm = new LongMap((int) (size / machineNum));
+			bm = new LongMap(capacity);
 			break;
 		default:
 			throw new RuntimeException("Error Machine number!");

--- a/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/AbstractFilterTest.java
+++ b/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/AbstractFilterTest.java
@@ -1,0 +1,30 @@
+package cn.hutool.bloomfilter;
+
+import cn.hutool.bloomfilter.bitMap.BitMap;
+import cn.hutool.bloomfilter.filter.DefaultFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class AbstractFilterTest {
+
+	@Test
+	void testInitWhenMaxValueLessThanMachineNum() {
+		assertDoesNotThrow(() -> {
+			DefaultFilter filter = new DefaultFilter(1, BitMap.MACHINE32);
+			filter.add("init");
+		}, "maxValue=1且machineNum=32时add应无异常");
+		assertDoesNotThrow(() -> {
+			DefaultFilter filter = new DefaultFilter(31, BitMap.MACHINE32);
+			filter.add("init");
+		}, "maxValue=31且machineNum=32时add应无异常");
+		assertDoesNotThrow(() -> {
+			DefaultFilter filter = new DefaultFilter(1, BitMap.MACHINE64);
+			filter.add("init");
+		}, "maxValue=1且machineNum=64时add应无异常");
+		assertDoesNotThrow(() -> {
+			DefaultFilter filter = new DefaultFilter(63, BitMap.MACHINE64);
+			filter.add("init");
+		}, "maxValue=63且machineNum=64时add应无异常");
+	}
+}


### PR DESCRIPTION

1. [bug修复] 修复布隆过滤器AbstractFilter 的 init 方法在 maxValue 小于 machineNum 时导致数组越界异常，并且补充AbstractFilter的init方法单元测试案例。

