### PR TITLE
Add '.' to invalid characters in Windows file names

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
@@ -40,7 +40,7 @@ public class FileNameUtil {
 	/**
 	 * Windows下文件名中的无效字符
 	 */
-	private static final Pattern FILE_NAME_INVALID_PATTERN_WIN = Pattern.compile("[\\\\/:*?\"<>|\r\n]");
+	private static final Pattern FILE_NAME_INVALID_PATTERN_WIN = Pattern.compile("[\\\\/:*?\"<>|\r\n.]");
 
 	/**
 	 * 特殊后缀


### PR DESCRIPTION
In Windows 11, paths containing a period (.) will have the period automatically removed. Creating such paths will result in an error

win11系统下，带 `.` 的路径会自动去掉这个 `.`，如果是创建那么会报错。

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过