### PR TITLE
Fix StringIndexOutOfBoundsException when parsing ISO8601 with a short zone offset

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/date/DateUtil.java
@@ -904,6 +904,9 @@ public class DateUtil extends CalendarUtil {
 			}
 			if (false == StrUtil.contains(zoneOffset, ':')) {
 				// +0800转换为+08:00
+				if (zoneOffset.length() < 2) {
+					throw new DateException("Invalid format: [{}]", iso8601String);
+				}
 				final String pre = StrUtil.subBefore(iso8601String, '+', true);
 				iso8601String = pre + "+" + zoneOffset.substring(0, 2) + ":" + "00";
 			}

--- a/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/date/DateUtilTest.java
@@ -1261,4 +1261,12 @@ public class DateUtilTest {
 		 */
 	}
 
+
+	@Test
+	public void parseISO8601ShortZoneOffsetTest() {
+		// Short zone offset like "+0" should throw DateException, not StringIndexOutOfBoundsException
+		assertThrows(DateException.class, () -> {
+			DateUtil.parseISO8601("2019-06-01T19:45:43+0");
+		});
+	}
 }


### PR DESCRIPTION
Re-submitting against `v5-dev` as requested (previously #4274 against v5-master); the diff is code-only, no file-mode change.

## Problem

`DateUtil.parseISO8601()` normalizes a numeric zone offset like `+0800` to `+08:00` via `zoneOffset.substring(0, 2)`. When the part after the `+` is shorter than two characters, e.g.:

```java
DateUtil.parseISO8601("2019-06-01T19:45:43+0");
```

`substring(0, 2)` throws a raw `StringIndexOutOfBoundsException` instead of the `DateException` the method already throws for other malformed input.

## Fix

Validate the offset length and throw `DateException` for offsets shorter than two characters, consistent with the existing blank-offset handling a few lines above.

## Test

Adds `parseISO8601ShortZoneOffsetTest`, asserting `DateException` is thrown for `"2019-06-01T19:45:43+0"`. It fails before the change (`StringIndexOutOfBoundsException`) and passes after. Full `DateUtilTest` passes (run with `-e TZ=Asia/Shanghai`, since several unrelated tests assume the CST default time zone).