### PR TITLE
fix: 修复根据新版外国人永久居留身份证（18位）身份编号获取户籍省份编码的问题

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/IdcardUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/IdcardUtil.java
@@ -588,7 +588,8 @@ public class IdcardUtil {
 	public static String getProvinceCodeByIdCard(String idcard) {
 		int len = idcard.length();
 		if (len == CHINA_ID_MIN_LENGTH || len == CHINA_ID_MAX_LENGTH) {
-			return idcard.substring(0, 2);
+			// 截取省份代码。新版外国人永久居留身份证以9开头，第二三位是受理地代码
+			return idcard.startsWith("9") ? idcard.substring(1, 3): idcard.substring(0, 2);
 		}
 		return null;
 	}


### PR DESCRIPTION
### 修改描述

1. [bug修复] `IdcardUtil.getProvinceCodeByIdCard` 缺失对外国人永久居留证（18位）获取户籍省份编码的分支
`isValidCard18`(282 行) 取省份码：`idcard.startsWith("9") ? substring(1,3) : substring(0,2)` ，处理了 "9" 开头的外国人永久居留证，并校验 CITY_CODES。
`getProvinceCodeByIdCard`(591 行) 直接返回的是 substring(0, 2) ，没处理 "9" 开头的分支。
