### PR TITLE
修复`CharSequenceUtil.center`两个重载方法的注释问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/CharSequenceUtil.java
@@ -3372,7 +3372,7 @@ public class CharSequenceUtil {
 	// ------------------------------------------------------------------------ center
 
 	/**
-	 * 居中字符串，两边补充指定字符串，如果指定长度小于字符串，则返回原字符串
+	 * 居中字符串，两边补充空格符，如果指定长度小于字符串，则返回原字符串
 	 *
 	 * <pre>
 	 * CharSequenceUtil.center(null, *)   = null
@@ -3393,7 +3393,7 @@ public class CharSequenceUtil {
 	}
 
 	/**
-	 * 居中字符串，两边补充指定字符串，如果指定长度小于字符串，则返回原字符串
+	 * 居中字符串，两边补充指定字符，如果指定长度小于字符串，则返回原字符串
 	 *
 	 * <pre>
 	 * CharSequenceUtil.center(null, *, *)     = null


### PR DESCRIPTION
#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过