### PR TITLE
Return null from CsvRow.get for a negative index

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvRow.java
+++ b/hutool-core/src/main/java/cn/hutool/core/text/csv/CsvRow.java
@@ -191,7 +191,7 @@ public final class CsvRow implements List<String> {
 
 	@Override
 	public String get(int index) {
-		return index >= fields.size() ? null : fields.get(index);
+		return index < 0 || index >= fields.size() ? null : fields.get(index);
 	}
 
 	@Override

--- a/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/text/csv/CsvReaderTest.java
@@ -202,4 +202,17 @@ public class CsvReaderTest {
 		final CsvReader reader = CsvUtil.getReader(ResourceUtil.getUtf8Reader("test_bean.csv"));
 		reader.stream().limit(2).forEach(Console::log);
 	}
+
+	@Test
+	public void csvRowGetNegativeIndexReturnsNull() {
+		// CsvRow.get(int) should return null for any out-of-bounds index, including negative.
+		CsvReader reader = new CsvReader();
+		CsvData data = reader.readFromStr("a,b,c\n");
+		CsvRow row = data.getRow(0);
+		// Negative index should return null, not throw IndexOutOfBoundsException
+		assertNull(row.get(-1));
+		assertNull(row.get(-100));
+		// Positive out-of-bounds already works
+		assertNull(row.get(10));
+	}
 }


### PR DESCRIPTION
`CsvRow.get(int)` guards `index >= fields.size()` but not negative indices, so `get(-1)` calls `fields.get(-1)` and throws `IndexOutOfBoundsException`. This returns `null` for a negative index too, matching the method contract of returning `null` for any out-of-bounds index. Adds a regression test that throws before the change and passes after.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
