### PR TITLE
fix: BeanConverter支持protected setter的Bean转换 #4245

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/impl/BeanConverter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/impl/BeanConverter.java
@@ -12,6 +12,7 @@ import cn.hutool.core.util.ReflectUtil;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.core.util.TypeUtil;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -78,8 +79,9 @@ public class BeanConverter<T> extends AbstractConverter<T> {
 		}
 
 		if(value instanceof Map ||
-				value instanceof ValueProvider ||
-				BeanUtil.isBean(value.getClass())) {
+			value instanceof ValueProvider ||
+			BeanUtil.isBean(value.getClass()) ||
+			hasAnySetter(value.getClass())) {
 			if(value instanceof Map && this.beanClass.isInterface()) {
 				// 将Map动态代理为Bean
 				return MapProxy.create((Map<?, ?>)value).toProxyBean(this.beanClass);
@@ -96,6 +98,21 @@ public class BeanConverter<T> extends AbstractConverter<T> {
 		}
 
 		throw new ConvertException("Unsupported source type: {}", value.getClass());
+	}
+
+	/**
+	 * 判断类是否有任意访问级别的setter方法（包括protected、private）
+	 *
+	 * @param clazz 待检测类
+	 * @return 是否有setter方法
+	 */
+	private boolean hasAnySetter(Class<?> clazz) {
+		for (Method method : clazz.getDeclaredMethods()) {
+			if (method.getParameterCount() == 1 && method.getName().startsWith("set")) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/hutool-core/src/test/java/cn/hutool/core/bean/Issue4245Test.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/Issue4245Test.java
@@ -1,0 +1,64 @@
+package cn.hutool.core.bean;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * https://github.com/chinabugotech/hutool/issues/4245
+ */
+public class Issue4245Test {
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	static class Order {
+		private Long orderId;
+		private String orderNo;
+		private List<OrderItem> orderItemList;
+	}
+
+	@Getter
+	@Setter(AccessLevel.PROTECTED)
+	@AllArgsConstructor(access = AccessLevel.PROTECTED)
+	@NoArgsConstructor
+	static class OrderItem {
+		private Long itemId;
+		private String productName;
+		private Integer quantity;
+	}
+
+	@Data
+	static class OrderDto {
+		private Long orderId;
+		private String orderNo;
+		private List<OrderItemDto> orderItemList;
+	}
+
+	@Data
+	static class OrderItemDto {
+		private Long itemId;
+		private String productName;
+		private Integer quantity;
+	}
+
+	@Test
+	public void testCopyPropertiesWithProtectedSetter() {
+		Order order = new Order(1L, "01", new ArrayList<>());
+		order.getOrderItemList().add(new OrderItem(1L, "aa", 1));
+
+		OrderDto dto = BeanUtil.copyProperties(order, OrderDto.class);
+
+		Assertions.assertNotNull(dto);
+		Assertions.assertEquals(Long.valueOf(1L), dto.getOrderId());
+		Assertions.assertEquals("01", dto.getOrderNo());
+		Assertions.assertNotNull(dto.getOrderItemList());
+	}
+}


### PR DESCRIPTION
### 修改描述
1. [bug修复] 修正BeanConverter在源对象setter为protected时抛出ConvertException的问题。BeanUtil.isBean()只检查public方法，导致protected setter的对象被判断为非Bean，BeanCopier无法处理。新增hasAnySetter()方法检查所有访问级别的setter，使protected setter的对象也能正常转换。

### 提交前自测
1. 已添加测试用例 Issue4245Test，本地测试通过
2. 关联 issue: #4245