### PR TITLE
Guard Condition.unwrapQuote against a whitespace-only value

### DIFF
--- a/hutool-db/src/main/java/cn/hutool/db/sql/Condition.java
+++ b/hutool-db/src/main/java/cn/hutool/db/sql/Condition.java
@@ -563,6 +563,9 @@ public class Condition extends CloneSupport<Condition> {
 			return null;
 		}
 		value = value.trim();
+		if (value.isEmpty()) {
+			return value;
+		}
 
 		int from = 0;
 		int to = value.length();


### PR DESCRIPTION
`Condition.unwrapQuote` trims the value and then calls `charAt(0)`, which throws `StringIndexOutOfBoundsException` when the value is whitespace-only (it trims to an empty string). This returns the trimmed value in that case instead. Adds a test.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
