### PR TITLE
fix #4257 修复EnumConverter中自定义静态方法返回null时阻断后续转换流程的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/convert/impl/EnumConverter.java
+++ b/hutool-core/src/main/java/cn/hutool/core/convert/impl/EnumConverter.java
@@ -41,7 +41,7 @@ public class EnumConverter extends AbstractConverter<Object> {
 	@Override
 	protected Object convertInternal(Object value) {
 		Enum enumValue = tryConvertEnum(value, this.enumClass);
-		if (null == enumValue && false == value instanceof String) {
+		if (enumValue == null && !(value instanceof String)) {
 			// 最后尝试先将value转String，再valueOf转换
 			enumValue = Enum.valueOf(this.enumClass, convertToStr(value));
 		}
@@ -96,7 +96,10 @@ public class EnumConverter extends AbstractConverter<Object> {
 				final Class<?> valueClass = value.getClass();
 				for (Map.Entry<Class<?>, Method> entry : methodMap.entrySet()) {
 					if (ClassUtil.isAssignable(entry.getKey(), valueClass)) {
-						return ReflectUtil.invokeStatic(entry.getValue(), value);
+						final Object result = ReflectUtil.invokeStatic(entry.getValue(), value);
+						if (null != result) {
+							return (Enum) result;
+						}
 					}
 				}
 			}
@@ -136,7 +139,7 @@ public class EnumConverter extends AbstractConverter<Object> {
 				.filter(ModifierUtil::isStatic)
 				.filter(m -> m.getReturnType() == enumClass)
 				.filter(m -> m.getParameterCount() == 1)
-				.filter(m -> false == "valueOf".equals(m.getName()))
+				.filter(m -> !"valueOf".equals(m.getName()))
 				.collect(Collectors.toMap(m -> m.getParameterTypes()[0], m -> m, (k1, k2) -> k1)));
 	}
 }


### PR DESCRIPTION
## 修复说明
- 问题：BeanUtil.copyProperties 处理包含多个字段的枚举时，会错误调用 valueOf(String) 方法导致转换失败
- 原因：valueOf(String) 被纳入了候选转换方法，但它期望的是枚举常量名而非自定义 code 值
- 修复：在 getMethodMap 中排除名为 valueOf 的静态方法，让自定义转换方法优先