### PR TITLE
[codex] Fix HMAC JWT signer concurrency

### DIFF
--- a/hutool-jwt/src/main/java/cn/hutool/jwt/signers/HMacJWTSigner.java
+++ b/hutool-jwt/src/main/java/cn/hutool/jwt/signers/HMacJWTSigner.java
@@ -17,6 +17,7 @@ public class HMacJWTSigner implements JWTSigner {
 
 	private Charset charset = CharsetUtil.CHARSET_UTF_8;
 	private final HMac hMac;
+	private final Object lock = new Object();
 
 	/**
 	 * 构造
@@ -45,21 +46,27 @@ public class HMacJWTSigner implements JWTSigner {
 	 * @return 编码
 	 */
 	public HMacJWTSigner setCharset(Charset charset) {
-		this.charset = charset;
+		synchronized (this.lock) {
+			this.charset = charset;
+		}
 		return this;
 	}
 
 	@Override
 	public String sign(String headerBase64, String payloadBase64) {
-		return hMac.digestBase64(StrUtil.format("{}.{}", headerBase64, payloadBase64), charset, true);
+		synchronized (this.lock) {
+			return hMac.digestBase64(StrUtil.format("{}.{}", headerBase64, payloadBase64), charset, true);
+		}
 	}
 
 	@Override
 	public boolean verify(String headerBase64, String payloadBase64, String signBase64) {
-		final String sign = sign(headerBase64, payloadBase64);
-		return hMac.verify(
-				StrUtil.bytes(sign, charset),
-				StrUtil.bytes(signBase64, charset));
+		synchronized (this.lock) {
+			final String sign = hMac.digestBase64(StrUtil.format("{}.{}", headerBase64, payloadBase64), charset, true);
+			return hMac.verify(
+					StrUtil.bytes(sign, charset),
+					StrUtil.bytes(signBase64, charset));
+		}
 	}
 
 	@Override

--- a/hutool-jwt/src/test/java/cn/hutool/jwt/JWTSignerTest.java
+++ b/hutool-jwt/src/test/java/cn/hutool/jwt/JWTSignerTest.java
@@ -1,12 +1,18 @@
 package cn.hutool.jwt;
 
 import cn.hutool.core.date.DateUtil;
+import cn.hutool.core.thread.ThreadUtil;
 import cn.hutool.crypto.KeyUtil;
 import cn.hutool.jwt.signers.AlgorithmUtil;
 import cn.hutool.jwt.signers.JWTSigner;
 import cn.hutool.jwt.signers.JWTSignerUtil;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class JWTSignerTest {
 
@@ -24,6 +30,40 @@ public class JWTSignerTest {
 		final JWTSigner signer = JWTSignerUtil.hs256("123456".getBytes());
 
 		signAndVerify(signer);
+	}
+
+	@Test
+	public void sharedHs256SignerShouldBeSafeForConcurrentUse() throws InterruptedException {
+		final JWTSigner signer = JWTSignerUtil.hs256("123456".getBytes());
+		final int threadCount = 8;
+		final int iterationsPerThread = 200;
+		final CountDownLatch startLatch = new CountDownLatch(1);
+		final CountDownLatch doneLatch = new CountDownLatch(threadCount);
+		final AtomicReference<Throwable> failure = new AtomicReference<>();
+		final List<Runnable> tasks = new ArrayList<>(threadCount);
+
+		for (int i = 0; i < threadCount; i++) {
+			tasks.add(() -> {
+				try {
+					startLatch.await();
+					for (int j = 0; j < iterationsPerThread; j++) {
+						signAndVerify(signer);
+					}
+				} catch (Throwable e) {
+					failure.compareAndSet(null, e);
+				} finally {
+					doneLatch.countDown();
+				}
+			});
+		}
+
+		tasks.forEach(ThreadUtil::execute);
+		startLatch.countDown();
+		doneLatch.await();
+
+		if (failure.get() != null) {
+			fail(failure.get());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Summary`n- serialize access to the shared `HMac` instance inside `HMacJWTSigner`n- add a concurrent regression test for shared HS256 signer usage`n`n## Why`n`HMac` is documented as not thread-safe, but `HMacJWTSigner` keeps a single shared instance and reuses it across `sign` and `verify`. Under concurrent token validation, that can cause intermittent signature verification failures.`n`n## Validation`n- `mvn -pl hutool-jwt -am -Dsurefire.failIfNoSpecifiedTests=false -Dtest=JWTSignerTest,JWTValidatorTest,JWTUtilTest test`