### PR TITLE
Reject too-short salt in BCrypt.hashpw with IllegalArgumentException

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/digest/BCrypt.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/digest/BCrypt.java
@@ -418,6 +418,8 @@ public class BCrypt {
 		int rounds, off;
 		StringBuilder rs = new StringBuilder();
 
+		if (salt.length() < 29)
+			throw new IllegalArgumentException("Invalid salt");
 		if (salt.charAt(0) != '$' || salt.charAt(1) != '2')
 			throw new IllegalArgumentException("Invalid salt version");
 		if (salt.charAt(2) == '$')

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/digest/BCryptTest.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/digest/BCryptTest.java
@@ -10,4 +10,13 @@ public class BCryptTest {
 		assertFalse(BCrypt.checkpw("xxx",
 				"$2a$2a$10$e4lBTlZ019KhuAFyqAlgB.Jxc6cM66GwkSR/5/xXNQuHUItPLyhzy"));
 	}
+
+	@Test
+	public void hashpwShortSaltThrowsIllegalArgumentException() {
+		assertThrows(IllegalArgumentException.class, () -> BCrypt.hashpw("password", "$"));
+		assertThrows(IllegalArgumentException.class, () -> BCrypt.hashpw("password", "$2"));
+		assertThrows(IllegalArgumentException.class, () -> BCrypt.hashpw("password", "$2a"));
+		assertThrows(IllegalArgumentException.class, () -> BCrypt.hashpw("password", "$2a$"));
+		assertThrows(IllegalArgumentException.class, () -> BCrypt.hashpw("password", "$2a$10$"));
+	}
 }


### PR DESCRIPTION
`BCrypt.hashpw` indexes into the salt (`charAt`, `substring`) assuming a full 29-character salt. A shorter salt (for example `"$"`, `"$2a"`, `"$2a$10$"`) throws `StringIndexOutOfBoundsException` rather than a meaningful error.

This validates `salt.length()` up front and throws `IllegalArgumentException`, consistent with the existing salt-format checks right below it. Adds a test covering several short salts.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
