### PR TITLE
Reject a null modelName in AIConfigRegistry.getConfigClass with a clear message

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java
@@ -49,6 +49,9 @@ public class AIConfigRegistry {
 	 * @return AIConfig实现类
 	 */
 	public static Class<? extends AIConfig> getConfigClass(final String modelName) {
+		if (modelName == null) {
+			throw new IllegalArgumentException("modelName cannot be null");
+		}
 		return configClasses.get(modelName.toLowerCase());
 	}
 }

--- a/hutool-ai/src/test/java/cn/hutool/ai/core/AIConfigRegistryNullTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/core/AIConfigRegistryNullTest.java
@@ -1,0 +1,10 @@
+package cn.hutool.ai.core;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+class AIConfigRegistryNullTest {
+    @Test
+    void getConfigClassNullThrowsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> AIConfigRegistry.getConfigClass(null),
+            "getConfigClass(null) should throw IllegalArgumentException, not NullPointerException");
+    }
+}


### PR DESCRIPTION
## What is wrong

`AIConfigRegistry.getConfigClass(String modelName)` calls `modelName.toLowerCase()` without a null check, so passing `null` throws a bare `NullPointerException` with no indication of what went wrong.

## Where (file `hutool-ai/src/main/java/cn/hutool/ai/core/AIConfigRegistry.java`)

- **Line 52** — dereferences `modelName` directly:
  ```java
  public static Class<? extends AIConfig> getConfigClass(final String modelName) {
      return configClasses.get(modelName.toLowerCase());   // NPE when modelName == null
  }
  ```

## How it fails

```java
AIConfigRegistry.getConfigClass(null);   // throws NullPointerException (no message)
```

## Test (`hutool-ai/src/test/java/cn/hutool/ai/core/AIConfigRegistryNullTest.java`)

```java
@Test
void getConfigClassNullThrowsIllegalArgument() {
    assertThrows(IllegalArgumentException.class, () -> AIConfigRegistry.getConfigClass(null),
            "getConfigClass(null) should throw IllegalArgumentException, not NullPointerException");
}
```

Before the fix it fails:

```
org.opentest4j.AssertionFailedError: ... ==> Unexpected exception type thrown,
expected: <java.lang.IllegalArgumentException> but was: <java.lang.NullPointerException>
```

## Fix

```diff
 public static Class<? extends AIConfig> getConfigClass(final String modelName) {
+    if (modelName == null) {
+        throw new IllegalArgumentException("modelName cannot be null");
+    }
     return configClasses.get(modelName.toLowerCase());
 }
```

## Verification

`mvn test -Dtest=cn.hutool.ai.core.AIConfigRegistryNullTest -pl hutool-ai` — **red before** (`expected IllegalArgumentException but was NullPointerException`), **green after** (`Tests run: 1, Failures: 0, BUILD SUCCESS`).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
