### PR TITLE
fix(hutool-ai): normalize model names with Locale.ROOT

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/AIServiceFactory.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/AIServiceFactory.java
@@ -20,7 +20,9 @@ import cn.hutool.ai.core.AIConfig;
 import cn.hutool.ai.core.AIService;
 import cn.hutool.ai.core.AIServiceProvider;
 import cn.hutool.core.util.ServiceLoaderUtil;
+import cn.hutool.core.util.StrUtil;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -37,11 +39,11 @@ public class AIServiceFactory {
 	// 加载所有 AIModelProvider 实现类
 	static {
 		for (final AIServiceProvider provider : ServiceLoaderUtil.load(AIServiceProvider.class)) {
-			providers.putIfAbsent(provider.getServiceName().toLowerCase(), provider);
+			providers.putIfAbsent(normalizeModelName(provider.getServiceName()), provider);
 		}
 		// issue#4241@github，多线程和Spring环境下可能导致SPI文件找不到问题
 		for (final AIServiceProvider provider : ServiceLoaderUtil.load(AIServiceProvider.class, AIServiceProvider.class.getClassLoader())) {
-			providers.putIfAbsent(provider.getServiceName().toLowerCase(), provider);
+			providers.putIfAbsent(normalizeModelName(provider.getServiceName()), provider);
 		}
 	}
 
@@ -67,7 +69,10 @@ public class AIServiceFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public static <T extends AIService> T getAIService(final AIConfig config, final Class<T> clazz) {
-		final AIServiceProvider provider = providers.get(config.getModelName().toLowerCase());
+		if (config == null) {
+			throw new IllegalArgumentException("AIConfig must not be null");
+		}
+		final AIServiceProvider provider = providers.get(normalizeModelName(config.getModelName()));
 		if (provider == null) {
 			throw new IllegalArgumentException("Unsupported model: " + config.getModelName());
 		}
@@ -78,5 +83,12 @@ public class AIServiceFactory {
 		}
 
 		return (T) service;
+	}
+
+	private static String normalizeModelName(final String modelName) {
+		if (StrUtil.isBlank(modelName)) {
+			throw new IllegalArgumentException("Model name must not be blank");
+		}
+		return modelName.trim().toLowerCase(Locale.ROOT);
 	}
 }

--- a/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigBuilder.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigBuilder.java
@@ -16,6 +16,8 @@
 
 package cn.hutool.ai.core;
 
+import cn.hutool.ai.AIException;
+
 import java.lang.reflect.Constructor;
 import java.net.Proxy;
 
@@ -35,18 +37,15 @@ public class AIConfigBuilder {
 	 * @param modelName 模型厂商的名称（注意不是指具体的模型）
 	 */
 	public AIConfigBuilder(final String modelName) {
+		final Class<? extends AIConfig> configClass = AIConfigRegistry.getConfigClass(modelName);
+		if (configClass == null) {
+			throw new IllegalArgumentException("Unsupported model: " + modelName);
+		}
 		try {
-			// 获取配置类
-			final Class<? extends AIConfig> configClass = AIConfigRegistry.getConfigClass(modelName);
-			if (configClass == null) {
-				throw new IllegalArgumentException("Unsupported model: " + modelName);
-			}
-
-			// 使用反射创建实例
 			final Constructor<? extends AIConfig> constructor = configClass.getDeclaredConstructor();
 			config = constructor.newInstance();
-		} catch (final Exception e) {
-			throw new RuntimeException("Failed to create AIConfig instance", e);
+		} catch (final ReflectiveOperationException e) {
+			throw new AIException("Failed to create AIConfig instance", e);
 		}
 	}
 
@@ -95,7 +94,7 @@ public class AIConfigBuilder {
 	/**
 	 * 动态设置Request请求体中的属性字段，每个模型功能支持的字段请参照对应的官方文档
 	 *
-	 * @param key   Request中的支持的属性名
+	 * @param key Request中的支持的属性名
 	 * @param value 设置的属性值
 	 * @return config
 	 * @since 5.8.38

--- a/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java
@@ -17,7 +17,9 @@
 package cn.hutool.ai.core;
 
 import cn.hutool.core.util.ServiceLoaderUtil;
+import cn.hutool.core.util.StrUtil;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -34,11 +36,11 @@ public class AIConfigRegistry {
 	// 加载所有 AIConfig 实现类
 	static {
 		for (final AIConfig config : ServiceLoaderUtil.load(AIConfig.class)) {
-			configClasses.putIfAbsent(config.getModelName().toLowerCase(), config.getClass());
+			configClasses.putIfAbsent(normalizeModelName(config.getModelName()), config.getClass());
 		}
 		// issue#4241@github，多线程和Spring环境下可能导致SPI文件找不到问题
 		for (final AIConfig config : ServiceLoaderUtil.load(AIConfig.class, AIConfig.class.getClassLoader())) {
-			configClasses.putIfAbsent(config.getModelName().toLowerCase(), config.getClass());
+			configClasses.putIfAbsent(normalizeModelName(config.getModelName()), config.getClass());
 		}
 	}
 
@@ -49,6 +51,13 @@ public class AIConfigRegistry {
 	 * @return AIConfig实现类
 	 */
 	public static Class<? extends AIConfig> getConfigClass(final String modelName) {
-		return configClasses.get(modelName.toLowerCase());
+		return configClasses.get(normalizeModelName(modelName));
+	}
+
+	private static String normalizeModelName(final String modelName) {
+		if (StrUtil.isBlank(modelName)) {
+			throw new IllegalArgumentException("Model name must not be blank");
+		}
+		return modelName.trim().toLowerCase(Locale.ROOT);
 	}
 }

--- a/hutool-ai/src/test/java/cn/hutool/ai/AIModelLookupTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/AIModelLookupTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai;
+
+import cn.hutool.ai.core.AIConfigBuilder;
+import cn.hutool.ai.model.openai.OpenaiConfig;
+import cn.hutool.ai.model.openai.OpenaiService;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AIModelLookupTest {
+
+	private static final Locale TURKISH = Locale.forLanguageTag("tr-TR");
+
+	@Test
+	void builderShouldResolveUppercaseModelNameWithTurkishLocale() {
+		final Locale previous = Locale.getDefault();
+		Locale.setDefault(TURKISH);
+		try {
+			assertNotNull(new AIConfigBuilder("OPENAI").build());
+		} finally {
+			Locale.setDefault(previous);
+		}
+	}
+
+	@Test
+	void serviceFactoryShouldResolveUppercaseModelNameWithTurkishLocale() {
+		final Locale previous = Locale.getDefault();
+		Locale.setDefault(TURKISH);
+		try {
+			final OpenaiService service = AIServiceFactory.getAIService(new UppercaseOpenaiConfig(), OpenaiService.class);
+			assertNotNull(service);
+		} finally {
+			Locale.setDefault(previous);
+		}
+	}
+
+	@Test
+	void builderShouldRejectBlankModelName() {
+		final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new AIConfigBuilder("  "));
+		assertEquals("Model name must not be blank", exception.getMessage());
+	}
+
+	private static class UppercaseOpenaiConfig extends OpenaiConfig {
+		@Override
+		public String getModelName() {
+			return "OPENAI";
+		}
+	}
+}


### PR DESCRIPTION
### Changes
1. Fix locale-sensitive model/provider lookup in `AIServiceFactory` and `AIConfigRegistry`
2. Add `AIConfigBuilder` parameter validation for blank model names
3. Add unit tests for Turkish locale lookup and blank model-name validation

### Test
Run `mvn -pl hutool-ai "-Dtest=AIServiceFactoryTest,cn.hutool.ai.AIModelLookupTest" test`
Result: BUILD SUCCESS, all 5 tests passed.