### PR TITLE
[codex] Fix AI SPI classloader fallback

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/AIServiceFactory.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/AIServiceFactory.java
@@ -18,11 +18,10 @@ package cn.hutool.ai;
 
 import cn.hutool.ai.core.AIConfig;
 import cn.hutool.ai.core.AIService;
+import cn.hutool.ai.core.AISpiLoader;
 import cn.hutool.ai.core.AIServiceProvider;
-import cn.hutool.core.util.ServiceLoaderUtil;
 
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -37,9 +36,8 @@ public class AIServiceFactory {
 
 	// 加载所有 AIModelProvider 实现类
 	static {
-		final ServiceLoader<AIServiceProvider> loader = ServiceLoaderUtil.load(AIServiceProvider.class);
-		for (final AIServiceProvider provider : loader) {
-			providers.put(provider.getServiceName().toLowerCase(), provider);
+		for (final AIServiceProvider provider : AISpiLoader.load(AIServiceProvider.class)) {
+			providers.putIfAbsent(provider.getServiceName().toLowerCase(), provider);
 		}
 	}
 

--- a/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java
@@ -16,10 +16,7 @@
 
 package cn.hutool.ai.core;
 
-import cn.hutool.core.util.ServiceLoaderUtil;
-
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -34,9 +31,8 @@ public class AIConfigRegistry {
 
 	// 加载所有 AIConfig 实现类
 	static {
-		final ServiceLoader<AIConfig> loader = ServiceLoaderUtil.load(AIConfig.class);
-		for (final AIConfig config : loader) {
-			configClasses.put(config.getModelName().toLowerCase(), config.getClass());
+		for (final AIConfig config : AISpiLoader.load(AIConfig.class)) {
+			configClasses.putIfAbsent(config.getModelName().toLowerCase(), config.getClass());
 		}
 	}
 

--- a/hutool-ai/src/main/java/cn/hutool/ai/core/AISpiLoader.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/AISpiLoader.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.core;
+
+import cn.hutool.core.util.ClassLoaderUtil;
+import cn.hutool.core.util.ServiceLoaderUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * AI SPI 鍔犺浇宸ュ叿锛屽吋瀹?ContextClassLoader 鍜屾帴鍙ｅ畾涔夋墍鍦ㄧ殑 ClassLoader銆?
+ *
+ * @author Looly
+ * @since 5.8.45
+ */
+public class AISpiLoader {
+
+	private AISpiLoader() {
+		// static utility class
+	}
+
+	/**
+	 * 鎸夐『搴忓皾璇曞姞杞斤細褰撳墠绾跨▼ ContextClassLoader 浼樺厛锛屽叾娆℃槸 SPI 鎺ュ彛鎵€鍦?ClassLoader銆?
+	 *
+	 * @param type SPI 鎺ュ彛绫诲瀷
+	 * @param <T>  SPI 瀹炵幇绫诲瀷
+	 * @return 宸插姞杞界殑 SPI 瀹炵幇鍒楄〃
+	 */
+	public static <T> List<T> load(final Class<T> type) {
+		final List<T> services = new ArrayList<>();
+		final Set<ClassLoader> visited = Collections.newSetFromMap(new IdentityHashMap<ClassLoader, Boolean>());
+
+		load(services, visited, type, ClassLoaderUtil.getContextClassLoader());
+		load(services, visited, type, type.getClassLoader());
+
+		return services;
+	}
+
+	private static <T> void load(final List<T> services, final Set<ClassLoader> visited,
+								 final Class<T> type, final ClassLoader loader) {
+		if (loader == null || false == visited.add(loader)) {
+			return;
+		}
+
+		for (final T service : ServiceLoaderUtil.load(type, loader)) {
+			services.add(service);
+		}
+	}
+}

--- a/hutool-ai/src/test/java/cn/hutool/ai/AISpiClassLoaderCompatibilityTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/AISpiClassLoaderCompatibilityTest.java
@@ -1,0 +1,80 @@
+package cn.hutool.ai;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class AISpiClassLoaderCompatibilityTest {
+
+	@Test
+	void aiServiceFactoryFallsBackToModuleClassLoaderWhenContextClassLoaderCannotSeeSpi() throws Exception {
+		try (final URLClassLoader isolatedLoader = new URLClassLoader(currentClasspathUrls(), null);
+			 final URLClassLoader hiddenContextLoader = new URLClassLoader(new URL[0], null)) {
+			final Thread thread = Thread.currentThread();
+			final ClassLoader originalContextLoader = thread.getContextClassLoader();
+			try {
+				thread.setContextClassLoader(hiddenContextLoader);
+
+				final Class<?> builderClass = Class.forName("cn.hutool.ai.core.AIConfigBuilder", true, isolatedLoader);
+				final Object builder = builderClass.getConstructor(String.class).newInstance("openai");
+				builderClass.getMethod("setApiKey", String.class).invoke(builder, "test-key");
+				final Object config = builderClass.getMethod("build").invoke(builder);
+
+				final Class<?> factoryClass = Class.forName("cn.hutool.ai.AIServiceFactory", true, isolatedLoader);
+				final Class<?> aiConfigClass = Class.forName("cn.hutool.ai.core.AIConfig", true, isolatedLoader);
+				final Method getAIService = factoryClass.getMethod("getAIService", aiConfigClass);
+				final Object service = getAIService.invoke(null, config);
+
+				assertNotNull(service);
+				assertEquals("cn.hutool.ai.model.openai.OpenaiServiceImpl", service.getClass().getName());
+			} finally {
+				thread.setContextClassLoader(originalContextLoader);
+			}
+		}
+	}
+
+	@Test
+	void aiConfigRegistryFallsBackToModuleClassLoaderWhenContextClassLoaderCannotSeeSpi() throws Exception {
+		try (final URLClassLoader isolatedLoader = new URLClassLoader(currentClasspathUrls(), null);
+			 final URLClassLoader hiddenContextLoader = new URLClassLoader(new URL[0], null)) {
+			final Thread thread = Thread.currentThread();
+			final ClassLoader originalContextLoader = thread.getContextClassLoader();
+			try {
+				thread.setContextClassLoader(hiddenContextLoader);
+
+				final Class<?> registryClass = Class.forName("cn.hutool.ai.core.AIConfigRegistry", true, isolatedLoader);
+				final Method getConfigClass = registryClass.getMethod("getConfigClass", String.class);
+				final Class<?> configClass = (Class<?>) getConfigClass.invoke(null, "openai");
+
+				assertNotNull(configClass);
+				assertEquals("cn.hutool.ai.model.openai.OpenaiConfig", configClass.getName());
+			} finally {
+				thread.setContextClassLoader(originalContextLoader);
+			}
+		}
+	}
+
+	private static URL[] currentClasspathUrls() throws Exception {
+		return Arrays.stream(System.getProperty("java.class.path").split(File.pathSeparator))
+				.filter(path -> false == path.isEmpty())
+				.flatMap(AISpiClassLoaderCompatibilityTest::toUrlStream)
+				.toArray(URL[]::new);
+	}
+
+	private static Stream<URL> toUrlStream(final String path) {
+		try {
+			return Stream.of(Paths.get(path).toUri().toURL());
+		} catch (final Exception e) {
+			throw new IllegalStateException("Failed to convert classpath entry to URL: " + path, e);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- load AI SPI implementations from the thread context class loader first, then fall back to the SPI interface class loader
- apply the same fallback behavior to both AIServiceFactory and AIConfigRegistry`n- add regression tests that simulate a context class loader which cannot see the SPI resources

## Root cause
ServiceLoader was only using the current thread context class loader. In thread-pool or Spring-style execution environments, that loader may not be able to resolve META-INF/services, which leaves the AI provider/config registries empty and causes Unsupported model errors.

## Validation
- mvn -pl hutool-ai -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=AISpiClassLoaderCompatibilityTest,AIServiceFactoryTest test (run with JDK 8)