### PR TITLE
Preserve IllegalArgumentException for an unsupported model in AIConfigBuilder

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigBuilder.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigBuilder.java
@@ -46,6 +46,9 @@ public class AIConfigBuilder {
 			final Constructor<? extends AIConfig> constructor = configClass.getDeclaredConstructor();
 			config = constructor.newInstance();
 		} catch (final Exception e) {
+			if (e instanceof RuntimeException) {
+				throw (RuntimeException) e;
+			}
 			throw new RuntimeException("Failed to create AIConfig instance", e);
 		}
 	}

--- a/hutool-ai/src/test/java/cn/hutool/ai/core/AIConfigBuilderExceptionTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/core/AIConfigBuilderExceptionTest.java
@@ -1,0 +1,18 @@
+package cn.hutool.ai.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AIConfigBuilderExceptionTest {
+
+	@Test
+	void unsupportedModelThrowsIllegalArgumentException() {
+		IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+				() -> new AIConfigBuilder("__no_such_model__"),
+				"an unsupported model must surface as IllegalArgumentException, not a generic RuntimeException");
+		assertTrue(ex.getMessage().contains("Unsupported model"),
+				"message should name the unsupported model");
+	}
+}


### PR DESCRIPTION
## What is wrong

`AIConfigBuilder(String modelName)` throws `IllegalArgumentException("Unsupported model: ...")` for an unknown model, but that throw happens **inside a `try` whose `catch (Exception e)` re-wraps everything** as a generic `RuntimeException("Failed to create AIConfig instance", e)`. So a caller who passes a bad model name gets the wrong exception type and a misleading message; the real reason ("Unsupported model: ...") is buried as the cause.

## Where (file `hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigBuilder.java`)

```java
public AIConfigBuilder(final String modelName) {
    try {
        final Class<? extends AIConfig> configClass = AIConfigRegistry.getConfigClass(modelName);
        if (configClass == null) {
            throw new IllegalArgumentException("Unsupported model: " + modelName);   // L42: the informative error
        }
        final Constructor<? extends AIConfig> constructor = configClass.getDeclaredConstructor();
        config = constructor.newInstance();
    } catch (final Exception e) {                                                     // L48: catches the above too
        throw new RuntimeException("Failed to create AIConfig instance", e);          // L49: re-wrapped as generic
    }
}
```

## How it fails

```java
new AIConfigBuilder("__no_such_model__");
// expected: IllegalArgumentException("Unsupported model: __no_such_model__")
// actual:   RuntimeException("Failed to create AIConfig instance")  (real cause hidden)
```

## Test (`hutool-ai/src/test/java/cn/hutool/ai/core/AIConfigBuilderExceptionTest.java`)

```java
@Test
void unsupportedModelThrowsIllegalArgumentException() {
    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
            () -> new AIConfigBuilder("__no_such_model__"));
    assertTrue(ex.getMessage().contains("Unsupported model"));
}
```

Before the fix it fails:

```
org.opentest4j.AssertionFailedError: ... ==> Unexpected exception type thrown,
expected: <java.lang.IllegalArgumentException> but was: <java.lang.RuntimeException>
Caused by: java.lang.IllegalArgumentException: Unsupported model: __no_such_model__
```

## Fix

```diff
 } catch (final Exception e) {
+    if (e instanceof RuntimeException) {
+        throw (RuntimeException) e;
+    }
     throw new RuntimeException("Failed to create AIConfig instance", e);
 }
```

Runtime exceptions (including the `IllegalArgumentException`) propagate unchanged; only the checked reflection exceptions (`NoSuchMethodException`, `InstantiationException`, ...) are still wrapped.

## Verification

`mvn test -Dtest=cn.hutool.ai.core.AIConfigBuilderExceptionTest -pl hutool-ai` — **red before** (`expected IllegalArgumentException but was RuntimeException`), **green after** (`Tests run: 1, Failures: 0, BUILD SUCCESS`).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
