### PR TITLE
Guard FileMagicNumber AAC/M4A/AMR matchers against short byte arrays

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/io/FileMagicNumber.java
+++ b/hutool-core/src/main/java/cn/hutool/core/io/FileMagicNumber.java
@@ -251,7 +251,7 @@ public enum FileMagicNumber {
 					&& Objects.equals(bytes[8], (byte) 0x4d)
 					&& Objects.equals(bytes[9], (byte) 0x34)
 					&& Objects.equals(bytes[10], (byte) 0x41))
-					|| (Objects.equals(bytes[0], (byte) 0x4d)
+					|| (bytes.length > 3 && Objects.equals(bytes[0], (byte) 0x4d)
 					&& Objects.equals(bytes[1], (byte) 0x34)
 					&& Objects.equals(bytes[2], (byte) 0x41)
 					&& Objects.equals(bytes[3], (byte) 0x20));
@@ -260,7 +260,7 @@ public enum FileMagicNumber {
 	AAC("audio/aac", "aac") {
 		@Override
 		public boolean match(final byte[] bytes) {
-			if (bytes.length < 1) {
+			if (bytes.length < 2) {
 				return false;
 			}
 			final boolean flag1 = Objects.equals(bytes[0], (byte) 0xFF) && Objects.equals(bytes[1], (byte) 0xF1);
@@ -282,7 +282,7 @@ public enum FileMagicNumber {
 					&& Objects.equals(bytes[4], (byte) 0x52)
 					&& Objects.equals(bytes[5], (byte) 0x0A);
 			//multi-channel:
-			final boolean flag2 = Objects.equals(bytes[0], (byte) 0x23)
+			final boolean flag2 = bytes.length >= 12 && Objects.equals(bytes[0], (byte) 0x23)
 					&& Objects.equals(bytes[1], (byte) 0x21)
 					&& Objects.equals(bytes[2], (byte) 0x41)
 					&& Objects.equals(bytes[3], (byte) 0x4d)

--- a/hutool-core/src/test/java/cn/hutool/core/io/FileMagicNumberShortArrayTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/io/FileMagicNumberShortArrayTest.java
@@ -1,0 +1,22 @@
+package cn.hutool.core.io;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Regression test: the AAC, M4A and AMR matchers must return {@code false} for byte arrays too short
+ * to contain their magic number, instead of throwing {@link ArrayIndexOutOfBoundsException}.
+ */
+class FileMagicNumberShortArrayTest {
+
+	@Test
+	void shortArraysReturnFalseInsteadOfThrowing() {
+		for (int len = 0; len <= 12; len++) {
+			final byte[] bytes = new byte[len];
+			assertFalse(FileMagicNumber.AAC.match(bytes), "AAC len=" + len);
+			assertFalse(FileMagicNumber.M4A.match(bytes), "M4A len=" + len);
+			assertFalse(FileMagicNumber.AMR.match(bytes), "AMR len=" + len);
+		}
+	}
+}


### PR DESCRIPTION
The `AAC`, `M4A` and `AMR` matchers in `FileMagicNumber` read byte indices beyond their length guard, throwing `ArrayIndexOutOfBoundsException` on short inputs instead of returning `false`:

- `AAC.match` guards `bytes.length < 1` but reads `bytes[1]` — a 1-byte array throws.
- `M4A.match`s second OR branch reads `bytes[0..3]` with no guard — arrays shorter than 4 bytes throw.
- `AMR.match` guards `bytes.length < 11` but `flag2` reads `bytes[11]` — an 11-byte array throws.

File-type detection should never crash on a short or truncated input. This adds the missing length checks so each matcher returns `false`. Includes a regression test that throws `ArrayIndexOutOfBoundsException` before the change and passes after.

## Verifying this change

The added `FileMagicNumberShortArrayTest` fails before this change and passes after:

Before the fix:

```
$ mvn test -Dtest=FileMagicNumberShortArrayTest -pl hutool-core
[INFO] Running cn.hutool.core.io.FileMagicNumberShortArrayTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0 <<< ERROR!
cn.hutool.core.io.FileMagicNumberShortArrayTest.shortArraysReturnFalseInsteadOfThrowing <<< ERROR!
java.lang.ArrayIndexOutOfBoundsException: 0
[INFO] BUILD FAILURE
```

After the fix:

```
$ mvn test -Dtest=FileMagicNumberShortArrayTest -pl hutool-core
[INFO] Running cn.hutool.core.io.FileMagicNumberShortArrayTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.

