### PR TITLE
修改注释错别字

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/bean/BeanPath.java
+++ b/hutool-core/src/main/java/cn/hutool/core/bean/BeanPath.java
@@ -99,7 +99,7 @@ public class BeanPath implements Serializable {
 	}
 
 	/**
-	 * 设置表达式指定位置（或filed对应）的值<br>
+	 * 设置表达式指定位置（或field对应）的值<br>
 	 * 若表达式指向一个List则设置其坐标对应位置的值，若指向Map则put对应key的值，Bean则设置字段的值<br>
 	 * 注意：
 	 *
@@ -123,7 +123,7 @@ public class BeanPath implements Serializable {
 	//region Private Methods
 
 	/**
-	 * 设置表达式指定位置（或filed对应）的值<br>
+	 * 设置表达式指定位置（或field对应）的值<br>
 	 * 若表达式指向一个List则设置其坐标对应位置的值，若指向Map则put对应key的值，Bean则设置字段的值<br>
 	 * 注意：
 	 *

--- a/hutool-cron/src/main/java/cn/hutool/cron/TaskExecutorManager.java
+++ b/hutool-cron/src/main/java/cn/hutool/cron/TaskExecutorManager.java
@@ -53,9 +53,9 @@ public class TaskExecutorManager implements Serializable {
 		synchronized (this.executors) {
 			this.executors.add(executor);
 		}
-		// 子线程是否为deamon线程取决于父线程，因此此处无需显示调用
+		// 子线程是否为daemon线程取决于父线程，因此此处无需显式调用
 		// executor.setDaemon(this.scheduler.daemon);
-//		executor.start();
+		// executor.start();
 		this.scheduler.threadExecutor.execute(executor);
 		return executor;
 	}

--- a/hutool-cron/src/main/java/cn/hutool/cron/TaskLauncherManager.java
+++ b/hutool-cron/src/main/java/cn/hutool/cron/TaskLauncherManager.java
@@ -31,9 +31,9 @@ public class TaskLauncherManager implements Serializable {
 		synchronized (this.launchers) {
 			this.launchers.add(launcher);
 		}
-		//子线程是否为deamon线程取决于父线程，因此此处无需显示调用
+		// 子线程是否为daemon线程取决于父线程，因此此处无需显式调用
 		//launcher.setDaemon(this.scheduler.daemon);
-//		launcher.start();
+		// launcher.start();
 		this.scheduler.threadExecutor.execute(launcher);
 		return launcher;
 	}

--- a/hutool-cron/src/test/java/cn/hutool/cron/demo/TestJob.java
+++ b/hutool-cron/src/test/java/cn/hutool/cron/demo/TestJob.java
@@ -24,7 +24,7 @@ public class TestJob {
 	}
 
 	/**
-	 * 执行循环定时任务，测试在定时任务结束时作为deamon线程是否能正常结束
+	 * 执行循环定时任务，测试在定时任务结束时作为daemon线程是否能正常结束
 	 */
 	@SuppressWarnings("InfiniteLoopStatement")
 	public void doWhileTest() {

--- a/hutool-db/src/test/resources/config/example/db-example-druid.setting
+++ b/hutool-db/src/test/resources/config/example/db-example-druid.setting
@@ -25,7 +25,7 @@ formatSql = true
 ## 连接池配置项
 
 ## ---------------------------------------------------- Druid
-# 初始化时建立物理连接的个数。初始化发生在显示调用init方法，或者第一次getConnection时
+# 初始化时建立物理连接的个数。初始化发生在显式调用init方法，或者第一次getConnection时
 initialSize = 0
 # 最大连接池数量
 maxActive = 8

--- a/hutool-json/src/main/java/cn/hutool/json/JSON.java
+++ b/hutool-json/src/main/java/cn/hutool/json/JSON.java
@@ -48,7 +48,7 @@ public interface JSON extends Cloneable, Serializable, IJSONTypeConverter {
 	Object getByPath(String expression);
 
 	/**
-	 * 设置表达式指定位置（或filed对应）的值<br>
+	 * 设置表达式指定位置（或field对应）的值<br>
 	 * 若表达式指向一个JSONArray则设置其坐标对应位置的值，若指向JSONObject则put对应key的值<br>
 	 * 注意：如果为JSONArray，设置值下标小于其长度，将替换原有值，否则追加新值<br>
 	 * <ol>

--- a/hutool-json/src/main/java/cn/hutool/json/JSONUtil.java
+++ b/hutool-json/src/main/java/cn/hutool/json/JSONUtil.java
@@ -595,9 +595,9 @@ public class JSONUtil {
 	}
 
 	/**
-	 * 设置表达式指定位置（或filed对应）的值<br>
+	 * 设置表达式指定位置（或field对应）的值<br>
 	 * 若表达式指向一个JSONArray则设置其坐标对应位置的值，若指向JSONObject则put对应key的值<br>
-	 * 注意：如果为JSONArray，则设置值得下标不能大于已有JSONArray的长度<br>
+	 * 注意：如果为JSONArray，则设置值的下标不能大于已有JSONArray的长度<br>
 	 * <ol>
 	 * <li>.表达式，可以获取Bean对象中的属性（字段）值或者Map中key对应的值</li>
 	 * <li>[]表达式，可以获取集合等对象中对应index的值</li>


### PR DESCRIPTION
修改 TaskExecutorManager.spawnExecutor、TaskLauncherManager.spawnLauncher、TestJob.doWhileTest、JSON.putByPath、JSONUtil.putByPath、BeanPath.set(Object bean, Object value)、BeanPath.set(Object bean, List<String> patternParts, boolean nextNumberPart, Object value)、db-example-druid.setting 注释错别字，无逻辑变动