### PR TITLE
Fix wrong substring range in AntPathMatcher wildcard counting

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/AntPathMatcher.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/AntPathMatcher.java
@@ -866,7 +866,7 @@ public class AntPathMatcher {
 							if (pos + 1 < this.pattern.length() && this.pattern.charAt(pos + 1) == '*') {
 								this.doubleWildcards++;
 								pos += 2;
-							} else if (pos > 0 && !this.pattern.substring(pos - 1).equals(".*")) {
+							} else if (pos > 0 && !this.pattern.substring(pos - 1, pos + 1).equals(".*")) {
 								this.singleWildcards++;
 								pos++;
 							} else {

--- a/hutool-core/src/test/java/cn/hutool/core/text/AntPathMatcherTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/AntPathMatcherTest.java
@@ -3,9 +3,33 @@ package cn.hutool.core.text;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
 import java.util.HashMap;
 
 public class AntPathMatcherTest {
+
+	/**
+	 * Test that the pattern comparator correctly handles ".*" in the middle of a pattern.
+	 * The bug: substring(pos - 1) without end index returns the rest of the string,
+	 * not just two characters, so ".*" followed by more chars is miscounted.
+	 */
+	@Test
+	public void testPatternComparatorDotStarInMiddle() {
+		AntPathMatcher matcher = new AntPathMatcher();
+		Comparator<String> comparator = matcher.getPatternComparator("/files/file.txt");
+
+		// Pattern A: "/files/.*.txt" - the ".*" should NOT count as a single wildcard
+		// because ".*" is a special pattern (match any extension), not a standalone "*"
+		// Correct total count: 0 (no single wildcards, no uri vars, no double wildcards)
+		//
+		// Pattern B: "/files/*a.txt" - the "*" preceded by "/" IS a single wildcard
+		// Correct total count: 1 (one single wildcard)
+		//
+		// Pattern A should be more specific (fewer wildcards), so compare(A, B) < 0
+		int result = comparator.compare("/files/.*.txt", "/files/*a.txt");
+		assertTrue(result < 0, "Pattern with .* should be more specific than pattern with *; " +
+				"got compare result: " + result);
+	}
 
 	@Test
 	public void matchesTest() {


### PR DESCRIPTION
Re-submitting against `v5-dev` as requested (previously #4273 against v5-master); code-only diff, no file-mode change.

## Problem

In `AntPathMatcher`, the wildcard counting used `this.pattern.substring(pos - 1)`, which returns the entire remainder of the pattern from `pos - 1` to the end rather than just the two characters being checked against `".*"`. This produces an incorrect `singleWildcards` count.

## Fix

Use `this.pattern.substring(pos - 1, pos + 1)` so only the two characters at that position are compared against `".*"`.

## Test

Adds a case to `AntPathMatcherTest` that fails before the change and passes after.