### PR TITLE
Validate md5HexTo16 input length to avoid StringIndexOutOfBoundsException

### DIFF
--- a/hutool-crypto/src/main/java/cn/hutool/crypto/digest/DigestUtil.java
+++ b/hutool-crypto/src/main/java/cn/hutool/crypto/digest/DigestUtil.java
@@ -196,6 +196,9 @@ public class DigestUtil {
 	 * @since 4.4.1
 	 */
 	public static String md5HexTo16(String md5Hex) {
+		if (md5Hex.length() < 24) {
+			throw new IllegalArgumentException("md5Hex length must be at least 24");
+		}
 		return md5Hex.substring(8, 24);
 	}
 

--- a/hutool-crypto/src/test/java/cn/hutool/crypto/digest/Md5Test.java
+++ b/hutool-crypto/src/test/java/cn/hutool/crypto/digest/Md5Test.java
@@ -30,4 +30,9 @@ public class Md5Test {
 		});
 		IoUtil.close(tester);
 	}
+
+	@Test
+	public void md5HexTo16ShortInputTest() {
+		assertThrows(IllegalArgumentException.class, () -> DigestUtil.md5HexTo16("short"));
+	}
 }


### PR DESCRIPTION
`DigestUtil.md5HexTo16` returns `md5Hex.substring(8, 24)`, which throws `StringIndexOutOfBoundsException` when the input is shorter than 24 characters. This validates the length up front and throws `IllegalArgumentException` with a clear message instead. Adds a test.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
