### PR TITLE
fix(NumberUtil): 严格模式解析数字字符串 (issue#4177)

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -2659,6 +2659,11 @@ public class NumberUtil {
 			return Integer.parseInt(number.substring(2), 16);
 		}
 
+		// issue#4177@Github 严格模式：只有纯数字才能转换
+		if (!isNumber(number)) {
+			throw new NumberFormatException("For input string: \"" + number + "\"");
+		}
+
 		if (StrUtil.containsIgnoreCase(number, "E")) {
 			// 科学计数法忽略支持，科学计数法一般用于表示非常小和非常大的数字，这类数字转换为int后精度丢失，没有意义。
 			throw new NumberFormatException(StrUtil.format("Unsupported int format: [{}]", number));
@@ -2697,9 +2702,15 @@ public class NumberUtil {
 			return Long.parseLong(number.substring(2), 16);
 		}
 
+		// issue#4177@Github 严格模式：只有纯数字才能转换
+		if (!isNumber(number)) {
+			throw new NumberFormatException("For input string: \"" + number + "\"");
+		}
+
 		try {
 			return Long.parseLong(number);
 		} catch (NumberFormatException e) {
+			// 如果是科学计数法等特殊格式，尝试使用NumberUtil解析
 			return parseNumber(number).longValue();
 		}
 	}


### PR DESCRIPTION
## 修复 Issue #4177

### 问题描述
`NumberUtil.parseInt()/parseLong()` 在严格模式下，将类似 `000` 的字符串视为无效数字，但根据 `Integer.decode()` 的行为，这些应该是有效的十进制整数。

`NumberUtil.isNumber()` 在严格模式下，将类似 `96dc187f` 的字符串视为无效数字，但根据用户预期，非纯数字字符串应该转换失败，返回 null 或抛出异常。

### 修复内容
在 `parseInt()` 和 `parseLong()` 方法中，在调用 `parseLong()/parseInt()` 之前，先使用 `isNumber()` 进行严格校验，确保只有纯数字字符串才能转换。

### 测试
已在本地通过 JUnit 测试验证。

fixes #4177