### PR TITLE
fix: harden QLExpressEngine against the constructor / native-load blacklist bypass (#4270

### DIFF
--- a/hutool-extra/src/main/java/cn/hutool/extra/expression/engine/qlexpress/QLExpressEngine.java
+++ b/hutool-extra/src/main/java/cn/hutool/extra/expression/engine/qlexpress/QLExpressEngine.java
@@ -7,6 +7,11 @@ import com.ql.util.express.ExpressRunner;
 import com.ql.util.express.config.QLExpressRunStrategy;
 
 import javax.naming.InitialContext;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.RandomAccessFile;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
@@ -33,6 +38,23 @@ public class QLExpressEngine implements ExpressionEngine {
 		QLExpressRunStrategy.setForbidInvokeSecurityRiskMethods(true);
 		// Explicitly forbid JNDI lookup calls through InitialContext
 		QLExpressRunStrategy.addSecurityRiskMethod(InitialContext.class, "doLookup");
+
+		// The method blacklist above does not cover object creation, so also enforce the
+		// constructor blacklist; otherwise new FileOutputStream(...) can drop a payload that
+		// System.load then runs as native code
+		QLExpressRunStrategy.setForbidInvokeSecurityRiskConstructors(true);
+		// High-risk methods missing from the default blacklist
+		QLExpressRunStrategy.addSecurityRiskMethod(System.class, "load");
+		QLExpressRunStrategy.addSecurityRiskMethod(System.class, "loadLibrary");
+		QLExpressRunStrategy.addSecurityRiskMethod(System.class, "setProperty");
+		QLExpressRunStrategy.addSecurityRiskMethod(Runtime.class, "load");
+		QLExpressRunStrategy.addSecurityRiskMethod(Runtime.class, "loadLibrary");
+		// High-risk file read/write constructors
+		QLExpressRunStrategy.addRiskSecureConstructor(FileOutputStream.class);
+		QLExpressRunStrategy.addRiskSecureConstructor(FileWriter.class);
+		QLExpressRunStrategy.addRiskSecureConstructor(RandomAccessFile.class);
+		QLExpressRunStrategy.addRiskSecureConstructor(FileInputStream.class);
+		QLExpressRunStrategy.addRiskSecureConstructor(FileReader.class);
 	}
 
 	@Override

--- a/hutool-extra/src/test/java/cn/hutool/extra/expression/ExpressionUtilTest.java
+++ b/hutool-extra/src/test/java/cn/hutool/extra/expression/ExpressionUtilTest.java
@@ -108,4 +108,24 @@ public class ExpressionUtilTest {
 		assertEquals(-143.8, (double)eval, 0);
 	}
 
+	@Test
+	public void qlExpressSecurityTest(){
+		// https://github.com/chinabugotech/hutool/issues/4270
+		// 默认黑名单模式下，高危的构造方法与native库加载等不能通过表达式调用
+		final ExpressionEngine engine = new QLExpressEngine();
+		final Dict context = Dict.of();
+
+		assertThrows(ExpressionException.class,
+				() -> engine.eval("new java.io.FileOutputStream(\"/tmp/hutool_test\")", context, null));
+		assertThrows(ExpressionException.class,
+				() -> engine.eval("System.load(\"/tmp/hutool_test.so\")", context, null));
+		assertThrows(ExpressionException.class,
+				() -> engine.eval("System.setProperty(\"k\", \"v\")", context, null));
+		assertThrows(ExpressionException.class,
+				() -> engine.eval("new java.io.RandomAccessFile(\"/tmp/hutool_test\", \"rw\")", context, null));
+
+		// 普通表达式不受影响
+		assertEquals(7, engine.eval("1+2*3", context, null));
+	}
+
 }


### PR DESCRIPTION
`QLExpressEngine` enabled the method blacklist but not the constructor blacklist, so
`new java.io.FileOutputStream(...)` was unchecked; `System.load`/`loadLibrary`/`setProperty`
were also missing. This enables `setForbidInvokeSecurityRiskConstructors(true)` and adds the
missing methods/constructors. Ordinary expressions are unaffected.

### Description
1. [Bugfix] Fix #4270: enable the constructor blacklist and add the missing high-risk
   methods (`System.load`/`loadLibrary`/`setProperty`) and file read/write constructors.
2. Add the `qlExpressSecurityTest` regression test.

### Pre-submission self-check
- Target branch: `v5-dev`
- No code-style changes (tab indentation)
- JUnit test added