### PR TITLE
fix: BeanConverter和MapConverter对源Bean使用isReadableBean替代isBean

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/impl/BeanConverter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/impl/BeanConverter.java
@@ -79,7 +79,7 @@ public class BeanConverter<T> extends AbstractConverter<T> {
 
 		if(value instanceof Map ||
 				value instanceof ValueProvider ||
-				BeanUtil.isBean(value.getClass())) {
+				BeanUtil.isReadableBean(value.getClass())) {
 			if(value instanceof Map && this.beanClass.isInterface()) {
 				// 将Map动态代理为Bean
 				return MapProxy.create((Map<?, ?>)value).toProxyBean(this.beanClass);

--- a/hutool-core/src/main/java/cn/hutool/core/convert/impl/MapConverter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/impl/MapConverter.java
@@ -73,7 +73,7 @@ public class MapConverter extends AbstractConverter<Map<?, ?>> {
 				map = MapUtil.createMap(mapClass);
 			}
 			convertMapToMap((Map) value, map);
-		} else if (BeanUtil.isBean(value.getClass())) {
+		} else if (BeanUtil.isReadableBean(value.getClass())) {
 			if(value.getClass().getName().equals("cn.hutool.json.JSONArray")){
 				// issue#3795 增加JSONArray转Map错误检查
 				throw new UnsupportedOperationException(StrUtil.format("Unsupported {} to Map.", value.getClass().getName()));

--- a/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/bean/BeanUtilTest.java
@@ -974,4 +974,85 @@ public class BeanUtilTest {
 		final boolean bean = BeanUtil.isBean(Dict.class);
 		assertFalse(bean);
 	}
+
+	// ============ Test for GitHub issue #4245 ============
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Order4245 {
+		private Long orderId;
+		private String orderNo;
+		private List<OrderItem4245> orderItemList;
+	}
+
+	@Getter
+	@Setter(AccessLevel.PROTECTED)
+	@AllArgsConstructor(access = AccessLevel.PROTECTED)
+	@NoArgsConstructor
+	public static class OrderItem4245 {
+		private Long itemId;
+		private String productName;
+		private Integer quantity;
+	}
+
+	@Data
+	public static class OrderDto4245 {
+		private Long orderId;
+		private String orderNo;
+		private List<OrderItemDto4245> orderItemList;
+	}
+
+	@Data
+	public static class OrderItemDto4245 {
+		private Long itemId;
+		private String productName;
+		private Integer quantity;
+	}
+
+	/**
+	 * GitHub issue#4245: BeanUtil.copyProperties throws ConvertException
+	 * when source list element has protected setters.
+	 *
+	 * <p>Root cause: BeanConverter used isBean() (which checks for public setters)
+	 * on the SOURCE object instead of isReadableBean() (which checks for public getters).
+	 * A source bean only needs to be readable, not writable.</p>
+	 */
+	@Test
+	public void issue4245Test() {
+		final Order4245 order = new Order4245(
+				1L,
+				"01",
+				new ArrayList<>()
+		);
+		order.getOrderItemList().add(
+				new OrderItem4245(1L, "aa", 1)
+		);
+
+		// This should not throw ConvertException
+		final OrderDto4245 dto = BeanUtil.copyProperties(order, OrderDto4245.class);
+
+		assertNotNull(dto);
+		assertEquals(order.getOrderId(), dto.getOrderId());
+		assertEquals(order.getOrderNo(), dto.getOrderNo());
+		assertNotNull(dto.getOrderItemList());
+		assertEquals(1, dto.getOrderItemList().size());
+		assertEquals(Long.valueOf(1L), dto.getOrderItemList().get(0).getItemId());
+		assertEquals("aa", dto.getOrderItemList().get(0).getProductName());
+		assertEquals(Integer.valueOf(1), dto.getOrderItemList().get(0).getQuantity());
+	}
+
+	/**
+	 * Test map conversion with protected setter bean
+	 */
+	@Test
+	public void issue4245MapConvertTest() {
+		final OrderItem4245 item = new OrderItem4245(1L, "aa", 1);
+		// Should not throw UnsupportedOperationException
+		final Map<String, Object> map = BeanUtil.beanToMap(item);
+		assertNotNull(map);
+		assertEquals(1L, map.get("itemId"));
+		assertEquals("aa", map.get("productName"));
+		assertEquals(1, map.get("quantity"));
+	}
 }


### PR DESCRIPTION
修了 #4245 的问题。当 List 里的元素类用了 @Setter(AccessLevel.PROTECTED) 只有 protected setter 的时候，BeanUtil.copyProperties 会抛 ConvertException: Unsupported source type，但实际上这个类有 public getter， 作为源对象完全可以被读取。

原因是 BeanConverter 和 MapConverter 在处理源对象时用 isBean() 做检查， 但 isBean() 看的是有没有 public setter，这是判断"能不能写"的标准，
而源对象需要的是"能不能读"。BeanUtil 里其实已经有 isReadableBean() 方法 （检查 public getter），正好适合这个场景，换过来就行。两个转换器各改了一行，
另外补了两个单测覆盖这种情况。

#### 说明

1. 请确认你提交的PR是到'v5-dev'分支，否则我会手动修改代码并关闭PR。
2. 请确认没有更改代码风格（如tab缩进）
3. 新特性添加请确认注释完备，如有必要，请在src/test/java下添加Junit测试用例

### 修改描述(包括说明bug修复或者添加新特性)

1. [bug修复] balabala……
2. [新特性]  balabala……

### 提交前自测
> 请在提交前自测确保代码没有问题，提交新代码应包含：测试用例、通过(mvn javadoc:javadoc)检验详细注释。

1. 本地如有多个JDK版本，可以设置临时JDk版本,如：`export JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_331.jdk/Contents/Home`，具体替换为本地jdk目录
2. 确保本地测试使用JDK8最新版本，`echo $JAVA_HOME`、`mvn -v`、`java -version`均正确。
3. 执行打包生成文档，使用`mvn clean package -Dmaven.test.skip=true -U`，并确认通过，会自动执行打包、生成文档
4. 如需要单独执行文档生成，执行：`mvn javadoc:javadoc `，并确认通过
5. 如需要单独执行测试用例，执行：`mvn clean test`，并确认通过