### PR TITLE
Reject empty cipherKey in Vigenere with a clear exception

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/Vigenere.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/symmetric/Vigenere.java
@@ -20,6 +20,9 @@ public class Vigenere {
 	public static String encrypt(CharSequence data, CharSequence cipherKey) {
 		final int dataLen = data.length();
 		final int cipherKeyLen = cipherKey.length();
+		if (cipherKeyLen == 0) {
+			throw new IllegalArgumentException("cipherKey must not be empty");
+		}
 
 		final char[] cipherArray = new char[dataLen];
 		for (int i = 0; i < dataLen / cipherKeyLen + 1; i++) {
@@ -45,6 +48,9 @@ public class Vigenere {
 	public static String decrypt(CharSequence data, CharSequence cipherKey) {
 		final int dataLen = data.length();
 		final int cipherKeyLen = cipherKey.length();
+		if (cipherKeyLen == 0) {
+			throw new IllegalArgumentException("cipherKey must not be empty");
+		}
 
 		final char[] clearArray = new char[dataLen];
 		for (int i = 0; i < dataLen; i++) {

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/symmetric/SymmetricTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/symmetric/SymmetricTest.java
@@ -273,4 +273,15 @@ public class SymmetricTest {
 		String decrypt = Vigenere.decrypt(encrypt, key);
 		assertEquals(content, decrypt);
 	}
+
+	@Test
+	public void vigenereEmptyKeyTest() {
+		String content = "Hello";
+		String emptyKey = "";
+
+		// encrypt with an empty key should throw IllegalArgumentException, not ArithmeticException
+		assertThrows(IllegalArgumentException.class, () -> Vigenere.encrypt(content, emptyKey));
+		// decrypt with an empty key should also throw IllegalArgumentException
+		assertThrows(IllegalArgumentException.class, () -> Vigenere.decrypt(content, emptyKey));
+	}
 }


### PR DESCRIPTION
`Vigenere.encrypt` computes `dataLen / cipherKeyLen`, so an empty `cipherKey` throws a raw `ArithmeticException: / by zero`; `decrypt` silently produces garbage for an empty key. This validates the key in both methods and throws a clear `IllegalArgumentException` instead. Adds a regression test that fails before (ArithmeticException) and passes after.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
