### PR TITLE
feat(http-sign-v5): 新增HTTP AK/SK签名功能模块

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/AkSkCredentials.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/AkSkCredentials.java
@@ -1,0 +1,79 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.lang.Assert;
+
+/**
+ * AK/SK凭证。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class AkSkCredentials {
+
+	private final String accessKeyId;
+	private final String accessKeySecret;
+
+	/**
+	 * 构造AK/SK凭证。
+	 *
+	 * @param accessKeyId     访问身份ID
+	 * @param accessKeySecret 访问密钥
+	 * @return AK/SK凭证
+	 */
+	public static AkSkCredentials of(final String accessKeyId, final String accessKeySecret) {
+		return ofAccessKey(accessKeyId, accessKeySecret);
+	}
+
+	/**
+	 * 构造AK/SK凭证。
+	 *
+	 * @param accessKeyId     访问身份ID
+	 * @param accessKeySecret 访问密钥
+	 * @return AK/SK凭证
+	 */
+	public static AkSkCredentials ofAccessKey(final String accessKeyId, final String accessKeySecret) {
+		return new AkSkCredentials(accessKeyId, accessKeySecret);
+	}
+
+	/**
+	 * 通过AppId/AppSecret别名构造凭证。
+	 *
+	 * @param appId     应用ID
+	 * @param appSecret 应用密钥
+	 * @return AK/SK凭证
+	 */
+	public static AkSkCredentials ofAppIdAndAppSecret(final String appId, final String appSecret) {
+		return new AkSkCredentials(appId, appSecret);
+	}
+
+	/**
+	 * 构造。
+	 *
+	 * @param accessKeyId     访问身份ID
+	 * @param accessKeySecret 访问密钥
+	 */
+	public AkSkCredentials(final String accessKeyId, final String accessKeySecret) {
+		Assert.notBlank(accessKeyId, "AccessKeyId must be not blank!");
+		Assert.notBlank(accessKeySecret, "AccessKeySecret must be not blank!");
+		this.accessKeyId = accessKeyId;
+		this.accessKeySecret = accessKeySecret;
+	}
+
+	/**
+	 * 获取访问身份ID。
+	 *
+	 * @return 访问身份ID
+	 */
+	public String getAccessKeyId() {
+		return accessKeyId;
+	}
+
+	/**
+	 * 获取访问密钥。
+	 *
+	 * @return 访问密钥
+	 */
+	public String getAccessKeySecret() {
+		return accessKeySecret;
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/CanonicalRequest.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/CanonicalRequest.java
@@ -1,0 +1,133 @@
+package cn.hutool.crypto.sign.http;
+
+/**
+ * HTTP规范请求。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class CanonicalRequest {
+
+	/**
+	 * 默认签名版本。
+	 */
+	public static final String VERSION = "HTTP-SIGN-V1";
+
+	/**
+	 * 签名规范版本。
+	 */
+	private final String version;
+	/**
+	 * 规范化后的HTTP方法。
+	 */
+	private final String method;
+	/**
+	 * 规范化后的URI路径。
+	 */
+	private final String canonicalUri;
+	/**
+	 * 规范化后的Query字符串。
+	 */
+	private final String canonicalQuery;
+	/**
+	 * 规范化后的Header字符串。
+	 */
+	private final String canonicalHeaders;
+	/**
+	 * 请求体SHA-256摘要。
+	 */
+	private final String bodyHash;
+
+	/**
+	 * 构造规范请求。
+	 *
+	 * @param version          签名规范版本
+	 * @param method           HTTP方法
+	 * @param canonicalUri     规范化URI路径
+	 * @param canonicalQuery   规范化Query字符串
+	 * @param canonicalHeaders 规范化Header字符串
+	 * @param bodyHash         请求体摘要
+	 */
+	public CanonicalRequest(final String version, final String method, final String canonicalUri,
+							final String canonicalQuery, final String canonicalHeaders, final String bodyHash) {
+		this.version = version;
+		this.method = method;
+		this.canonicalUri = canonicalUri;
+		this.canonicalQuery = canonicalQuery;
+		this.canonicalHeaders = canonicalHeaders;
+		this.bodyHash = bodyHash;
+	}
+
+	/**
+	 * 获取签名规范版本。
+	 *
+	 * @return 签名规范版本
+	 */
+	public String getVersion() {
+		return version;
+	}
+
+	/**
+	 * 获取HTTP方法。
+	 *
+	 * @return HTTP方法
+	 */
+	public String getMethod() {
+		return method;
+	}
+
+	/**
+	 * 获取规范化URI路径。
+	 *
+	 * @return 规范化URI路径
+	 */
+	public String getCanonicalUri() {
+		return canonicalUri;
+	}
+
+	/**
+	 * 获取规范化Query字符串。
+	 *
+	 * @return 规范化Query字符串
+	 */
+	public String getCanonicalQuery() {
+		return canonicalQuery;
+	}
+
+	/**
+	 * 获取规范化Header字符串。
+	 *
+	 * @return 规范化Header字符串
+	 */
+	public String getCanonicalHeaders() {
+		return canonicalHeaders;
+	}
+
+	/**
+	 * 获取请求体SHA-256摘要。
+	 *
+	 * @return 请求体摘要
+	 */
+	public String getBodyHash() {
+		return bodyHash;
+	}
+
+	/**
+	 * 转为待签名字符串。
+	 *
+	 * @return 待签名字符串
+	 */
+	public String toStringToSign() {
+		return version + '\n'
+			+ method + '\n'
+			+ canonicalUri + '\n'
+			+ canonicalQuery + '\n'
+			+ canonicalHeaders + '\n'
+			+ bodyHash;
+	}
+
+	@Override
+	public String toString() {
+		return toStringToSign();
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignAlgorithm.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignAlgorithm.java
@@ -1,0 +1,83 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.util.StrUtil;
+import cn.hutool.crypto.digest.HmacAlgorithm;
+
+/**
+ * HTTP签名算法。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public enum HttpSignAlgorithm {
+	/**
+	 * HmacSHA256，默认推荐算法。
+	 */
+	HMAC_SHA256("HmacSHA256", HmacAlgorithm.HmacSHA256),
+	/**
+	 * HmacSHA1，仅用于兼容老系统。
+	 */
+	HMAC_SHA1("HmacSHA1", HmacAlgorithm.HmacSHA1),
+	/**
+	 * HmacSHA512。
+	 */
+	HMAC_SHA512("HmacSHA512", HmacAlgorithm.HmacSHA512),
+	/**
+	 * HmacMD5，仅用于兼容老系统。
+	 */
+	HMAC_MD5("HmacMD5", HmacAlgorithm.HmacMD5),
+	/**
+	 * HmacSM3，需要运行环境支持BouncyCastle。
+	 */
+	HMAC_SM3("HmacSM3", HmacAlgorithm.HmacSM3);
+
+	/**
+	 * Header中传输的标准算法名称。
+	 */
+	private final String algorithmName;
+	/**
+	 * Hutool HMAC算法枚举。
+	 */
+	private final HmacAlgorithm hmacAlgorithm;
+
+	HttpSignAlgorithm(final String algorithmName, final HmacAlgorithm hmacAlgorithm) {
+		this.algorithmName = algorithmName;
+		this.hmacAlgorithm = hmacAlgorithm;
+	}
+
+	/**
+	 * 获取请求头中使用的算法名。
+	 *
+	 * @return 算法名
+	 */
+	public String getAlgorithmName() {
+		return algorithmName;
+	}
+
+	/**
+	 * 转为Hutool HMAC算法。
+	 *
+	 * @return Hutool HMAC算法
+	 */
+	public HmacAlgorithm toHmacAlgorithm() {
+		return hmacAlgorithm;
+	}
+
+	/**
+	 * 根据算法名解析。
+	 *
+	 * @param value 算法名
+	 * @return 算法，无法解析返回{@code null}
+	 */
+	public static HttpSignAlgorithm of(final String value) {
+		if (StrUtil.isBlank(value)) {
+			return null;
+		}
+		for (final HttpSignAlgorithm algorithm : values()) {
+			if (algorithm.algorithmName.equalsIgnoreCase(value) || algorithm.name().equalsIgnoreCase(value)) {
+				return algorithm;
+			}
+		}
+		return null;
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignCanonical.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignCanonical.java
@@ -20,7 +20,7 @@ import java.util.TreeMap;
  * @author mumu
  * @since 5.8.45
  */
-class HttpSignCanonicalizer {
+class HttpSignCanonical {
 
 	private static final byte[] EMPTY_BODY = new byte[0];
 

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignCanonicalizer.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignCanonicalizer.java
@@ -1,0 +1,240 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.util.CharsetUtil;
+import cn.hutool.core.util.HexUtil;
+import cn.hutool.core.util.StrUtil;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * HTTP签名规范化工具。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+class HttpSignCanonicalizer {
+
+	private static final byte[] EMPTY_BODY = new byte[0];
+
+	/**
+	 * 空字节数组的SHA-256摘要，HTTP无请求体时使用。
+	 */
+	static final String EMPTY_BODY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+	/**
+	 * 创建规范请求。
+	 *
+	 * @param request 签名请求
+	 * @param config  签名配置
+	 * @return 规范请求
+	 */
+	CanonicalRequest canonicalize(final HttpSignRequest request, final HttpSignConfig config) {
+		final String method = canonicalMethod(request.getMethod());
+		return new CanonicalRequest(
+			CanonicalRequest.VERSION,
+			method,
+			canonicalizePath(request.getPath(), config.getCharset()),
+			canonicalizeQuery(request, config.getCharset()),
+			canonicalizeHeaders(request, config),
+			hashBody(method, request.getBodyBytes(), config)
+		);
+	}
+
+	private String canonicalMethod(final String method) {
+		final String upperMethod = nullToEmpty(method).trim().toUpperCase(Locale.ROOT);
+		if ("GET".equals(upperMethod) || "POST".equals(upperMethod)
+			|| "PUT".equals(upperMethod) || "DELETE".equals(upperMethod)) {
+			return upperMethod;
+		}
+		throw new HttpSignException(HttpSignErrorCode.SIGN_UNSUPPORTED_METHOD, "Unsupported HTTP method: " + method);
+	}
+
+	/**
+	 * 规范化URI路径。
+	 *
+	 * @param path    URI路径
+	 * @param charset 字符集
+	 * @return 规范化URI路径
+	 */
+	String canonicalizePath(final String path, final Charset charset) {
+		final String target = StrUtil.isBlank(path) ? "/" : path;
+		return percentEncode(target.startsWith("/") ? target : "/" + target, charset, true, true);
+	}
+
+	/**
+	 * 规范化查询参数。
+	 *
+	 * @param request 签名请求
+	 * @param charset 字符集
+	 * @return 规范化查询参数
+	 */
+	String canonicalizeQuery(final HttpSignRequest request, final Charset charset) {
+		if (CollUtil.isEmpty(request.getQueryParams())) {
+			return StrUtil.EMPTY;
+		}
+		final List<CanonicalQueryParam> canonicalQueryParams = new ArrayList<>();
+		for (final HttpSignRequest.QueryParam queryParam : request.getQueryParams()) {
+			final String rawName = nullToEmpty(queryParam.getName());
+			final String rawValue = nullToEmpty(queryParam.getValue());
+			canonicalQueryParams.add(new CanonicalQueryParam(
+				rawName,
+				rawValue,
+				percentEncode(rawName, charset, false, false),
+				percentEncode(rawValue, charset, false, false)
+			));
+		}
+		Collections.sort(canonicalQueryParams, new Comparator<CanonicalQueryParam>() {
+			@Override
+			public int compare(final CanonicalQueryParam param1, final CanonicalQueryParam param2) {
+				final int nameCompare = param1.rawName.compareTo(param2.rawName);
+				return 0 == nameCompare ? param1.rawValue.compareTo(param2.rawValue) : nameCompare;
+			}
+		});
+		final StringBuilder canonicalQuery = new StringBuilder();
+		for (final CanonicalQueryParam queryParam : canonicalQueryParams) {
+			if (canonicalQuery.length() > 0) {
+				canonicalQuery.append('&');
+			}
+			canonicalQuery.append(queryParam.encodedName).append('=').append(queryParam.encodedValue);
+		}
+		return canonicalQuery.toString();
+	}
+
+	/**
+	 * 规范化Header。
+	 *
+	 * @param request 签名请求
+	 * @param config  签名配置
+	 * @return 规范化Header
+	 */
+	String canonicalizeHeaders(final HttpSignRequest request, final HttpSignConfig config) {
+		final TreeMap<String, List<String>> signedHeaders = new TreeMap<>();
+		for (final Map.Entry<String, List<String>> entry : request.getHeaders().entrySet()) {
+			final String name = entry.getKey();
+			checkHeader(name, null);
+			final String lowerName = name.toLowerCase(Locale.ROOT);
+			if (config.getSignHeaderNames().isSignatureHeader(name) || false == config.isSignedHeader(lowerName)) {
+				continue;
+			}
+			List<String> values = signedHeaders.get(lowerName);
+			if (null == values) {
+				values = new ArrayList<>();
+				signedHeaders.put(lowerName, values);
+			}
+			if (null != entry.getValue()) {
+				for (final String value : entry.getValue()) {
+					checkHeader(name, value);
+					values.add(normalizeHeaderValue(value));
+				}
+			}
+		}
+		final StringBuilder canonicalHeaders = new StringBuilder();
+		for (final Map.Entry<String, List<String>> entry : signedHeaders.entrySet()) {
+			if (canonicalHeaders.length() > 0) {
+				canonicalHeaders.append('&');
+			}
+			canonicalHeaders.append(entry.getKey()).append('=').append(CollUtil.join(entry.getValue(), ","));
+		}
+		return canonicalHeaders.toString();
+	}
+
+	/**
+	 * 计算Body摘要。
+	 *
+	 * @param method    HTTP方法
+	 * @param bodyBytes Body字节
+	 * @param config    签名配置
+	 * @return SHA-256摘要16进制
+	 */
+	String hashBody(final String method, final byte[] bodyBytes, final HttpSignConfig config) {
+		// GET请求按无请求体处理，避免客户端误传Body导致签名不稳定。
+		if ("GET".equals(method)) {
+			return config.getBodyDigestAlgorithm().digestHex(EMPTY_BODY);
+		}
+		final byte[] bytes = null == bodyBytes ? EMPTY_BODY : bodyBytes;
+		if (bytes.length > config.getMaxBodySignBytes()) {
+			throw new HttpSignException(HttpSignErrorCode.SIGN_BODY_TOO_LARGE, "Body is too large to sign.");
+		}
+		return config.getBodyDigestAlgorithm().digestHex(bytes);
+	}
+
+	private static String normalizeHeaderValue(final String value) {
+		return nullToEmpty(value).trim().replaceAll("\\s+", " ");
+	}
+
+	private static void checkHeader(final String name, final String value) {
+		if (containsCrlf(name) || containsCrlf(value)) {
+			throw new HttpSignException(HttpSignErrorCode.SIGN_CANONICALIZE_FAILED, "Header contains CR/LF.");
+		}
+	}
+
+	private static boolean containsCrlf(final String value) {
+		return null != value && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0);
+	}
+
+	private static String nullToEmpty(final String value) {
+		return null == value ? "" : value;
+	}
+
+	private static String percentEncode(final String value, Charset charset, final boolean keepSlash, final boolean keepEncodedPercent) {
+		if (null == charset) {
+			charset = CharsetUtil.CHARSET_UTF_8;
+		}
+		final StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < value.length();) {
+			final int codePoint = value.codePointAt(i);
+			if (isUnreserved(codePoint) || (keepSlash && '/' == codePoint)) {
+				builder.appendCodePoint(codePoint);
+				i += Character.charCount(codePoint);
+			} else if (keepEncodedPercent && '%' == codePoint && i + 2 < value.length()
+				&& isHex(value.charAt(i + 1)) && isHex(value.charAt(i + 2))) {
+				builder.append('%')
+					.append(Character.toUpperCase(value.charAt(i + 1)))
+					.append(Character.toUpperCase(value.charAt(i + 2)));
+				i += 3;
+			} else {
+				final byte[] bytes = new String(Character.toChars(codePoint)).getBytes(charset);
+				for (final byte b : bytes) {
+					builder.append('%');
+					HexUtil.appendHex(builder, b, false);
+				}
+				i += Character.charCount(codePoint);
+			}
+		}
+		return builder.toString();
+	}
+
+	private static boolean isUnreserved(final int c) {
+		return c >= 'A' && c <= 'Z'
+			|| c >= 'a' && c <= 'z'
+			|| c >= '0' && c <= '9'
+			|| '-' == c || '_' == c || '.' == c || '~' == c;
+	}
+
+	private static boolean isHex(final char c) {
+		return c >= '0' && c <= '9' || c >= 'A' && c <= 'F' || c >= 'a' && c <= 'f';
+	}
+
+	private static class CanonicalQueryParam {
+		private final String rawName;
+		private final String rawValue;
+		private final String encodedName;
+		private final String encodedValue;
+
+		private CanonicalQueryParam(final String rawName, final String rawValue,
+									final String encodedName, final String encodedValue) {
+			this.rawName = rawName;
+			this.rawValue = rawValue;
+			this.encodedName = encodedName;
+			this.encodedValue = encodedValue;
+		}
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignConfig.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignConfig.java
@@ -1,0 +1,468 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.util.CharsetUtil;
+
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * HTTP签名配置。
+ * <p>
+ * 此对象为可变配置对象，适合在启动阶段或调用前组装参数；不建议在多个线程中同时修改同一个实例。
+ * {@link HttpSigner}和{@link HttpSignVerifier}会在构造时复制配置快照，构造完成后可安全复用。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSignConfig {
+
+	/**
+	 * 默认Body签名大小上限：1MB。
+	 */
+	public static final long DEFAULT_MAX_BODY_SIGN_BYTES = 1024L * 1024L;
+	/**
+	 * 默认时间戳允许偏移秒数。
+	 */
+	public static final long DEFAULT_TIMESTAMP_SKEW_SECONDS = 300L;
+
+	/**
+	 * 客户端默认使用的签名算法。
+	 */
+	private HttpSignAlgorithm defaultAlgorithm = HttpSignAlgorithm.HMAC_SHA256;
+	/**
+	 * Body摘要算法。
+	 */
+	private HttpSignDigestAlgorithm bodyDigestAlgorithm = HttpSignDigestAlgorithm.SHA256;
+	/**
+	 * 服务端全局允许使用的签名算法白名单。
+	 */
+	private Set<HttpSignAlgorithm> allowedAlgorithmSet = new LinkedHashSet<>();
+	/**
+	 * 签名结果编码方式。
+	 */
+	private SignatureEncoding signatureEncoding = SignatureEncoding.BASE64;
+	/**
+	 * 签名字符串和密钥转字节时使用的字符集。
+	 */
+	private Charset charset = CharsetUtil.CHARSET_UTF_8;
+	/**
+	 * 服务端验签允许的时间戳偏移秒数。
+	 */
+	private long timestampSkewSeconds = DEFAULT_TIMESTAMP_SKEW_SECONDS;
+	/**
+	 * 请求体参与摘要计算的最大字节数。
+	 */
+	private long maxBodySignBytes = DEFAULT_MAX_BODY_SIGN_BYTES;
+	/**
+	 * 签名相关Header名称配置。
+	 */
+	private SignHeaderNames signHeaderNames = SignHeaderNames.defaultHeaders();
+	/**
+	 * 时间戳提供器。
+	 */
+	private TimestampProvider timestampProvider = TimestampProvider.SYSTEM;
+	/**
+	 * Nonce生成器。
+	 */
+	private NonceGenerator nonceGenerator = NonceGenerator.UUID_GENERATOR;
+	/**
+	 * 业务额外要求参与签名的Header名称集合，小写保存。
+	 */
+	private Set<String> extraSignedHeaderNameSet = new LinkedHashSet<>();
+	/**
+	 * 明确排除签名的Header名称集合，小写保存。
+	 */
+	private Set<String> excludedHeaderNameSet = defaultExcludedHeaderNames();
+
+	/**
+	 * 创建默认配置。
+	 *
+	 * @return 签名配置
+	 */
+	public static HttpSignConfig create() {
+		return new HttpSignConfig();
+	}
+
+	/**
+	 * 构造。
+	 */
+	public HttpSignConfig() {
+		this.allowedAlgorithmSet.add(HttpSignAlgorithm.HMAC_SHA256);
+	}
+
+	/**
+	 * 复制配置。
+	 *
+	 * @return 配置副本
+	 */
+	public HttpSignConfig copy() {
+		return create()
+			.setDefaultAlgorithm(this.defaultAlgorithm)
+			.setBodyDigestAlgorithm(this.bodyDigestAlgorithm)
+			.setAllowedAlgorithms(this.allowedAlgorithmSet)
+			.setSignatureEncoding(this.signatureEncoding)
+			.setCharset(this.charset)
+			.setTimestampSkewSeconds(this.timestampSkewSeconds)
+			.setMaxBodySignBytes(this.maxBodySignBytes)
+			.setSignHeaderNames(null == this.signHeaderNames ? null : this.signHeaderNames.copy())
+			.setTimestampProvider(this.timestampProvider)
+			.setNonceGenerator(this.nonceGenerator)
+			.setSignedHeaderNames(this.extraSignedHeaderNameSet)
+			.setExcludedHeaderNames(this.excludedHeaderNameSet);
+	}
+
+	/**
+	 * 获取默认不参与签名的Header名称。
+	 *
+	 * @return 小写Header名称集合
+	 */
+	public static Set<String> defaultExcludedHeaderNames() {
+		final Set<String> excludedHeaderNames = new LinkedHashSet<>();
+		excludedHeaderNames.add("authorization");
+		excludedHeaderNames.add("content-length");
+		excludedHeaderNames.add("host");
+		excludedHeaderNames.add("user-agent");
+		excludedHeaderNames.add("connection");
+		excludedHeaderNames.add("accept");
+		excludedHeaderNames.add("accept-encoding");
+		return excludedHeaderNames;
+	}
+
+	/**
+	 * 获取客户端默认签名算法。
+	 *
+	 * @return 签名算法
+	 */
+	public HttpSignAlgorithm getDefaultAlgorithm() {
+		return defaultAlgorithm;
+	}
+
+	/**
+	 * 设置客户端默认签名算法。
+	 *
+	 * @param defaultAlgorithm 签名算法
+	 * @return this
+	 */
+	public HttpSignConfig setDefaultAlgorithm(final HttpSignAlgorithm defaultAlgorithm) {
+		this.defaultAlgorithm = defaultAlgorithm;
+		return this;
+	}
+
+	/**
+	 * 获取Body摘要算法。
+	 *
+	 * @return Body摘要算法
+	 */
+	public HttpSignDigestAlgorithm getBodyDigestAlgorithm() {
+		return null == bodyDigestAlgorithm ? HttpSignDigestAlgorithm.SHA256 : bodyDigestAlgorithm;
+	}
+
+	/**
+	 * 设置Body摘要算法。
+	 *
+	 * @param bodyDigestAlgorithm Body摘要算法
+	 * @return this
+	 */
+	public HttpSignConfig setBodyDigestAlgorithm(final HttpSignDigestAlgorithm bodyDigestAlgorithm) {
+		this.bodyDigestAlgorithm = bodyDigestAlgorithm;
+		return this;
+	}
+
+	/**
+	 * 获取服务端允许使用的签名算法集合。
+	 *
+	 * @return 签名算法集合
+	 */
+	public Set<HttpSignAlgorithm> getAllowedAlgorithms() {
+		return Collections.unmodifiableSet(allowedAlgorithmSet);
+	}
+
+	/**
+	 * 设置服务端允许使用的签名算法集合。
+	 *
+	 * @param allowedAlgorithms 签名算法集合
+	 * @return this
+	 */
+	public HttpSignConfig setAllowedAlgorithms(final Set<HttpSignAlgorithm> allowedAlgorithms) {
+		this.allowedAlgorithmSet = new LinkedHashSet<>();
+		if (null != allowedAlgorithms) {
+			this.allowedAlgorithmSet.addAll(allowedAlgorithms);
+		}
+		return this;
+	}
+
+	/**
+	 * 设置服务端允许使用的签名算法。
+	 *
+	 * @param algorithms 签名算法
+	 * @return this
+	 */
+	public HttpSignConfig allowAlgorithms(final HttpSignAlgorithm... algorithms) {
+		this.allowedAlgorithmSet.clear();
+		if (null != algorithms) {
+			Collections.addAll(this.allowedAlgorithmSet, algorithms);
+		}
+		return this;
+	}
+
+	/**
+	 * 获取签名输出编码。
+	 *
+	 * @return 签名输出编码
+	 */
+	public SignatureEncoding getSignatureEncoding() {
+		return null == signatureEncoding ? SignatureEncoding.BASE64 : signatureEncoding;
+	}
+
+	/**
+	 * 设置签名输出编码。
+	 *
+	 * @param signatureEncoding 签名输出编码
+	 * @return this
+	 */
+	public HttpSignConfig setSignatureEncoding(final SignatureEncoding signatureEncoding) {
+		this.signatureEncoding = signatureEncoding;
+		return this;
+	}
+
+	/**
+	 * 获取签名字符串字符集。
+	 *
+	 * @return 字符集
+	 */
+	public Charset getCharset() {
+		return null == charset ? CharsetUtil.CHARSET_UTF_8 : charset;
+	}
+
+	/**
+	 * 设置签名字符串字符集。
+	 *
+	 * @param charset 字符集
+	 * @return this
+	 */
+	public HttpSignConfig setCharset(final Charset charset) {
+		this.charset = charset;
+		return this;
+	}
+
+	/**
+	 * 获取时间戳允许偏移秒数。
+	 *
+	 * @return 秒数
+	 */
+	public long getTimestampSkewSeconds() {
+		return timestampSkewSeconds;
+	}
+
+	/**
+	 * 设置时间戳允许偏移秒数。
+	 *
+	 * @param timestampSkewSeconds 秒数
+	 * @return this
+	 */
+	public HttpSignConfig setTimestampSkewSeconds(final long timestampSkewSeconds) {
+		this.timestampSkewSeconds = timestampSkewSeconds;
+		return this;
+	}
+
+	/**
+	 * 获取参与签名的Body最大字节数。
+	 *
+	 * @return 最大字节数
+	 */
+	public long getMaxBodySignBytes() {
+		return maxBodySignBytes;
+	}
+
+	/**
+	 * 设置参与签名的Body最大字节数。
+	 *
+	 * @param maxBodySignBytes 最大字节数
+	 * @return this
+	 */
+	public HttpSignConfig setMaxBodySignBytes(final long maxBodySignBytes) {
+		this.maxBodySignBytes = maxBodySignBytes;
+		return this;
+	}
+
+	/**
+	 * 获取签名Header名称配置。
+	 *
+	 * @return 签名Header名称配置
+	 */
+	public SignHeaderNames getSignHeaderNames() {
+		return null == signHeaderNames ? SignHeaderNames.defaultHeaders() : signHeaderNames;
+	}
+
+	/**
+	 * 设置签名Header名称配置。
+	 *
+	 * @param signHeaderNames 签名Header名称配置
+	 * @return this
+	 */
+	public HttpSignConfig setSignHeaderNames(final SignHeaderNames signHeaderNames) {
+		this.signHeaderNames = signHeaderNames;
+		return this;
+	}
+
+	/**
+	 * 获取时间戳提供器。
+	 *
+	 * @return 时间戳提供器
+	 */
+	public TimestampProvider getTimestampProvider() {
+		return null == timestampProvider ? TimestampProvider.SYSTEM : timestampProvider;
+	}
+
+	/**
+	 * 设置时间戳提供器。
+	 *
+	 * @param timestampProvider 时间戳提供器
+	 * @return this
+	 */
+	public HttpSignConfig setTimestampProvider(final TimestampProvider timestampProvider) {
+		this.timestampProvider = timestampProvider;
+		return this;
+	}
+
+	/**
+	 * 获取Nonce生成器。
+	 *
+	 * @return Nonce生成器
+	 */
+	public NonceGenerator getNonceGenerator() {
+		return null == nonceGenerator ? NonceGenerator.UUID_GENERATOR : nonceGenerator;
+	}
+
+	/**
+	 * 设置Nonce生成器。
+	 *
+	 * @param nonceGenerator Nonce生成器
+	 * @return this
+	 */
+	public HttpSignConfig setNonceGenerator(final NonceGenerator nonceGenerator) {
+		this.nonceGenerator = nonceGenerator;
+		return this;
+	}
+
+	/**
+	 * 获取额外参与签名的Header名称。
+	 *
+	 * @return 小写Header名称集合
+	 */
+	public Set<String> getSignedHeaderNames() {
+		return Collections.unmodifiableSet(extraSignedHeaderNameSet);
+	}
+
+	/**
+	 * 设置额外参与签名的Header名称。
+	 *
+	 * @param signedHeaderNames Header名称集合
+	 * @return this
+	 */
+	public HttpSignConfig setSignedHeaderNames(final Set<String> signedHeaderNames) {
+		this.extraSignedHeaderNameSet = normalizeHeaderNameSet(signedHeaderNames);
+		return this;
+	}
+
+	/**
+	 * 增加额外参与签名的Header名称。
+	 *
+	 * @param headerName Header名称
+	 * @return this
+	 */
+	public HttpSignConfig addSignedHeaderName(final String headerName) {
+		final String normalizedHeaderName = normalizeHeaderName(headerName);
+		if (null != normalizedHeaderName) {
+			this.extraSignedHeaderNameSet.add(normalizedHeaderName);
+		}
+		return this;
+	}
+
+	/**
+	 * 获取不参与签名的Header名称。
+	 *
+	 * @return 小写Header名称集合
+	 */
+	public Set<String> getExcludedHeaderNames() {
+		return Collections.unmodifiableSet(excludedHeaderNameSet);
+	}
+
+	/**
+	 * 设置不参与签名的Header名称。
+	 *
+	 * @param excludedHeaderNames Header名称集合
+	 * @return this
+	 */
+	public HttpSignConfig setExcludedHeaderNames(final Set<String> excludedHeaderNames) {
+		this.excludedHeaderNameSet = normalizeHeaderNameSet(excludedHeaderNames);
+		return this;
+	}
+
+	/**
+	 * 增加不参与签名的Header名称。
+	 *
+	 * @param headerName Header名称
+	 * @return this
+	 */
+	public HttpSignConfig addExcludedHeaderName(final String headerName) {
+		final String normalizedHeaderName = normalizeHeaderName(headerName);
+		if (null != normalizedHeaderName) {
+			this.excludedHeaderNameSet.add(normalizedHeaderName);
+		}
+		return this;
+	}
+
+	/**
+	 * 判断Header是否参与签名。
+	 *
+	 * @param headerName Header名称
+	 * @return 是否参与签名
+	 */
+	public boolean isSignedHeader(final String headerName) {
+		if (null == headerName) {
+			return false;
+		}
+		final String lowerName = headerName.trim().toLowerCase(Locale.ROOT);
+		return !isExcludedHeader(lowerName)
+			&& (getSignHeaderNames().signedHeaderNameSet().contains(lowerName) || extraSignedHeaderNameSet.contains(lowerName));
+	}
+
+	/**
+	 * 判断Header是否排除签名。
+	 *
+	 * @param headerName Header名称
+	 * @return 是否排除签名
+	 */
+	public boolean isExcludedHeader(final String headerName) {
+		final String normalizedHeaderName = normalizeHeaderName(headerName);
+		return null != normalizedHeaderName && excludedHeaderNameSet.contains(normalizedHeaderName);
+	}
+
+	private static Set<String> normalizeHeaderNameSet(final Set<String> rawHeaderNameSet) {
+		final Set<String> normalizedHeaderNames = new LinkedHashSet<>();
+		if (null != rawHeaderNameSet) {
+			for (final String headerName : rawHeaderNameSet) {
+				final String normalizedHeaderName = normalizeHeaderName(headerName);
+				if (null != normalizedHeaderName) {
+					normalizedHeaderNames.add(normalizedHeaderName);
+				}
+			}
+		}
+		return normalizedHeaderNames;
+	}
+
+	private static String normalizeHeaderName(final String headerName) {
+		if (null == headerName) {
+			return null;
+		}
+		if (headerName.indexOf('\r') >= 0 || headerName.indexOf('\n') >= 0) {
+			throw new HttpSignException(HttpSignErrorCode.SIGN_CANONICALIZE_FAILED, "Header name contains CR/LF.");
+		}
+		final String trimmedHeaderName = headerName.trim();
+		return trimmedHeaderName.isEmpty() ? null : trimmedHeaderName.toLowerCase(Locale.ROOT);
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignDigestAlgorithm.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignDigestAlgorithm.java
@@ -1,0 +1,63 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.crypto.digest.DigestAlgorithm;
+import cn.hutool.crypto.digest.DigestUtil;
+
+/**
+ * HTTP签名Body摘要算法。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public enum HttpSignDigestAlgorithm {
+	/**
+	 * SHA-256，默认推荐算法。
+	 */
+	SHA256("SHA-256", DigestAlgorithm.SHA256),
+	/**
+	 * SHA-1，仅用于兼容老系统。
+	 */
+	SHA1("SHA-1", DigestAlgorithm.SHA1),
+	/**
+	 * SHA-512。
+	 */
+	SHA512("SHA-512", DigestAlgorithm.SHA512),
+	/**
+	 * MD5，仅用于兼容老系统。
+	 */
+	MD5("MD5", DigestAlgorithm.MD5),
+	/**
+	 * 国密SM3摘要算法。
+	 */
+	SM3("SM3", null);
+
+	/**
+	 * 算法名称。
+	 */
+	private final String algorithmName;
+	/**
+	 * Hutool摘要算法枚举，SM3单独使用Hutool SM3实现。
+	 */
+	private final DigestAlgorithm digestAlgorithm;
+
+	HttpSignDigestAlgorithm(final String algorithmName, final DigestAlgorithm digestAlgorithm) {
+		this.algorithmName = algorithmName;
+		this.digestAlgorithm = digestAlgorithm;
+	}
+
+	/**
+	 * 获取算法名称。
+	 *
+	 * @return 算法名称
+	 */
+	public String getAlgorithmName() {
+		return algorithmName;
+	}
+
+	String digestHex(final byte[] data) {
+		if (SM3.equals(this)) {
+			return cn.hutool.crypto.digest.SM3.create().digestHex(data);
+		}
+		return DigestUtil.digester(this.digestAlgorithm).digestHex(data);
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignErrorCode.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignErrorCode.java
@@ -1,0 +1,74 @@
+package cn.hutool.crypto.sign.http;
+
+/**
+ * HTTP签名错误码。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public enum HttpSignErrorCode {
+	/**
+	 * 缺少访问身份ID。
+	 */
+	SIGN_MISSING_ACCESS_KEY_ID,
+	/**
+	 * 缺少时间戳。
+	 */
+	SIGN_MISSING_TIMESTAMP,
+	/**
+	 * 缺少Nonce。
+	 */
+	SIGN_MISSING_NONCE,
+	/**
+	 * 缺少签名算法。
+	 */
+	SIGN_MISSING_ALGORITHM,
+	/**
+	 * 缺少签名值。
+	 */
+	SIGN_MISSING_SIGNATURE,
+	/**
+	 * 不支持的HTTP方法。
+	 */
+	SIGN_UNSUPPORTED_METHOD,
+	/**
+	 * 不支持或不允许的签名算法。
+	 */
+	SIGN_UNSUPPORTED_ALGORITHM,
+	/**
+	 * 未找到访问身份ID对应的密钥。
+	 */
+	SIGN_ACCESS_KEY_NOT_FOUND,
+	/**
+	 * 访问密钥已禁用。
+	 */
+	SIGN_ACCESS_KEY_DISABLED,
+	/**
+	 * 访问密钥已过期。
+	 */
+	SIGN_SECRET_EXPIRED,
+	/**
+	 * 时间戳格式非法。
+	 */
+	SIGN_TIMESTAMP_INVALID,
+	/**
+	 * 时间戳偏移超过允许范围。
+	 */
+	SIGN_TIMESTAMP_SKEW,
+	/**
+	 * Nonce重复。
+	 */
+	SIGN_NONCE_REPLAY,
+	/**
+	 * Body超过允许签名大小。
+	 */
+	SIGN_BODY_TOO_LARGE,
+	/**
+	 * 规范化请求失败。
+	 */
+	SIGN_CANONICALIZE_FAILED,
+	/**
+	 * 签名不匹配。
+	 */
+	SIGN_MISMATCH
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignException.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignException.java
@@ -1,0 +1,46 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.crypto.CryptoException;
+
+/**
+ * HTTP签名异常。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSignException extends CryptoException {
+	private static final long serialVersionUID = 1L;
+
+	private final HttpSignErrorCode errorCode;
+
+	/**
+	 * 构造。
+	 *
+	 * @param errorCode 错误码
+	 * @param message   错误消息
+	 */
+	public HttpSignException(final HttpSignErrorCode errorCode, final String message) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	/**
+	 * 构造。
+	 *
+	 * @param errorCode 错误码
+	 * @param throwable 原始异常
+	 */
+	public HttpSignException(final HttpSignErrorCode errorCode, final Throwable throwable) {
+		super(throwable);
+		this.errorCode = errorCode;
+	}
+
+	/**
+	 * 获取错误码。
+	 *
+	 * @return 错误码
+	 */
+	public HttpSignErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignRequest.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignRequest.java
@@ -1,0 +1,355 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.util.ArrayUtil;
+import cn.hutool.core.util.CharsetUtil;
+
+import java.lang.reflect.Array;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * HTTP签名请求，是签名核心模块使用的轻量请求模型。
+ * <p>
+ * 此对象为可变对象，不保证并发修改安全。调用方应在单线程中构造完成后再传入签名或验签流程。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSignRequest {
+
+	private String method;
+	private String path;
+	private final List<QueryParam> queryParamList = new ArrayList<>();
+	private final Map<String, List<String>> headerMap = new LinkedHashMap<>();
+	private byte[] bodyBytes;
+
+	/**
+	 * 创建请求。
+	 *
+	 * @return 请求
+	 */
+	public static HttpSignRequest create() {
+		return new HttpSignRequest();
+	}
+
+	/**
+	 * 获取HTTP方法。
+	 *
+	 * @return HTTP方法
+	 */
+	public String getMethod() {
+		return method;
+	}
+
+	/**
+	 * 设置HTTP方法。
+	 *
+	 * @param method HTTP方法
+	 * @return this
+	 */
+	public HttpSignRequest setMethod(final String method) {
+		this.method = method;
+		return this;
+	}
+
+	/**
+	 * 获取请求路径。
+	 *
+	 * @return 请求路径
+	 */
+	public String getPath() {
+		return path;
+	}
+
+	/**
+	 * 设置请求路径。
+	 *
+	 * @param path 请求路径
+	 * @return this
+	 */
+	public HttpSignRequest setPath(final String path) {
+		this.path = path;
+		return this;
+	}
+
+	/**
+	 * 获取查询参数列表。
+	 *
+	 * @return 查询参数列表
+	 */
+	public List<QueryParam> getQueryParams() {
+		return Collections.unmodifiableList(queryParamList);
+	}
+
+	/**
+	 * 增加查询参数。
+	 *
+	 * @param name  参数名
+	 * @param value 参数值，{@code null}按空字符串处理
+	 * @return this
+	 */
+	public HttpSignRequest addQueryParam(final String name, final Object value) {
+		if (value instanceof Iterable) {
+			for (final Object item : (Iterable<?>) value) {
+				addQueryParam(name, item);
+			}
+			return this;
+		}
+		if (null != value && value.getClass().isArray()) {
+			final int length = Array.getLength(value);
+			for (int i = 0; i < length; i++) {
+				addQueryParam(name, Array.get(value, i));
+			}
+			return this;
+		}
+		this.queryParamList.add(new QueryParam(name, null == value ? "" : String.valueOf(value)));
+		return this;
+	}
+
+	/**
+	 * 设置查询参数并清空已有查询参数。
+	 *
+	 * @param queryParams 查询参数
+	 * @return this
+	 */
+	public HttpSignRequest setQueryParams(final Map<String, ?> queryParams) {
+		this.queryParamList.clear();
+		if (null != queryParams) {
+			for (final Map.Entry<String, ?> entry : queryParams.entrySet()) {
+				addQueryParam(entry.getKey(), entry.getValue());
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * 获取Header映射。
+	 *
+	 * @return Header映射
+	 */
+	public Map<String, List<String>> getHeaders() {
+		final Map<String, List<String>> headers = new LinkedHashMap<>();
+		for (final Map.Entry<String, List<String>> entry : this.headerMap.entrySet()) {
+			headers.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
+		}
+		return Collections.unmodifiableMap(headers);
+	}
+
+	/**
+	 * 设置Header并清空已有Header。
+	 *
+	 * @param headers Header映射
+	 * @return this
+	 */
+	public HttpSignRequest setHeaders(final Map<String, ? extends Collection<String>> headers) {
+		this.headerMap.clear();
+		if (null != headers) {
+			for (final Map.Entry<String, ? extends Collection<String>> entry : headers.entrySet()) {
+				if (null != entry.getValue()) {
+					for (final String value : entry.getValue()) {
+						addHeader(entry.getKey(), value);
+					}
+				}
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * 设置单值Header并清空已有Header。
+	 *
+	 * @param headers Header映射
+	 * @return this
+	 */
+	public HttpSignRequest setHeaderMap(final Map<String, String> headers) {
+		this.headerMap.clear();
+		if (null != headers) {
+			for (final Map.Entry<String, String> entry : headers.entrySet()) {
+				setHeader(entry.getKey(), entry.getValue());
+			}
+		}
+		return this;
+	}
+
+	/**
+	 * 设置Header，替换同名Header已有值。
+	 *
+	 * @param name  Header名称
+	 * @param value Header值
+	 * @return this
+	 */
+	public HttpSignRequest setHeader(final String name, final String value) {
+		removeHeader(name);
+		return addHeader(name, value);
+	}
+
+	/**
+	 * 增加Header值。
+	 *
+	 * @param name  Header名称
+	 * @param value Header值
+	 * @return this
+	 */
+	public HttpSignRequest addHeader(final String name, final String value) {
+		if (null == name) {
+			return this;
+		}
+		List<String> headerValues = this.headerMap.get(name);
+		if (null == headerValues) {
+			headerValues = new ArrayList<>();
+			this.headerMap.put(name, headerValues);
+		}
+		headerValues.add(null == value ? "" : value);
+		return this;
+	}
+
+	/**
+	 * 获取Header首个值。
+	 *
+	 * @param name Header名称
+	 * @return Header值
+	 */
+	public String getHeader(final String name) {
+		final List<String> values = getHeaderValues(name);
+		return ArrayUtil.isEmpty(values) ? null : values.get(0);
+	}
+
+	/**
+	 * 获取Header值列表。
+	 *
+	 * @param name Header名称
+	 * @return Header值列表
+	 */
+	public List<String> getHeaderValues(final String name) {
+		if (null == name) {
+			return null;
+		}
+		for (final Map.Entry<String, List<String>> entry : this.headerMap.entrySet()) {
+			if (name.equalsIgnoreCase(entry.getKey())) {
+				return Collections.unmodifiableList(entry.getValue());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * 获取请求体原始字节。
+	 *
+	 * @return 请求体原始字节
+	 */
+	public byte[] getBodyBytes() {
+		return null == bodyBytes ? null : bodyBytes.clone();
+	}
+
+	/**
+	 * 设置请求体原始字节。
+	 *
+	 * @param bodyBytes 请求体原始字节
+	 * @return this
+	 */
+	public HttpSignRequest setBodyBytes(final byte[] bodyBytes) {
+		this.bodyBytes = null == bodyBytes ? null : bodyBytes.clone();
+		return this;
+	}
+
+	/**
+	 * 设置UTF-8字符串请求体。
+	 *
+	 * @param body 请求体字符串
+	 * @return this
+	 */
+	public HttpSignRequest setBody(final String body) {
+		return setBody(body, CharsetUtil.CHARSET_UTF_8);
+	}
+
+	/**
+	 * 设置字符串请求体。
+	 *
+	 * @param body    请求体字符串
+	 * @param charset 字符集
+	 * @return this
+	 */
+	public HttpSignRequest setBody(final String body, final Charset charset) {
+		this.bodyBytes = null == body ? null : body.getBytes(null == charset ? CharsetUtil.CHARSET_UTF_8 : charset);
+		return this;
+	}
+
+	/**
+	 * 复制请求。
+	 *
+	 * @return 请求副本
+	 */
+	public HttpSignRequest copy() {
+		final HttpSignRequest request = create()
+			.setMethod(this.method)
+			.setPath(this.path)
+			.setBodyBytes(this.bodyBytes);
+		for (final QueryParam param : this.queryParamList) {
+			request.queryParamList.add(param);
+		}
+		for (final Map.Entry<String, List<String>> entry : this.headerMap.entrySet()) {
+			for (final String value : entry.getValue()) {
+				request.addHeader(entry.getKey(), value);
+			}
+		}
+		return request;
+	}
+
+	private void removeHeader(final String name) {
+		if (null == name) {
+			return;
+		}
+		final List<String> removeNames = new ArrayList<>();
+		for (final String existsName : this.headerMap.keySet()) {
+			if (name.equalsIgnoreCase(existsName)) {
+				removeNames.add(existsName);
+			}
+		}
+		for (final String removeName : removeNames) {
+			this.headerMap.remove(removeName);
+		}
+	}
+
+	/**
+	 * 查询参数。
+	 */
+	public static class QueryParam {
+		private final String name;
+		private final String value;
+
+		/**
+		 * 构造查询参数。
+		 *
+		 * @param name  参数名
+		 * @param value 参数值
+		 */
+		public QueryParam(final String name, final String value) {
+			this.name = name;
+			this.value = value;
+		}
+
+		/**
+		 * 获取参数名。
+		 *
+		 * @return 参数名
+		 */
+		public String getName() {
+			return name;
+		}
+
+		/**
+		 * 获取参数值。
+		 *
+		 * @return 参数值
+		 */
+		public String getValue() {
+			return value;
+		}
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignResult.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignResult.java
@@ -1,0 +1,83 @@
+package cn.hutool.crypto.sign.http;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * HTTP签名结果，包含需要写入请求的签名Header、签名值和调试用规范请求信息。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSignResult {
+
+	/**
+	 * 待写入HTTP请求的签名Header。
+	 */
+	private final Map<String, String> headers;
+	/**
+	 * 编码后的签名值。
+	 */
+	private final String signature;
+	/**
+	 * 规范请求。
+	 */
+	private final CanonicalRequest canonicalRequest;
+	/**
+	 * 待签名字符串。
+	 */
+	private final String stringToSign;
+
+	/**
+	 * 构造签名结果。
+	 *
+	 * @param headers          签名Header
+	 * @param signature        签名值
+	 * @param canonicalRequest 规范请求
+	 * @param stringToSign     待签名字符串
+	 */
+	public HttpSignResult(final Map<String, String> headers, final String signature,
+						  final CanonicalRequest canonicalRequest, final String stringToSign) {
+		this.headers = new LinkedHashMap<>(headers);
+		this.signature = signature;
+		this.canonicalRequest = canonicalRequest;
+		this.stringToSign = stringToSign;
+	}
+
+	/**
+	 * 获取待写入HTTP请求的签名Header。
+	 *
+	 * @return 签名Header
+	 */
+	public Map<String, String> getHeaders() {
+		return Collections.unmodifiableMap(headers);
+	}
+
+	/**
+	 * 获取签名值。
+	 *
+	 * @return 签名值
+	 */
+	public String getSignature() {
+		return signature;
+	}
+
+	/**
+	 * 获取规范请求。
+	 *
+	 * @return 规范请求
+	 */
+	public CanonicalRequest getCanonicalRequest() {
+		return canonicalRequest;
+	}
+
+	/**
+	 * 获取待签名字符串。
+	 *
+	 * @return 待签名字符串
+	 */
+	public String getStringToSign() {
+		return stringToSign;
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignVerifier.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignVerifier.java
@@ -1,0 +1,153 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.lang.Assert;
+import cn.hutool.core.util.StrUtil;
+
+import java.security.MessageDigest;
+import java.util.Set;
+
+/**
+ * HTTP AK/SK验签器。
+ * <p>
+ * 验签器构造时会复制{@link HttpSignConfig}配置快照。只要传入的{@link SecretProvider}
+ * 与{@link NonceStore}本身可并发使用，验签器实例可在多个线程中复用。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSignVerifier {
+
+	private final SecretProvider secretProvider;
+	private final NonceStore nonceStore;
+	private final HttpSignConfig config;
+	private final HttpSignCanonicalizer canonicalizer;
+
+	/**
+	 * 创建验签器。
+	 *
+	 * @param secretProvider 密钥提供器
+	 * @param nonceStore     Nonce存储
+	 * @param config         签名配置
+	 * @return 验签器
+	 */
+	public static HttpSignVerifier create(final SecretProvider secretProvider, final NonceStore nonceStore, final HttpSignConfig config) {
+		return new HttpSignVerifier(secretProvider, nonceStore, config);
+	}
+
+	/**
+	 * 构造验签器。
+	 *
+	 * @param secretProvider 密钥提供器
+	 * @param nonceStore     Nonce存储，传{@code null}表示不做防重放
+	 * @param config         签名配置
+	 */
+	public HttpSignVerifier(final SecretProvider secretProvider, final NonceStore nonceStore, final HttpSignConfig config) {
+		Assert.notNull(secretProvider, "SecretProvider must be not null!");
+		this.secretProvider = secretProvider;
+		this.nonceStore = nonceStore;
+		this.config = null == config ? HttpSignConfig.create() : config.copy();
+		this.canonicalizer = new HttpSignCanonicalizer();
+	}
+
+	/**
+	 * 验签。
+	 *
+	 * @param request 请求
+	 * @return 验签结果
+	 */
+	public HttpSignVerifyResult verify(final HttpSignRequest request) {
+		final SignHeaderNames signHeaderNames = config.getSignHeaderNames();
+		final String accessKeyId = request.getHeader(signHeaderNames.getAccessKeyIdHeaderName());
+		if (StrUtil.isBlank(accessKeyId)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_MISSING_ACCESS_KEY_ID, "Missing access key id.");
+		}
+		final String timestampValue = request.getHeader(signHeaderNames.getTimestampHeaderName());
+		if (StrUtil.isBlank(timestampValue)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_MISSING_TIMESTAMP, "Missing timestamp.");
+		}
+		final String nonce = request.getHeader(signHeaderNames.getNonceHeaderName());
+		if (StrUtil.isBlank(nonce)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_MISSING_NONCE, "Missing nonce.");
+		}
+		final String algorithmValue = request.getHeader(signHeaderNames.getAlgorithmHeaderName());
+		if (StrUtil.isBlank(algorithmValue)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_MISSING_ALGORITHM, "Missing algorithm.");
+		}
+		final String signature = request.getHeader(signHeaderNames.getSignatureHeaderName());
+		if (StrUtil.isBlank(signature)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_MISSING_SIGNATURE, "Missing signature.");
+		}
+
+		final HttpSignAlgorithm algorithm = HttpSignAlgorithm.of(algorithmValue);
+		if (null == algorithm || false == isAlgorithmAllowed(config.getAllowedAlgorithms(), algorithm)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_UNSUPPORTED_ALGORITHM, "Unsupported sign algorithm.");
+		}
+
+		final long timestamp;
+		try {
+			timestamp = Long.parseLong(timestampValue);
+		} catch (final NumberFormatException e) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_TIMESTAMP_INVALID, "Invalid timestamp.");
+		}
+		final long now = config.getTimestampProvider().currentTimestamp();
+		if (Math.abs(now - timestamp) > config.getTimestampSkewSeconds()) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_TIMESTAMP_SKEW, "Timestamp skew is too large.");
+		}
+
+		final SecretInfo secretInfo = secretProvider.loadSecret(accessKeyId);
+		if (null == secretInfo) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_ACCESS_KEY_NOT_FOUND, "Access key not found.");
+		}
+		if (false == secretInfo.isEnabled()) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_ACCESS_KEY_DISABLED, "Access key is disabled.");
+		}
+		if (null != secretInfo.getExpireAt() && secretInfo.getExpireAt() < now) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_SECRET_EXPIRED, "Secret is expired.");
+		}
+		if (false == secretInfo.getAllowedAlgorithms().isEmpty()
+			&& false == secretInfo.getAllowedAlgorithms().contains(algorithm)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_UNSUPPORTED_ALGORITHM, "Algorithm is not allowed by secret.");
+		}
+
+		final HttpSignResult expectedSignResult;
+		try {
+			expectedSignResult = HttpSigner.signPrepared(request, secretInfo.getAccessKeySecret(), algorithm, config, canonicalizer);
+		} catch (final HttpSignException e) {
+			return HttpSignVerifyResult.fail(e.getErrorCode(), e.getMessage());
+		}
+		if (false == constantTimeEquals(expectedSignResult.getSignature(), signature)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_MISMATCH, "Signature mismatch.",
+				expectedSignResult.getCanonicalRequest(), expectedSignResult.getStringToSign());
+		}
+		final long ttlSeconds = Math.max(1L, config.getTimestampSkewSeconds() * 2);
+		if (null != nonceStore && false == nonceStore.putIfAbsent(accessKeyId, nonce, ttlSeconds)) {
+			return HttpSignVerifyResult.fail(HttpSignErrorCode.SIGN_NONCE_REPLAY, "Nonce replay.");
+		}
+		return HttpSignVerifyResult.success(expectedSignResult.getCanonicalRequest(), expectedSignResult.getStringToSign());
+	}
+
+	/**
+	 * 判断算法是否在服务端配置白名单中。
+	 *
+	 * @param allowedAlgorithmSet 允许的算法集合
+	 * @param algorithm         待判断算法
+	 * @return 是否允许
+	 */
+	private static boolean isAlgorithmAllowed(final Set<HttpSignAlgorithm> allowedAlgorithmSet, final HttpSignAlgorithm algorithm) {
+		return null != allowedAlgorithmSet && allowedAlgorithmSet.contains(algorithm);
+	}
+
+	/**
+	 * 常量时间比较签名字符串。
+	 *
+	 * @param expected 服务端计算签名
+	 * @param actual   客户端传入签名
+	 * @return 是否一致
+	 */
+	private boolean constantTimeEquals(final String expected, final String actual) {
+		return MessageDigest.isEqual(
+			expected.getBytes(config.getCharset()),
+			actual.getBytes(config.getCharset())
+		);
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignVerifier.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignVerifier.java
@@ -20,7 +20,7 @@ public class HttpSignVerifier {
 	private final SecretProvider secretProvider;
 	private final NonceStore nonceStore;
 	private final HttpSignConfig config;
-	private final HttpSignCanonicalizer canonicalizer;
+	private final HttpSignCanonical canonicalizer;
 
 	/**
 	 * 创建验签器。
@@ -46,7 +46,7 @@ public class HttpSignVerifier {
 		this.secretProvider = secretProvider;
 		this.nonceStore = nonceStore;
 		this.config = null == config ? HttpSignConfig.create() : config.copy();
-		this.canonicalizer = new HttpSignCanonicalizer();
+		this.canonicalizer = new HttpSignCanonical();
 	}
 
 	/**

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignVerifyResult.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSignVerifyResult.java
@@ -1,0 +1,121 @@
+package cn.hutool.crypto.sign.http;
+
+/**
+ * HTTP验签结果。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSignVerifyResult {
+
+	/**
+	 * 是否验签成功。
+	 */
+	private final boolean success;
+	/**
+	 * 验签失败错误码。
+	 */
+	private final HttpSignErrorCode errorCode;
+	/**
+	 * 验签失败消息。
+	 */
+	private final String message;
+	/**
+	 * 规范请求，失败时仅在签名不匹配等需要排查场景返回。
+	 */
+	private final CanonicalRequest canonicalRequest;
+	/**
+	 * 待签名字符串。
+	 */
+	private final String stringToSign;
+
+	private HttpSignVerifyResult(final boolean success, final HttpSignErrorCode errorCode, final String message,
+								 final CanonicalRequest canonicalRequest, final String stringToSign) {
+		this.success = success;
+		this.errorCode = errorCode;
+		this.message = message;
+		this.canonicalRequest = canonicalRequest;
+		this.stringToSign = stringToSign;
+	}
+
+	/**
+	 * 创建成功结果。
+	 *
+	 * @param canonicalRequest 规范请求
+	 * @param stringToSign     待签名字符串
+	 * @return 验签结果
+	 */
+	public static HttpSignVerifyResult success(final CanonicalRequest canonicalRequest, final String stringToSign) {
+		return new HttpSignVerifyResult(true, null, null, canonicalRequest, stringToSign);
+	}
+
+	/**
+	 * 创建失败结果。
+	 *
+	 * @param errorCode 错误码
+	 * @param message   错误消息
+	 * @return 验签结果
+	 */
+	public static HttpSignVerifyResult fail(final HttpSignErrorCode errorCode, final String message) {
+		return new HttpSignVerifyResult(false, errorCode, message, null, null);
+	}
+
+	/**
+	 * 创建带规范请求信息的失败结果。
+	 *
+	 * @param errorCode        错误码
+	 * @param message          错误消息
+	 * @param canonicalRequest 规范请求
+	 * @param stringToSign     待签名字符串
+	 * @return 验签结果
+	 */
+	public static HttpSignVerifyResult fail(final HttpSignErrorCode errorCode, final String message,
+											final CanonicalRequest canonicalRequest, final String stringToSign) {
+		return new HttpSignVerifyResult(false, errorCode, message, canonicalRequest, stringToSign);
+	}
+
+	/**
+	 * 判断是否验签成功。
+	 *
+	 * @return 是否成功
+	 */
+	public boolean isSuccess() {
+		return success;
+	}
+
+	/**
+	 * 获取错误码。
+	 *
+	 * @return 错误码
+	 */
+	public HttpSignErrorCode getErrorCode() {
+		return errorCode;
+	}
+
+	/**
+	 * 获取错误消息。
+	 *
+	 * @return 错误消息
+	 */
+	public String getMessage() {
+		return message;
+	}
+
+	/**
+	 * 获取规范请求。
+	 *
+	 * @return 规范请求
+	 */
+	public CanonicalRequest getCanonicalRequest() {
+		return canonicalRequest;
+	}
+
+	/**
+	 * 获取待签名字符串。
+	 *
+	 * @return 待签名字符串
+	 */
+	public String getStringToSign() {
+		return stringToSign;
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSigner.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSigner.java
@@ -1,0 +1,127 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.codec.Base64;
+import cn.hutool.core.util.HexUtil;
+import cn.hutool.crypto.digest.DigestUtil;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * HTTP AK/SK签名器。
+ * <p>
+ * 签名器构造时会复制{@link HttpSignConfig}配置快照。只要自定义的{@link TimestampProvider}
+ * 和{@link NonceGenerator}本身可并发使用，签名器实例可在多个线程中复用。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class HttpSigner {
+
+	private final HttpSignConfig config;
+	private final HttpSignCanonicalizer canonicalizer;
+
+	/**
+	 * 创建签名器。
+	 *
+	 * @param config 签名配置
+	 * @return 签名器
+	 */
+	public static HttpSigner create(final HttpSignConfig config) {
+		return new HttpSigner(config);
+	}
+
+	/**
+	 * 使用默认配置签名。
+	 *
+	 * @param request     请求
+	 * @param credentials 凭证
+	 * @return 签名结果
+	 */
+	public static HttpSignResult sign(final HttpSignRequest request, final AkSkCredentials credentials) {
+		return create(HttpSignConfig.create()).signRequest(request, credentials);
+	}
+
+	/**
+	 * 使用指定配置签名。
+	 *
+	 * @param request     请求
+	 * @param credentials 凭证
+	 * @param config      签名配置
+	 * @return 签名结果
+	 */
+	public static HttpSignResult sign(final HttpSignRequest request, final AkSkCredentials credentials, final HttpSignConfig config) {
+		return create(config).signRequest(request, credentials);
+	}
+
+	/**
+	 * 构造。
+	 *
+	 * @param config 签名配置
+	 */
+	public HttpSigner(final HttpSignConfig config) {
+		this.config = null == config ? HttpSignConfig.create() : config.copy();
+		this.canonicalizer = new HttpSignCanonicalizer();
+	}
+
+	/**
+	 * 签名请求。
+	 *
+	 * @param request     请求
+	 * @param credentials 凭证
+	 * @return 签名结果
+	 */
+	public HttpSignResult signRequest(final HttpSignRequest request, final AkSkCredentials credentials) {
+		final SignHeaderNames signHeaderNames = config.getSignHeaderNames();
+		final HttpSignAlgorithm signAlgorithm = null == config.getDefaultAlgorithm() ? HttpSignAlgorithm.HMAC_SHA256 : config.getDefaultAlgorithm();
+		final Map<String, String> signatureHeaders = new LinkedHashMap<>();
+		signatureHeaders.put(signHeaderNames.getAccessKeyIdHeaderName(), credentials.getAccessKeyId());
+		signatureHeaders.put(signHeaderNames.getTimestampHeaderName(), String.valueOf(config.getTimestampProvider().currentTimestamp()));
+		signatureHeaders.put(signHeaderNames.getNonceHeaderName(), config.getNonceGenerator().generateNonce());
+		signatureHeaders.put(signHeaderNames.getAlgorithmHeaderName(), signAlgorithm.getAlgorithmName());
+
+		final HttpSignRequest preparedRequest = request.copy();
+		for (final Map.Entry<String, String> entry : signatureHeaders.entrySet()) {
+			preparedRequest.setHeader(entry.getKey(), entry.getValue());
+		}
+
+		final HttpSignResult signResult = signPrepared(preparedRequest, credentials.getAccessKeySecret(), signAlgorithm, config, canonicalizer);
+		signatureHeaders.put(signHeaderNames.getSignatureHeaderName(), signResult.getSignature());
+		return new HttpSignResult(signatureHeaders, signResult.getSignature(), signResult.getCanonicalRequest(), signResult.getStringToSign());
+	}
+
+	/**
+	 * 对已经包含签名相关Header的请求计算签名。
+	 *
+	 * @param request             签名请求
+	 * @param accessKeySecret     访问密钥
+	 * @param algorithm           签名算法
+	 * @param config              签名配置
+	 * @param canonicalizer       规范化工具
+	 * @return 签名结果
+	 */
+	static HttpSignResult signPrepared(final HttpSignRequest request, final String accessKeySecret,
+									   final HttpSignAlgorithm algorithm, final HttpSignConfig config,
+									   final HttpSignCanonicalizer canonicalizer) {
+		final CanonicalRequest canonicalRequest = canonicalizer.canonicalize(request, config);
+		final String stringToSign = canonicalRequest.toStringToSign();
+		final byte[] signBytes = DigestUtil.hmac(algorithm.toHmacAlgorithm(), accessKeySecret.getBytes(config.getCharset()))
+			.digest(stringToSign, config.getCharset());
+		final String signature = encodeSignature(signBytes, config.getSignatureEncoding());
+		return new HttpSignResult(new LinkedHashMap<>(), signature, canonicalRequest, stringToSign);
+	}
+
+	/**
+	 * 按配置编码签名字节。
+	 *
+	 * @param signBytes 签名字节
+	 * @param encoding  输出编码
+	 * @return 签名字符串
+	 */
+	static String encodeSignature(final byte[] signBytes, final SignatureEncoding encoding) {
+		if (SignatureEncoding.HEX.equals(encoding)) {
+			return HexUtil.encodeHexStr(signBytes);
+		}
+		return Base64.encode(signBytes);
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSigner.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/HttpSigner.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class HttpSigner {
 
 	private final HttpSignConfig config;
-	private final HttpSignCanonicalizer canonicalizer;
+	private final HttpSignCanonical canonicalizer;
 
 	/**
 	 * 创建签名器。
@@ -61,7 +61,7 @@ public class HttpSigner {
 	 */
 	public HttpSigner(final HttpSignConfig config) {
 		this.config = null == config ? HttpSignConfig.create() : config.copy();
-		this.canonicalizer = new HttpSignCanonicalizer();
+		this.canonicalizer = new HttpSignCanonical();
 	}
 
 	/**
@@ -102,7 +102,7 @@ public class HttpSigner {
 	 */
 	static HttpSignResult signPrepared(final HttpSignRequest request, final String accessKeySecret,
 									   final HttpSignAlgorithm algorithm, final HttpSignConfig config,
-									   final HttpSignCanonicalizer canonicalizer) {
+									   final HttpSignCanonical canonicalizer) {
 		final CanonicalRequest canonicalRequest = canonicalizer.canonicalize(request, config);
 		final String stringToSign = canonicalRequest.toStringToSign();
 		final byte[] signBytes = DigestUtil.hmac(algorithm.toHmacAlgorithm(), accessKeySecret.getBytes(config.getCharset()))

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/MemoryNonceStore.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/MemoryNonceStore.java
@@ -1,0 +1,62 @@
+package cn.hutool.crypto.sign.http;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 内存Nonce存储，适合单机测试或单机应用。
+ * <p>
+ * 该实现基于{@link ConcurrentHashMap}，单实例可被多线程并发调用。分布式部署应自行实现
+ * {@link NonceStore}并使用Redis等共享存储。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class MemoryNonceStore implements NonceStore {
+
+	/**
+	 * Nonce键与过期时间映射，过期时间单位为毫秒。
+	 */
+	private final ConcurrentHashMap<String, Long> nonceMap = new ConcurrentHashMap<>();
+
+	/**
+	 * 创建内存Nonce存储。
+	 *
+	 * @return 内存Nonce存储
+	 */
+	public static MemoryNonceStore create() {
+		return new MemoryNonceStore();
+	}
+
+	@Override
+	public boolean putIfAbsent(final String accessKeyId, final String nonce, final long ttlSeconds) {
+		final long now = System.currentTimeMillis();
+		final String nonceKey = accessKeyId + ':' + nonce;
+		final long expireAt = now + Math.max(1L, ttlSeconds) * 1000L;
+		final Long existsExpireAt = nonceMap.putIfAbsent(nonceKey, expireAt);
+		if (null == existsExpireAt) {
+			cleanExpired(now);
+			return true;
+		}
+		if (existsExpireAt <= now && nonceMap.replace(nonceKey, existsExpireAt, expireAt)) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * 清理已过期的Nonce。
+	 *
+	 * @param now 当前时间戳，单位毫秒
+	 */
+	private void cleanExpired(final long now) {
+		final Iterator<Map.Entry<String, Long>> iterator = nonceMap.entrySet().iterator();
+		while (iterator.hasNext()) {
+			final Map.Entry<String, Long> entry = iterator.next();
+			if (entry.getValue() <= now) {
+				iterator.remove();
+			}
+		}
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/NonceGenerator.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/NonceGenerator.java
@@ -1,0 +1,29 @@
+package cn.hutool.crypto.sign.http;
+
+import java.util.UUID;
+
+/**
+ * Nonce生成器。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public interface NonceGenerator {
+
+	/**
+	 * UUID Nonce生成器。
+	 */
+	NonceGenerator UUID_GENERATOR = new NonceGenerator() {
+		@Override
+		public String generateNonce() {
+			return UUID.randomUUID().toString().replace("-", "");
+		}
+	};
+
+	/**
+	 * 生成Nonce。
+	 *
+	 * @return Nonce
+	 */
+	String generateNonce();
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/NonceStore.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/NonceStore.java
@@ -1,0 +1,20 @@
+package cn.hutool.crypto.sign.http;
+
+/**
+ * Nonce存储，用于防重放。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public interface NonceStore {
+
+	/**
+	 * 在指定TTL内写入Nonce，若已存在返回{@code false}。
+	 *
+	 * @param accessKeyId 访问身份ID
+	 * @param nonce       Nonce
+	 * @param ttlSeconds  过期秒数
+	 * @return 是否写入成功
+	 */
+	boolean putIfAbsent(String accessKeyId, String nonce, long ttlSeconds);
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SecretInfo.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SecretInfo.java
@@ -1,0 +1,165 @@
+package cn.hutool.crypto.sign.http;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * 访问密钥信息，由业务系统通过{@link SecretProvider}提供。
+ * <p>
+ * 本类只承载验签所需的密钥状态，不负责密钥生成、加密存储、轮换和权限校验。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class SecretInfo {
+
+	/**
+	 * 访问身份ID。
+	 */
+	private String accessKeyId;
+	/**
+	 * 访问密钥明文或业务解密后的密钥。
+	 */
+	private String accessKeySecret;
+	/**
+	 * 密钥是否启用。
+	 */
+	private boolean enabled = true;
+	/**
+	 * 此密钥允许使用的签名算法，为空表示跟随全局配置。
+	 */
+	private Set<HttpSignAlgorithm> allowedAlgorithmSet;
+	/**
+	 * 密钥过期时间，Unix秒。
+	 */
+	private Long expireAt;
+
+	/**
+	 * 创建密钥信息。
+	 *
+	 * @param accessKeyId     访问身份ID
+	 * @param accessKeySecret 访问密钥
+	 * @return 密钥信息
+	 */
+	public static SecretInfo of(final String accessKeyId, final String accessKeySecret) {
+		return new SecretInfo().setAccessKeyId(accessKeyId).setAccessKeySecret(accessKeySecret);
+	}
+
+	/**
+	 * 获取访问身份ID。
+	 *
+	 * @return 访问身份ID
+	 */
+	public String getAccessKeyId() {
+		return accessKeyId;
+	}
+
+	/**
+	 * 设置访问身份ID。
+	 *
+	 * @param accessKeyId 访问身份ID
+	 * @return this
+	 */
+	public SecretInfo setAccessKeyId(final String accessKeyId) {
+		this.accessKeyId = accessKeyId;
+		return this;
+	}
+
+	/**
+	 * 获取访问密钥。
+	 *
+	 * @return 访问密钥
+	 */
+	public String getAccessKeySecret() {
+		return accessKeySecret;
+	}
+
+	/**
+	 * 设置访问密钥。
+	 *
+	 * @param accessKeySecret 访问密钥
+	 * @return this
+	 */
+	public SecretInfo setAccessKeySecret(final String accessKeySecret) {
+		this.accessKeySecret = accessKeySecret;
+		return this;
+	}
+
+	/**
+	 * 判断密钥是否启用。
+	 *
+	 * @return 是否启用
+	 */
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * 设置密钥是否启用。
+	 *
+	 * @param enabled 是否启用
+	 * @return this
+	 */
+	public SecretInfo setEnabled(final boolean enabled) {
+		this.enabled = enabled;
+		return this;
+	}
+
+	/**
+	 * 获取此密钥允许使用的签名算法。
+	 *
+	 * @return 签名算法集合
+	 */
+	public Set<HttpSignAlgorithm> getAllowedAlgorithms() {
+		return null == allowedAlgorithmSet ? Collections.<HttpSignAlgorithm>emptySet() : Collections.unmodifiableSet(allowedAlgorithmSet);
+	}
+
+	/**
+	 * 设置此密钥允许使用的签名算法。
+	 *
+	 * @param allowedAlgorithms 签名算法集合
+	 * @return this
+	 */
+	public SecretInfo setAllowedAlgorithms(final Set<HttpSignAlgorithm> allowedAlgorithms) {
+		this.allowedAlgorithmSet = null == allowedAlgorithms ? null : new LinkedHashSet<>(allowedAlgorithms);
+		return this;
+	}
+
+	/**
+	 * 增加此密钥允许使用的签名算法。
+	 *
+	 * @param algorithms 签名算法
+	 * @return this
+	 */
+	public SecretInfo allowAlgorithms(final HttpSignAlgorithm... algorithms) {
+		if (null == this.allowedAlgorithmSet) {
+			this.allowedAlgorithmSet = new LinkedHashSet<>();
+		}
+		if (null != algorithms) {
+			Collections.addAll(this.allowedAlgorithmSet, algorithms);
+		}
+		return this;
+	}
+
+	/**
+	 * 获取密钥过期时间。
+	 *
+	 * @return Unix秒时间戳
+	 */
+	public Long getExpireAt() {
+		return expireAt;
+	}
+
+	/**
+	 * 设置密钥过期时间。
+	 *
+	 * @param expireAt Unix秒时间戳
+	 * @return this
+	 */
+	public SecretInfo setExpireAt(final Long expireAt) {
+		this.expireAt = expireAt;
+		return this;
+	}
+
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SecretProvider.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SecretProvider.java
@@ -1,0 +1,18 @@
+package cn.hutool.crypto.sign.http;
+
+/**
+ * 访问密钥提供器。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public interface SecretProvider {
+
+	/**
+	 * 根据访问身份ID加载密钥信息。
+	 *
+	 * @param accessKeyId 访问身份ID
+	 * @return 密钥信息，未找到返回{@code null}
+	 */
+	SecretInfo loadSecret(String accessKeyId);
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SignHeaderNames.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SignHeaderNames.java
@@ -1,0 +1,254 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.lang.Assert;
+import cn.hutool.core.util.StrUtil;
+
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * HTTP签名Header名称配置，用于控制签名字段在HTTP Header中的具体名称。
+ * <p>
+ * 此对象为可变配置对象，建议在构造签名器或验签器前完成配置，不要在并发签名过程中继续修改。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public class SignHeaderNames {
+
+	/**
+	 * 访问身份ID Header名称。
+	 */
+	private String accessKeyIdHeaderName = "X-Access-Key-Id";
+	/**
+	 * Unix秒级时间戳 Header名称。
+	 */
+	private String timestampHeaderName = "X-Sign-Timestamp";
+	/**
+	 * 防重放随机串 Header名称。
+	 */
+	private String nonceHeaderName = "X-Sign-Nonce";
+	/**
+	 * 签名算法 Header名称。
+	 */
+	private String algorithmHeaderName = "X-Sign-Algorithm";
+	/**
+	 * 签名结果 Header名称。
+	 */
+	private String signatureHeaderName = "X-Signature";
+
+	/**
+	 * 创建默认Header名称。
+	 *
+	 * @return Header名称配置
+	 */
+	public static SignHeaderNames create() {
+		return new SignHeaderNames();
+	}
+
+	/**
+	 * 创建默认Header名称。
+	 *
+	 * @return Header名称配置
+	 */
+	public static SignHeaderNames defaultHeaders() {
+		return create();
+	}
+
+	/**
+	 * 创建自定义Header名称。
+	 *
+	 * @param accessKeyIdHeaderName 访问身份ID Header名称
+	 * @param timestampHeaderName   Unix秒级时间戳 Header名称
+	 * @param nonceHeaderName       防重放随机串 Header名称
+	 * @param algorithmHeaderName   签名算法 Header名称
+	 * @param signatureHeaderName   签名结果 Header名称
+	 * @return Header名称配置
+	 */
+	public static SignHeaderNames of(final String accessKeyIdHeaderName, final String timestampHeaderName,
+									 final String nonceHeaderName, final String algorithmHeaderName,
+									 final String signatureHeaderName) {
+		return create()
+			.setAccessKeyIdHeaderName(accessKeyIdHeaderName)
+			.setTimestampHeaderName(timestampHeaderName)
+			.setNonceHeaderName(nonceHeaderName)
+			.setAlgorithmHeaderName(algorithmHeaderName)
+			.setSignatureHeaderName(signatureHeaderName);
+	}
+
+	/**
+	 * 创建OpenAPI风格Header名称。
+	 *
+	 * @return Header名称配置
+	 */
+	public static SignHeaderNames openapi() {
+		return of(
+			"X-Openapi-App-Id",
+			"X-Openapi-Timestamp",
+			"X-Openapi-Nonce",
+			"X-Openapi-Algorithm",
+			"X-Openapi-Signature"
+		);
+	}
+
+	/**
+	 * 复制Header名称配置。
+	 *
+	 * @return Header名称配置副本
+	 */
+	public SignHeaderNames copy() {
+		return create()
+			.setAccessKeyIdHeaderName(this.accessKeyIdHeaderName)
+			.setTimestampHeaderName(this.timestampHeaderName)
+			.setNonceHeaderName(this.nonceHeaderName)
+			.setAlgorithmHeaderName(this.algorithmHeaderName)
+			.setSignatureHeaderName(this.signatureHeaderName);
+	}
+
+	/**
+	 * 获取访问身份ID Header名称。
+	 *
+	 * @return Header名称
+	 */
+	public String getAccessKeyIdHeaderName() {
+		return accessKeyIdHeaderName;
+	}
+
+	/**
+	 * 设置访问身份ID Header名称。
+	 *
+	 * @param accessKeyIdHeaderName Header名称
+	 * @return this
+	 */
+	public SignHeaderNames setAccessKeyIdHeaderName(final String accessKeyIdHeaderName) {
+		this.accessKeyIdHeaderName = normalizeHeaderName(accessKeyIdHeaderName);
+		return this;
+	}
+
+	/**
+	 * 获取时间戳 Header名称。
+	 *
+	 * @return Header名称
+	 */
+	public String getTimestampHeaderName() {
+		return timestampHeaderName;
+	}
+
+	/**
+	 * 设置时间戳 Header名称。
+	 *
+	 * @param timestampHeaderName Header名称
+	 * @return this
+	 */
+	public SignHeaderNames setTimestampHeaderName(final String timestampHeaderName) {
+		this.timestampHeaderName = normalizeHeaderName(timestampHeaderName);
+		return this;
+	}
+
+	/**
+	 * 获取随机串 Header名称。
+	 *
+	 * @return Header名称
+	 */
+	public String getNonceHeaderName() {
+		return nonceHeaderName;
+	}
+
+	/**
+	 * 设置随机串 Header名称。
+	 *
+	 * @param nonceHeaderName Header名称
+	 * @return this
+	 */
+	public SignHeaderNames setNonceHeaderName(final String nonceHeaderName) {
+		this.nonceHeaderName = normalizeHeaderName(nonceHeaderName);
+		return this;
+	}
+
+	/**
+	 * 获取签名算法 Header名称。
+	 *
+	 * @return Header名称
+	 */
+	public String getAlgorithmHeaderName() {
+		return algorithmHeaderName;
+	}
+
+	/**
+	 * 设置签名算法 Header名称。
+	 *
+	 * @param algorithmHeaderName Header名称
+	 * @return this
+	 */
+	public SignHeaderNames setAlgorithmHeaderName(final String algorithmHeaderName) {
+		this.algorithmHeaderName = normalizeHeaderName(algorithmHeaderName);
+		return this;
+	}
+
+	/**
+	 * 获取签名结果 Header名称。
+	 *
+	 * @return Header名称
+	 */
+	public String getSignatureHeaderName() {
+		return signatureHeaderName;
+	}
+
+	/**
+	 * 设置签名结果 Header名称。
+	 *
+	 * @param signatureHeaderName Header名称
+	 * @return this
+	 */
+	public SignHeaderNames setSignatureHeaderName(final String signatureHeaderName) {
+		this.signatureHeaderName = normalizeHeaderName(signatureHeaderName);
+		return this;
+	}
+
+	/**
+	 * 获取默认参与签名的Header名称。
+	 *
+	 * @return 小写Header名称集合
+	 */
+	Set<String> signedHeaderNameSet() {
+		final Set<String> set = new LinkedHashSet<>();
+		addLower(set, accessKeyIdHeaderName);
+		addLower(set, timestampHeaderName);
+		addLower(set, nonceHeaderName);
+		addLower(set, algorithmHeaderName);
+		return set;
+	}
+
+	/**
+	 * 判断是否为签名结果Header。
+	 *
+	 * @param name Header名称
+	 * @return 是否为签名结果Header
+	 */
+	boolean isSignatureHeader(final String name) {
+		return equalsHeader(signatureHeaderName, name);
+	}
+
+	private static void addLower(final Set<String> set, final String name) {
+		if (StrUtil.isNotBlank(name)) {
+			set.add(name.trim().toLowerCase(Locale.ROOT));
+		}
+	}
+
+	private static boolean equalsHeader(final String name1, final String name2) {
+		return null != name1 && name1.equalsIgnoreCase(name2);
+	}
+
+	private static String normalizeHeaderName(final String headerName) {
+		Assert.notBlank(headerName, "Header name must be not blank!");
+		if (containsCrlf(headerName)) {
+			throw new HttpSignException(HttpSignErrorCode.SIGN_CANONICALIZE_FAILED, "Header name contains CR/LF.");
+		}
+		return headerName.trim();
+	}
+
+	private static boolean containsCrlf(final String value) {
+		return null != value && (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0);
+	}
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SignatureEncoding.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/SignatureEncoding.java
@@ -1,0 +1,18 @@
+package cn.hutool.crypto.sign.http;
+
+/**
+ * 签名输出编码。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public enum SignatureEncoding {
+	/**
+	 * Base64编码。
+	 */
+	BASE64,
+	/**
+	 * 16进制编码。
+	 */
+	HEX
+}

--- a/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/TimestampProvider.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/sign/http/TimestampProvider.java
@@ -1,0 +1,24 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.core.date.DateUtil;
+
+/**
+ * 时间戳提供器，返回Unix epoch seconds。
+ *
+ * @author mumu
+ * @since 5.8.45
+ */
+public interface TimestampProvider {
+
+	/**
+	 * 系统时间戳提供器。
+	 */
+	TimestampProvider SYSTEM = DateUtil::currentSeconds;
+
+	/**
+	 * 获取当前时间戳，单位秒。
+	 *
+	 * @return 当前时间戳
+	 */
+	long currentTimestamp();
+}

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignCanonicalTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignCanonicalTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
  *
  * @author mumu
  */
-public class HttpSignCanonicalizerTest {
+public class HttpSignCanonicalTest {
 
-	private final HttpSignCanonicalizer canonicalizer = new HttpSignCanonicalizer();
+	private final HttpSignCanonical canonicalizer = new HttpSignCanonical();
 
 	@Test
 	public void canonicalizeQueryTest() {
@@ -88,17 +88,17 @@ public class HttpSignCanonicalizerTest {
 	public void hashBodyTest() {
 		final HttpSignConfig config = HttpSignConfig.create();
 
-		Assertions.assertEquals(DigestUtil.sha256Hex(new byte[0]), HttpSignCanonicalizer.EMPTY_BODY_SHA256);
-		Assertions.assertEquals(HttpSignCanonicalizer.EMPTY_BODY_SHA256, canonicalizer.hashBody("GET", "abc".getBytes(config.getCharset()), config));
+		Assertions.assertEquals(DigestUtil.sha256Hex(new byte[0]), HttpSignCanonical.EMPTY_BODY_SHA256);
+		Assertions.assertEquals(HttpSignCanonical.EMPTY_BODY_SHA256, canonicalizer.hashBody("GET", "abc".getBytes(config.getCharset()), config));
 		Assertions.assertEquals(DigestUtil.sha256Hex("abc".getBytes(config.getCharset())), canonicalizer.hashBody("POST", "abc".getBytes(config.getCharset()), config));
 		Assertions.assertEquals(DigestUtil.sha256Hex("abc".getBytes(config.getCharset())), canonicalizer.hashBody("PUT", "abc".getBytes(config.getCharset()), config));
-		Assertions.assertEquals(HttpSignCanonicalizer.EMPTY_BODY_SHA256, canonicalizer.hashBody("DELETE", null, config));
+		Assertions.assertEquals(HttpSignCanonical.EMPTY_BODY_SHA256, canonicalizer.hashBody("DELETE", null, config));
 	}
 
 	@Test
 	public void emptyBodyDigestAlgorithmsTest() {
 		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
-		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA256, HttpSignCanonicalizer.EMPTY_BODY_SHA256);
+		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA256, HttpSignCanonical.EMPTY_BODY_SHA256);
 		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA512,
 			"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce"
 				+ "47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignCanonicalizerTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignCanonicalizerTest.java
@@ -1,0 +1,131 @@
+package cn.hutool.crypto.sign.http;
+
+import cn.hutool.crypto.digest.DigestUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * HTTP签名规范化测试。
+ *
+ * @author mumu
+ */
+public class HttpSignCanonicalizerTest {
+
+	private final HttpSignCanonicalizer canonicalizer = new HttpSignCanonicalizer();
+
+	@Test
+	public void canonicalizeQueryTest() {
+		final HttpSignRequest request = HttpSignRequest.create()
+			.addQueryParam("b", "2")
+			.addQueryParam("a", "张三")
+			.addQueryParam("a", "abc")
+			.addQueryParam("empty", null)
+			.addQueryParam("space", "a b")
+			.addQueryParam("plus", "a+b")
+			.addQueryParam("slash", "a/b")
+			.addQueryParam("emoji", "\uD83D\uDE42");
+
+		Assertions.assertEquals(
+			"a=abc&a=%E5%BC%A0%E4%B8%89&b=2&emoji=%F0%9F%99%82&empty=&plus=a%2Bb&slash=a%2Fb&space=a%20b",
+			canonicalizer.canonicalizeQuery(request, HttpSignConfig.create().getCharset())
+		);
+	}
+
+	@Test
+	public void canonicalizeQueryOrderIndependentTest() {
+		final HttpSignRequest request1 = HttpSignRequest.create()
+			.addQueryParam("b", "2")
+			.addQueryParam("a", "张三")
+			.addQueryParam("a", "abc");
+		final HttpSignRequest request2 = HttpSignRequest.create()
+			.addQueryParam("a", "abc")
+			.addQueryParam("b", "2")
+			.addQueryParam("a", "张三");
+
+		Assertions.assertEquals(
+			canonicalizer.canonicalizeQuery(request1, HttpSignConfig.create().getCharset()),
+			canonicalizer.canonicalizeQuery(request2, HttpSignConfig.create().getCharset())
+		);
+	}
+
+	@Test
+	public void canonicalizePathTest() {
+		Assertions.assertEquals(
+			"/api/%E5%BC%A0%20%E4%B8%89",
+			canonicalizer.canonicalizePath("api/%E5%BC%A0 三", HttpSignConfig.create().getCharset())
+		);
+	}
+
+	@Test
+	public void canonicalizeHeadersTest() {
+		final HttpSignRequest request = HttpSignRequest.create()
+			.setHeader("X-Sign-Timestamp", "  1731312000  ")
+			.setHeader("X-Access-Key-Id", "ak_test")
+			.setHeader("X-Sign-Algorithm", "HmacSHA256")
+			.addHeader("X-Sign-Nonce", " n1  ")
+			.addHeader("x-sign-nonce", "n2")
+			.setHeader("X-Signature", "ignored")
+			.setHeader("Content-Length", "10")
+			.setHeader("User-Agent", "client");
+
+		Assertions.assertEquals(
+			"x-access-key-id=ak_test&x-sign-algorithm=HmacSHA256&x-sign-nonce=n1,n2&x-sign-timestamp=1731312000",
+			canonicalizer.canonicalizeHeaders(request, HttpSignConfig.create())
+		);
+	}
+
+	@Test
+	public void canonicalizeHeaderCrlfTest() {
+		final HttpSignRequest request = HttpSignRequest.create()
+			.setHeader("X-Access-Key-Id", "ak\r\nbad");
+
+		final HttpSignException exception = Assertions.assertThrows(HttpSignException.class,
+			() -> canonicalizer.canonicalizeHeaders(request, HttpSignConfig.create()));
+		Assertions.assertEquals(HttpSignErrorCode.SIGN_CANONICALIZE_FAILED, exception.getErrorCode());
+	}
+
+	@Test
+	public void hashBodyTest() {
+		final HttpSignConfig config = HttpSignConfig.create();
+
+		Assertions.assertEquals(DigestUtil.sha256Hex(new byte[0]), HttpSignCanonicalizer.EMPTY_BODY_SHA256);
+		Assertions.assertEquals(HttpSignCanonicalizer.EMPTY_BODY_SHA256, canonicalizer.hashBody("GET", "abc".getBytes(config.getCharset()), config));
+		Assertions.assertEquals(DigestUtil.sha256Hex("abc".getBytes(config.getCharset())), canonicalizer.hashBody("POST", "abc".getBytes(config.getCharset()), config));
+		Assertions.assertEquals(DigestUtil.sha256Hex("abc".getBytes(config.getCharset())), canonicalizer.hashBody("PUT", "abc".getBytes(config.getCharset()), config));
+		Assertions.assertEquals(HttpSignCanonicalizer.EMPTY_BODY_SHA256, canonicalizer.hashBody("DELETE", null, config));
+	}
+
+	@Test
+	public void emptyBodyDigestAlgorithmsTest() {
+		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA256, HttpSignCanonicalizer.EMPTY_BODY_SHA256);
+		assertEmptyBodyHash(HttpSignDigestAlgorithm.SHA512,
+			"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce"
+				+ "47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e");
+		assertEmptyBodyHash(HttpSignDigestAlgorithm.MD5, "d41d8cd98f00b204e9800998ecf8427e");
+		assertEmptyBodyHash(HttpSignDigestAlgorithm.SM3, "1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b");
+	}
+
+	@Test
+	public void bodyTooLargeTest() {
+		final HttpSignConfig config = HttpSignConfig.create().setMaxBodySignBytes(1);
+
+		final HttpSignException exception = Assertions.assertThrows(HttpSignException.class,
+			() -> canonicalizer.hashBody("POST", "12".getBytes(config.getCharset()), config));
+		Assertions.assertEquals(HttpSignErrorCode.SIGN_BODY_TOO_LARGE, exception.getErrorCode());
+	}
+
+	@Test
+	public void unsupportedMethodTest() {
+		final HttpSignException exception = Assertions.assertThrows(HttpSignException.class,
+			() -> canonicalizer.canonicalize(HttpSignRequest.create().setMethod("PATCH"), HttpSignConfig.create()));
+		Assertions.assertEquals(HttpSignErrorCode.SIGN_UNSUPPORTED_METHOD, exception.getErrorCode());
+	}
+
+	private void assertEmptyBodyHash(final HttpSignDigestAlgorithm digestAlgorithm, final String expectedHash) {
+		final HttpSignConfig config = HttpSignConfig.create().setBodyDigestAlgorithm(digestAlgorithm);
+
+		Assertions.assertEquals(expectedHash, canonicalizer.hashBody("POST", null, config));
+		Assertions.assertEquals(expectedHash, canonicalizer.hashBody("GET", "abc".getBytes(config.getCharset()), config));
+	}
+}

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignRequestTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignRequestTest.java
@@ -1,0 +1,59 @@
+package cn.hutool.crypto.sign.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * HTTP签名请求模型测试。
+ *
+ * @author mumu
+ */
+public class HttpSignRequestTest {
+
+	@Test
+	public void headerCaseInsensitiveReplaceTest() {
+		final HttpSignRequest request = HttpSignRequest.create()
+			.setHeader("X-Test", "1")
+			.setHeader("x-test", "2");
+
+		Assertions.assertEquals("2", request.getHeader("X-Test"));
+		Assertions.assertEquals(1, request.getHeaders().size());
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> request.getHeaderValues("X-Test").add("3"));
+		Assertions.assertThrows(UnsupportedOperationException.class, () -> request.getHeaders().get("x-test").add("3"));
+	}
+
+	@Test
+	public void queryIterableAndArrayTest() {
+		final Map<String, Object> queryParams = new LinkedHashMap<>();
+		queryParams.put("list", Arrays.asList("1", "2"));
+		queryParams.put("array", new String[]{"a", "b"});
+		queryParams.put("empty", null);
+
+		final HttpSignRequest request = HttpSignRequest.create().setQueryParams(queryParams);
+
+		Assertions.assertEquals(5, request.getQueryParams().size());
+		Assertions.assertEquals("", request.getQueryParams().get(4).getValue());
+	}
+
+	@Test
+	public void bodyBytesDefensiveCopyTest() {
+		final byte[] body = new byte[]{1, 2, 3};
+		final HttpSignRequest request = HttpSignRequest.create().setBodyBytes(body);
+		body[0] = 9;
+
+		Assertions.assertEquals(1, request.getBodyBytes()[0]);
+
+		final byte[] readBody = request.getBodyBytes();
+		readBody[1] = 9;
+		Assertions.assertEquals(2, request.getBodyBytes()[1]);
+
+		final HttpSignRequest copy = request.copy();
+		final byte[] copyBody = copy.getBodyBytes();
+		copyBody[2] = 9;
+		Assertions.assertEquals(3, copy.getBodyBytes()[2]);
+	}
+}

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignVerifierTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignVerifierTest.java
@@ -1,0 +1,180 @@
+package cn.hutool.crypto.sign.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * HTTP验签器测试。
+ *
+ * @author mumu
+ */
+public class HttpSignVerifierTest {
+
+	private static final String AK = "ak_test_123";
+	private static final String SK = "sk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+	private static final long NOW = 1731312000L;
+
+	@Test
+	public void verifySuccessAndReplayTest() {
+		final HttpSignConfig config = fixedConfig();
+		final HttpSignRequest request = signedRequest(baseRequest(), config);
+		final HttpSignVerifier verifier = HttpSignVerifier.create(secretProvider(true, SK, HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), config);
+
+		Assertions.assertTrue(verifier.verify(request).isSuccess());
+		assertError(verifier.verify(request), HttpSignErrorCode.SIGN_NONCE_REPLAY);
+	}
+
+	@Test
+	public void verifyMissingHeaderTest() {
+		final HttpSignVerifier verifier = HttpSignVerifier.create(secretProvider(true, SK, HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), fixedConfig());
+		final HttpSignRequest request = baseRequest();
+
+		assertError(verifier.verify(request), HttpSignErrorCode.SIGN_MISSING_ACCESS_KEY_ID);
+		request.setHeader("X-Access-Key-Id", AK);
+		assertError(verifier.verify(request), HttpSignErrorCode.SIGN_MISSING_TIMESTAMP);
+		request.setHeader("X-Sign-Timestamp", String.valueOf(NOW));
+		assertError(verifier.verify(request), HttpSignErrorCode.SIGN_MISSING_NONCE);
+		request.setHeader("X-Sign-Nonce", "n8K3pV9");
+		assertError(verifier.verify(request), HttpSignErrorCode.SIGN_MISSING_ALGORITHM);
+		request.setHeader("X-Sign-Algorithm", "HmacSHA256");
+		assertError(verifier.verify(request), HttpSignErrorCode.SIGN_MISSING_SIGNATURE);
+	}
+
+	@Test
+	public void verifyTimestampInvalidAndSkewTest() {
+		final HttpSignRequest invalidRequest = baseRequest()
+			.setHeader("X-Access-Key-Id", AK)
+			.setHeader("X-Sign-Timestamp", "bad")
+			.setHeader("X-Sign-Nonce", "n8K3pV9")
+			.setHeader("X-Sign-Algorithm", "HmacSHA256")
+			.setHeader("X-Signature", "invalid");
+
+		assertError(verifier(fixedConfig()).verify(invalidRequest), HttpSignErrorCode.SIGN_TIMESTAMP_INVALID);
+
+		final HttpSignRequest expiredRequest = signedRequest(baseRequest(), fixedConfig());
+		assertError(verifier(fixedConfig(NOW + 301)).verify(expiredRequest), HttpSignErrorCode.SIGN_TIMESTAMP_SKEW);
+	}
+
+	@Test
+	public void verifySecretStateTest() {
+		final HttpSignConfig config = fixedConfig();
+		final HttpSignRequest request = signedRequest(baseRequest(), config);
+
+		assertError(HttpSignVerifier.create(accessKeyId -> null, MemoryNonceStore.create(), config).verify(request), HttpSignErrorCode.SIGN_ACCESS_KEY_NOT_FOUND);
+		assertError(HttpSignVerifier.create(secretProvider(false, SK, HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), config).verify(request), HttpSignErrorCode.SIGN_ACCESS_KEY_DISABLED);
+		assertError(HttpSignVerifier.create(expiredSecretProvider(), MemoryNonceStore.create(), config).verify(request), HttpSignErrorCode.SIGN_SECRET_EXPIRED);
+		assertError(HttpSignVerifier.create(secretProvider(true, "wrong_secret_xxxxxxxxxxxxxxxxxxxxxxxxxxx", HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), config).verify(request), HttpSignErrorCode.SIGN_MISMATCH);
+	}
+
+	@Test
+	public void verifyAlgorithmAllowedTest() {
+		final HttpSignConfig signConfig = fixedConfig()
+			.setDefaultAlgorithm(HttpSignAlgorithm.HMAC_SHA1)
+			.allowAlgorithms(HttpSignAlgorithm.HMAC_SHA1);
+		final HttpSignRequest request = signedRequest(baseRequest(), signConfig);
+
+		assertError(HttpSignVerifier.create(secretProvider(true, SK, HttpSignAlgorithm.HMAC_SHA1), MemoryNonceStore.create(), fixedConfig()).verify(request),
+			HttpSignErrorCode.SIGN_UNSUPPORTED_ALGORITHM);
+
+		final HttpSignConfig verifyConfig = fixedConfig().allowAlgorithms(HttpSignAlgorithm.HMAC_SHA1);
+		assertError(HttpSignVerifier.create(secretProvider(true, SK, HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), verifyConfig).verify(request),
+			HttpSignErrorCode.SIGN_UNSUPPORTED_ALGORITHM);
+	}
+
+	@Test
+	public void verifyBodyChangedTest() {
+		final HttpSignConfig config = fixedConfig();
+		final HttpSignRequest request = signedRequest(baseRequest(), config);
+		request.setBody("{\"name\":\"李四\"}");
+
+		assertError(verifier(config).verify(request), HttpSignErrorCode.SIGN_MISMATCH);
+	}
+
+	@Test
+	public void verifyQueryChangedTest() {
+		final HttpSignConfig config = fixedConfig();
+		final HttpSignRequest request = signedRequest(baseRequest().addQueryParam("a", "1"), config);
+		request.addQueryParam("a", "2");
+
+		assertError(verifier(config).verify(request), HttpSignErrorCode.SIGN_MISMATCH);
+	}
+
+	@Test
+	public void verifyNullNonceStoreTest() {
+		final HttpSignConfig config = fixedConfig();
+		final HttpSignRequest request = signedRequest(baseRequest(), config);
+		final HttpSignVerifier verifier = HttpSignVerifier.create(secretProvider(true, SK, HttpSignAlgorithm.HMAC_SHA256), null, config);
+
+		Assertions.assertTrue(verifier.verify(request).isSuccess());
+		Assertions.assertTrue(verifier.verify(request).isSuccess());
+	}
+
+	@Test
+	public void verifierSecretProviderRequiredTest() {
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> HttpSignVerifier.create(null, MemoryNonceStore.create(), fixedConfig()));
+	}
+
+	private static HttpSignVerifier verifier(final HttpSignConfig config) {
+		return HttpSignVerifier.create(secretProvider(true, SK, HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), config);
+	}
+
+	private static HttpSignRequest signedRequest(final HttpSignRequest request, final HttpSignConfig config) {
+		final HttpSignResult signResult = HttpSigner.sign(request, AkSkCredentials.of(AK, SK), config);
+		applyHeaders(request, signResult.getHeaders());
+		return request;
+	}
+
+	private static HttpSignRequest baseRequest() {
+		return HttpSignRequest.create()
+			.setMethod("POST")
+			.setPath("/api/user/create")
+			.setHeader("Content-Type", "application/json")
+			.setBody("{\"name\":\"张三\"}");
+	}
+
+	private static HttpSignConfig fixedConfig() {
+		return fixedConfig(NOW);
+	}
+
+	private static HttpSignConfig fixedConfig(final long now) {
+		return HttpSignConfig.create()
+			.setTimestampProvider(() -> now)
+			.setNonceGenerator(() -> "n8K3pV9");
+	}
+
+	private static SecretProvider secretProvider(final boolean enabled, final String secret, final HttpSignAlgorithm allowedAlgorithm) {
+		return accessKeyId -> {
+			if (AK.equals(accessKeyId)) {
+				return SecretInfo.of(AK, secret)
+					.setEnabled(enabled)
+					.allowAlgorithms(allowedAlgorithm);
+			}
+			return null;
+		};
+	}
+
+	private static SecretProvider expiredSecretProvider() {
+		return accessKeyId -> {
+			if (AK.equals(accessKeyId)) {
+				return SecretInfo.of(AK, SK)
+					.setExpireAt(NOW - 1)
+					.allowAlgorithms(HttpSignAlgorithm.HMAC_SHA256);
+			}
+			return null;
+		};
+	}
+
+	private static void applyHeaders(final HttpSignRequest request, final Map<String, String> headers) {
+		for (final Map.Entry<String, String> entry : headers.entrySet()) {
+			request.setHeader(entry.getKey(), entry.getValue());
+		}
+	}
+
+	private static void assertError(final HttpSignVerifyResult result, final HttpSignErrorCode errorCode) {
+		Assertions.assertFalse(result.isSuccess());
+		Assertions.assertEquals(errorCode, result.getErrorCode());
+	}
+}

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignerTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/sign/http/HttpSignerTest.java
@@ -1,0 +1,163 @@
+package cn.hutool.crypto.sign.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * HTTP签名器测试。
+ *
+ * @author mumu
+ */
+public class HttpSignerTest {
+
+	private static final String AK = "ak_test_123";
+	private static final String SK = "sk_test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+	private static final long NOW = 1731312000L;
+
+	@Test
+	public void defaultHeaderNamesTest() {
+		final HttpSignResult result = HttpSigner.sign(baseRequest(), AkSkCredentials.of(AK, SK), fixedConfig());
+
+		Assertions.assertEquals(AK, result.getHeaders().get("X-Access-Key-Id"));
+		Assertions.assertEquals(String.valueOf(NOW), result.getHeaders().get("X-Sign-Timestamp"));
+		Assertions.assertEquals("n8K3pV9", result.getHeaders().get("X-Sign-Nonce"));
+		Assertions.assertEquals("HmacSHA256", result.getHeaders().get("X-Sign-Algorithm"));
+		Assertions.assertNotNull(result.getHeaders().get("X-Signature"));
+	}
+
+	@Test
+	public void openapiHeaderNamesTest() {
+		final HttpSignConfig config = fixedConfig().setSignHeaderNames(SignHeaderNames.openapi());
+		final HttpSignResult result = HttpSigner.sign(baseRequest(), AkSkCredentials.of(AK, SK), config);
+
+		Assertions.assertEquals(AK, result.getHeaders().get("X-Openapi-App-Id"));
+		Assertions.assertTrue(result.getHeaders().containsKey("X-Openapi-Signature"));
+	}
+
+	@Test
+	public void customHeaderNamesTest() {
+		final SignHeaderNames channelHeaderNames = SignHeaderNames.of(
+			"X-Channel-Ak",
+			"X-Channel-Time",
+			"X-Channel-Nonce",
+			"X-Channel-Algorithm",
+			"X-Channel-Sign"
+		);
+		final HttpSignConfig config = fixedConfig().setSignHeaderNames(channelHeaderNames);
+		final HttpSignResult signResult = HttpSigner.sign(baseRequest(), AkSkCredentials.of(AK, SK), config);
+		final HttpSignRequest request = baseRequest();
+		applyHeaders(request, signResult.getHeaders());
+
+		Assertions.assertTrue(signResult.getHeaders().containsKey("X-Channel-Ak"));
+		Assertions.assertTrue(signResult.getHeaders().containsKey("X-Channel-Sign"));
+		Assertions.assertTrue(signResult.getCanonicalRequest().getCanonicalHeaders().contains("x-channel-ak=" + AK));
+		Assertions.assertTrue(signResult.getCanonicalRequest().getCanonicalHeaders().contains("x-channel-time=" + NOW));
+		Assertions.assertTrue(HttpSignVerifier.create(secretProvider(HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), config).verify(request).isSuccess());
+	}
+
+	@Test
+	public void customSignedAndExcludedHeaderTest() {
+		final HttpSignRequest request = baseRequest()
+			.setHeader("X-Channel-Id", "  channel-a  ")
+			.setHeader("X-Trace-Id", "trace-1");
+		final HttpSignConfig config = fixedConfig()
+			.addSignedHeaderName(" X-Channel-Id ")
+			.addExcludedHeaderName(" X-Trace-Id ");
+
+		final HttpSignResult result = HttpSigner.sign(request, AkSkCredentials.of(AK, SK), config);
+
+		Assertions.assertTrue(result.getCanonicalRequest().getCanonicalHeaders().contains("x-channel-id=channel-a"));
+		Assertions.assertFalse(result.getCanonicalRequest().getCanonicalHeaders().contains("x-trace-id"));
+	}
+
+	@Test
+	public void hexSignatureEncodingTest() {
+		final HttpSignConfig config = fixedConfig().setSignatureEncoding(SignatureEncoding.HEX);
+		final HttpSignResult result = HttpSigner.sign(baseRequest(), AkSkCredentials.of(AK, SK), config);
+
+		Assertions.assertEquals(64, result.getSignature().length());
+		Assertions.assertTrue(result.getSignature().matches("[0-9a-f]+"));
+	}
+
+	@Test
+	public void signAlgorithmsTest() {
+		assertAlgorithm(HttpSignAlgorithm.HMAC_SHA1);
+		assertAlgorithm(HttpSignAlgorithm.HMAC_SHA256);
+		assertAlgorithm(HttpSignAlgorithm.HMAC_SHA512);
+		assertAlgorithm(HttpSignAlgorithm.HMAC_MD5);
+		assertAlgorithm(HttpSignAlgorithm.HMAC_SM3);
+	}
+
+	@Test
+	public void bodyDigestAlgorithmTest() {
+		final HttpSignConfig config = fixedConfig().setBodyDigestAlgorithm(HttpSignDigestAlgorithm.SM3);
+		final HttpSignResult signResult = HttpSigner.sign(baseRequest(), AkSkCredentials.of(AK, SK), config);
+
+		Assertions.assertTrue(HttpSignVerifier.create(secretProvider(HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), config)
+			.verify(signedRequest(signResult)).isSuccess());
+		Assertions.assertFalse(HttpSignVerifier.create(secretProvider(HttpSignAlgorithm.HMAC_SHA256), MemoryNonceStore.create(), fixedConfig())
+			.verify(signedRequest(signResult)).isSuccess());
+	}
+
+	@Test
+	public void headerNameInvalidTest() {
+		Assertions.assertThrows(IllegalArgumentException.class,
+			() -> SignHeaderNames.create().setAccessKeyIdHeaderName(" "));
+
+		final HttpSignException exception = Assertions.assertThrows(HttpSignException.class,
+			() -> SignHeaderNames.create().setAccessKeyIdHeaderName("X-Ak\r\n"));
+		Assertions.assertEquals(HttpSignErrorCode.SIGN_CANONICALIZE_FAILED, exception.getErrorCode());
+
+		final HttpSignException configException = Assertions.assertThrows(HttpSignException.class,
+			() -> HttpSignConfig.create().addSignedHeaderName("X-Channel\r\n"));
+		Assertions.assertEquals(HttpSignErrorCode.SIGN_CANONICALIZE_FAILED, configException.getErrorCode());
+	}
+
+	private static void assertAlgorithm(final HttpSignAlgorithm algorithm) {
+		final HttpSignConfig config = fixedConfig()
+			.setDefaultAlgorithm(algorithm)
+			.allowAlgorithms(algorithm);
+		final HttpSignResult signResult = HttpSigner.sign(baseRequest(), AkSkCredentials.of(AK, SK), config);
+
+		Assertions.assertEquals(algorithm.getAlgorithmName(), signResult.getHeaders().get("X-Sign-Algorithm"));
+		Assertions.assertTrue(HttpSignVerifier.create(secretProvider(algorithm), MemoryNonceStore.create(), config)
+			.verify(signedRequest(signResult)).isSuccess());
+	}
+
+	private static HttpSignRequest signedRequest(final HttpSignResult signResult) {
+		final HttpSignRequest request = baseRequest();
+		applyHeaders(request, signResult.getHeaders());
+		return request;
+	}
+
+	private static HttpSignRequest baseRequest() {
+		return HttpSignRequest.create()
+			.setMethod("POST")
+			.setPath("/api/user/create")
+			.setHeader("Content-Type", "application/json")
+			.setBody("{\"name\":\"张三\"}");
+	}
+
+	private static HttpSignConfig fixedConfig() {
+		return HttpSignConfig.create()
+			.setTimestampProvider(() -> NOW)
+			.setNonceGenerator(() -> "n8K3pV9");
+	}
+
+	private static SecretProvider secretProvider(final HttpSignAlgorithm algorithm) {
+		return accessKeyId -> {
+			if (AK.equals(accessKeyId)) {
+				return SecretInfo.of(AK, SK).allowAlgorithms(algorithm);
+			}
+			return null;
+		};
+	}
+
+	private static void applyHeaders(final HttpSignRequest request, final Map<String, String> headers) {
+		for (final Map.Entry<String, String> entry : headers.entrySet()) {
+			request.setHeader(entry.getKey(), entry.getValue());
+		}
+	}
+}


### PR DESCRIPTION
- 添加AkSkCredentials类，支持多种构造凭证方式
- 实现CanonicalRequest类，封装规范化HTTP请求内容
- 新增HttpSignAlgorithm枚举，支持多种HMAC算法
- 实现HttpSignCanonicalizer，完成请求路径、查询及Header的规范化
- 支持请求体摘要计算及大小限制检测
- 添加HttpSignConfig配置类，支持签名算法、编码、Header白名单等配置
- 新增HttpSignDigestAlgorithm枚举，支持SHA256、SHA1、MD5、SM3等摘要算法
- 实现HttpSigner签名器，支持不同配置和凭证的请求签名
- 增加HttpSignCanonicalizerTest单元测试，覆盖规范化和摘要计算场景