### PR TITLE
【issues/4196】增强 BitSetBloomFilter 构造器的参数有效性校验逻辑

### DIFF
--- a/hutool-bloomFilter/src/main/java/cn/hutool/bloomfilter/BitSetBloomFilter.java
+++ b/hutool-bloomFilter/src/main/java/cn/hutool/bloomfilter/BitSetBloomFilter.java
@@ -2,6 +2,7 @@ package cn.hutool.bloomfilter;
 
 import cn.hutool.core.io.FileUtil;
 import cn.hutool.core.io.IoUtil;
+import cn.hutool.core.lang.Assert;
 import cn.hutool.core.util.CharsetUtil;
 import cn.hutool.core.util.HashUtil;
 
@@ -32,7 +33,9 @@ public class BitSetBloomFilter implements BloomFilter {
 	 * @param k 哈希函数的个数，等同每条记录要占用的bit数，此处值取值为1~8
 	 */
 	public BitSetBloomFilter(int c, int n, int k) {
-		this.hashFunctionNumber = k;
+		Assert.isTrue(c > 0, "Parameter c must be positive");
+		Assert.isTrue(n > 0, "Parameter n must be positive");
+		this.hashFunctionNumber = Assert.checkBetween(k, 1, 8,"hashFunctionNumber must be between 1 and 8");
 		this.bitSetSize = (int) Math.ceil(c * k);
 		this.addedElements = n;
 		this.bitSet = new BitSet(this.bitSetSize);

--- a/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/BitSetBloomFilterTest.java
+++ b/hutool-bloomFilter/src/test/java/cn/hutool/bloomfilter/BitSetBloomFilterTest.java
@@ -1,0 +1,36 @@
+package cn.hutool.bloomfilter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BitSetBloomFilterTest {
+
+	@Test
+	public void testConstructorWithInvalidParameters() {
+		// 测试参数 c 的无效情况（c <= 0）
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(0, 100, 3);
+		});
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(-5, 100, 3);
+		});
+		// 测试参数 n 的无效情况 (n <= 0)
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(200, 0, 3);
+		});
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(200, -10, 3);
+		});
+		// 测试参数 k 的无效情况（k < 1 或 k > 8）
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(200, 100, 0);
+		});
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(200, 100, 9);
+		});
+		assertThrows(IllegalArgumentException.class, () -> {
+			new BitSetBloomFilter(200, 100, -2);
+		});
+	}
+}


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] 增强 BitSetBloomFilter 构造器的参数有效性校验逻辑，并且新增单元测试案例

