### PR TITLE
fix: correct NumberUtil.parseNumber scientific notation parsing

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -2783,6 +2783,16 @@ public class NumberUtil {
 		// issue@4197@Github 转为半角
 		numberStr = Convert.toDBC(numberStr);
 
+		// issue#IDJ1NS@Gitee 处理科学计数法E+格式
+		// NumberFormat对E+格式支持不佳,使用BigDecimal直接解析
+		if (numberStr.contains("E") || numberStr.contains("e")) {
+			try {
+				return new BigDecimal(numberStr);
+			} catch (NumberFormatException e) {
+				// BigDecimal解析失败,继续使用NumberFormat尝试
+			}
+		}
+
 		try {
 			final NumberFormat format = NumberFormat.getInstance();
 			if (format instanceof DecimalFormat) {

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -389,6 +389,17 @@ public class NumberUtilTest {
 	}
 
 	@Test
+	public void parseNumberTest5() {
+		String numberstr1 = "8.37095942E+9";
+		Number result1 = NumberUtil.parseNumber(numberstr1);
+		// 转换成BigDecimal再输出完整数字
+		System.out.println(((BigDecimal) result1).toPlainString());
+		String numberstr2 = "8.37095942e+9";
+		Number result2 = NumberUtil.parseNumber(numberstr2);
+		System.out.println(((BigDecimal) result2).toPlainString());
+	}
+
+	@Test
 	public void parseHexNumberTest() {
 		// 千位分隔符去掉
 		final int v1 = NumberUtil.parseNumber("0xff").intValue();


### PR DESCRIPTION
#### 说明

本次 PR 提交至 v5-dev 分支，未修改代码风格，新增测试用例覆盖修复场景。

### 修改描述

1. [bug修复] 修复 NumberUtil.parseNumber 在解析科学计数法字符串时结果不正确的问题。
2. [新特性] 无

### 提交前自测

- 本地使用 JDK8 进行测试
- 已执行 mvn clean test，通过
- 已执行 mvn javadoc:javadoc，通过
- 新增测试用例 parseNumberTest5 覆盖科学计数法解析场景
- 关联 Issue: #IDJ1NS
