### PR TITLE
fix(NumberUtil): validate byte array length in toInt(byte[])

### DIFF
--- a/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
+++ b/hutool-core/src/main/java/cn/hutool/core/util/NumberUtil.java
@@ -2976,6 +2976,11 @@ public class NumberUtil {
 	 * @since 4.4.5
 	 */
 	public static int toInt(byte[] bytes) {
+		// byte 数组必须为长度 4 的大端字节序，否则属于非法入参，抛出明确异常而非 NPE/AIOOBE
+		if (null == bytes || bytes.length != 4) {
+			throw new IllegalArgumentException("bytes must be length 4, but: "
+				+ (null == bytes ? "null" : bytes.length));
+		}
 		return (bytes[0] & 0xff) << 24//
 			| (bytes[1] & 0xff) << 16//
 			| (bytes[2] & 0xff) << 8//

--- a/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/NumberUtilTest.java
@@ -738,4 +738,29 @@ public class NumberUtilTest {
 	void issue4237Test(){
 		assertTrue(NumberUtil.isNumber("0008"));
 	}
+
+	@Test
+	public void toIntByteArrayTest() {
+		// toBytes/toInt 往返：大端字节序保持一致
+		final int value = 0x1234ABCD;
+		assertEquals(value, NumberUtil.toInt(NumberUtil.toBytes(value)));
+
+		// 边界值：全 0 与全 1
+		assertEquals(0, NumberUtil.toInt(new byte[]{0, 0, 0, 0}));
+		assertEquals(-1, NumberUtil.toInt(new byte[]{-1, -1, -1, -1}));
+	}
+
+	@Test
+	public void toIntByteArrayNullTest() {
+		// null 入参应抛出 IllegalArgumentException，而非 NPE
+		assertThrows(IllegalArgumentException.class, () -> NumberUtil.toInt((byte[]) null));
+	}
+
+	@Test
+	public void toIntByteArrayInvalidLengthTest() {
+		// 长度不为 4 的数组应抛出 IllegalArgumentException，而非 ArrayIndexOutOfBoundsException
+		assertThrows(IllegalArgumentException.class, () -> NumberUtil.toInt(new byte[0]));
+		assertThrows(IllegalArgumentException.class, () -> NumberUtil.toInt(new byte[]{1, 2, 3}));
+		assertThrows(IllegalArgumentException.class, () -> NumberUtil.toInt(new byte[]{1, 2, 3, 4, 5}));
+	}
 }


### PR DESCRIPTION
### 说明

1. PR 提交至 `v5-dev` 分支。
2. 未更改代码风格，沿用原文件的 tab 缩进。
3. 本 PR 为 bug 修复，已在 `src/test/java` 下补充 JUnit 测试用例。

### 修改描述

1. [bug修复] `NumberUtil.toInt(byte[])` 直接访问 `bytes[0..3]`，未做 null 与长度校验：
   - `NumberUtil.toInt(null)` 抛出 `NullPointerException`；
   - `NumberUtil.toInt(new byte[0])` / `toInt(new byte[]{1,2,3})` 抛出 `ArrayIndexOutOfBoundsException`。
   
   该方法是 `toBytes(int)` 的逆运算，`toBytes(int)` 恒返回长度为 4 的大端字节数组，因此合法入参应为长度 4 的数组。修复方式：对 `null` 或长度不为 4 的入参抛出明确的 `IllegalArgumentException`，与项目中已存在的同类边界处理（如 `DigestUtil.md5HexTo16`、`BCrypt.hashpw` 对定长输入的校验）保持一致。

### 提交前自测

- JDK：`openjdk version "1.8.0_432"`（Temurin），`JAVA_HOME` 已指向 `jdk8u432-b06`。
- `mvn -pl hutool-core -am -Dtest=NumberUtilTest test`：`Tests run: 68, Failures: 0, Errors: 0, Skipped: 0`，BUILD SUCCESS。
- `mvn -pl hutool-core javadoc:javadoc`：BUILD SUCCESS（注释检验通过）。

新增测试（`NumberUtilTest`）：
- `toIntByteArrayTest`：`toBytes`/`toInt` 往返一致性，及全 0、全 1 边界值；
- `toIntByteArrayNullTest`：`null` 入参抛 `IllegalArgumentException`；
- `toIntByteArrayInvalidLengthTest`：空数组、3 字节、5 字节数组抛 `IllegalArgumentException`。

上述测试在修复前会失败（实际抛 NPE / AIOOBE），修复后通过。