### PR TITLE
fix: Windows文件名增加圆点.为无效字符 + 修复MailAccount字段类型

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/annotation/CacheableAnnotationAttribute.java
+++ b/hutool-core/src/main/java/cn/hutool/core/annotation/CacheableAnnotationAttribute.java
@@ -17,8 +17,8 @@ public class CacheableAnnotationAttribute implements AnnotationAttribute {
 	private volatile boolean valueInvoked;
 	private volatile Object value;
 
-	private boolean defaultValueInvoked;
-	private Object defaultValue;
+	private volatile boolean defaultValueInvoked;
+	private volatile Object defaultValue;
 
 	private final Annotation annotation;
 	private final Method attribute;

--- a/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/file/FileNameUtil.java
@@ -40,7 +40,7 @@ public class FileNameUtil {
 	/**
 	 * Windows下文件名中的无效字符
 	 */
-	private static final Pattern FILE_NAME_INVALID_PATTERN_WIN = Pattern.compile("[\\\\/:*?\"<>|\r\n]");
+	private static final Pattern FILE_NAME_INVALID_PATTERN_WIN = Pattern.compile("[\\\\/:*?\"<>|\r\n.]");
 
 	/**
 	 * 特殊后缀

--- a/hutool-extra/src/main/java/cn/hutool/extra/mail/MailAccount.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/mail/MailAccount.java
@@ -224,7 +224,7 @@ public class MailAccount implements Serializable {
 	 * @param isAuth 是否需要用户名密码验证
 	 * @return this
 	 */
-	public MailAccount setAuth(boolean isAuth) {
+	public MailAccount setAuth(Boolean isAuth) {
 		this.auth = isAuth;
 		return this;
 	}


### PR DESCRIPTION
修复内容：
1. Windows文件名增加圆点.为无效字符
2. 修复MailAccount中auth字段setter参数类型与字段类型不一致的问题
3. 添加defaultValueInvoked和defaultValue的volatile修饰符