### PR TITLE
Set hasProxy in BaseConfig.setProxy so a directly-set proxy is not ignored

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/core/BaseConfig.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/BaseConfig.java
@@ -128,5 +128,6 @@ public class BaseConfig implements AIConfig {
 	@Override
 	public void setProxy(Proxy proxy) {
 		this.proxy = proxy;
+		this.hasProxy = proxy != null;
 	}
 }

--- a/hutool-ai/src/test/java/cn/hutool/ai/core/BaseConfigTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/core/BaseConfigTest.java
@@ -1,0 +1,29 @@
+package cn.hutool.ai.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BaseConfigTest {
+
+	@Test
+	void setProxyShouldSetHasProxyTrue() {
+		BaseConfig config = new BaseConfig();
+		Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8080));
+		config.setProxy(proxy);
+		assertTrue(config.getHasProxy(), "setProxy should automatically set hasProxy to true");
+		assertSame(proxy, config.getProxy());
+	}
+
+	@Test
+	void setNullProxyShouldClearHasProxy() {
+		BaseConfig config = new BaseConfig();
+		config.setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8080)));
+		config.setProxy(null);
+		assertNull(config.getProxy());
+		assertFalse(config.getHasProxy(), "setProxy(null) should clear hasProxy");
+	}
+}


### PR DESCRIPTION
## What is wrong

`BaseConfig` decides whether to apply a proxy by checking the `hasProxy` flag. But `setProxy(Proxy)` sets the `proxy` field and **forgets to update `hasProxy`**. So a proxy configured directly through `setProxy(...)` (instead of through the builder, which sets both) is silently ignored, and requests go out without it.

## Where (file `hutool-ai/src/main/java/cn/hutool/ai/core/BaseConfig.java`)

- **Line 44** — the gate flag, defaults to `false`:
  ```java
  protected volatile boolean hasProxy = false;
  ```
- **Lines 129-131** — `setProxy` updates `proxy` but never touches `hasProxy`:
  ```java
  public void setProxy(Proxy proxy) {
      this.proxy = proxy;     // hasProxy stays false
  }
  ```
- **Line 114** — consumers read `getHasProxy()`; with it stuck at `false`, the proxy you just set is treated as absent.

The builder (`AIConfigBuilder`) sets **both** fields, so `setProxy` is the inconsistent path.

## How it fails

```java
BaseConfig config = new BaseConfig();
config.setProxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8080)));
config.getHasProxy();   // returns false  ->  proxy ignored
```

## Test (`hutool-ai/src/test/java/cn/hutool/ai/core/BaseConfigTest.java`)

```java
@Test
void setProxyShouldSetHasProxyTrue() {
    BaseConfig config = new BaseConfig();
    Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("localhost", 8080));
    config.setProxy(proxy);
    assertTrue(config.getHasProxy(), "setProxy should automatically set hasProxy to true");
    assertSame(proxy, config.getProxy());
}
```

Before the fix this fails with:

```
org.opentest4j.AssertionFailedError: setProxy should automatically set hasProxy to true ==> expected: <true> but was: <false>
```

(A second test checks `setProxy(null)` clears the flag, so the fix cannot regress to a naive `hasProxy = true`.)

## Fix

```diff
 public void setProxy(Proxy proxy) {
     this.proxy = proxy;
+    this.hasProxy = proxy != null;
 }
```

## Verification

`mvn test -Dtest=cn.hutool.ai.core.BaseConfigTest -pl hutool-ai` — **red before** the fix (`Failures: 1`), **green after** (`Tests run: 2, Failures: 0, BUILD SUCCESS`).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.