### PR TITLE
Serialize the streaming AI request body as UTF-8

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/core/BaseAIService.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/core/BaseAIService.java
@@ -148,7 +148,7 @@ public class BaseAIService {
 				// 发送请求体
 				try (OutputStream os = connection.getOutputStream()) {
 					String jsonInputString = JSONUtil.toJsonStr(paramMap);
-					os.write(jsonInputString.getBytes());
+					os.write(jsonInputString.getBytes(java.nio.charset.StandardCharsets.UTF_8));
 					os.flush();
 				}
 

--- a/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
@@ -523,7 +523,7 @@ public class GeminiServiceImpl extends BaseAIService implements GeminiService {
 			// 发送请求体
 			try (OutputStream os = connection.getOutputStream()) {
 				String jsonInputString = JSONUtil.toJsonStr(paramMap);
-				os.write(jsonInputString.getBytes());
+				os.write(jsonInputString.getBytes(java.nio.charset.StandardCharsets.UTF_8));
 				os.flush();
 			}
 

--- a/hutool-ai/src/test/java/cn/hutool/ai/core/BaseAIServiceCharsetTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/core/BaseAIServiceCharsetTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.core;
+
+import cn.hutool.ai.ModelName;
+import cn.hutool.json.JSONUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class BaseAIServiceCharsetTest {
+
+	private static final ByteArrayOutputStream CAPTURED = new ByteArrayOutputStream();
+
+	static {
+		// Intercept only the custom "aiutf8" protocol; every other protocol falls back to the JDK default.
+		URL.setURLStreamHandlerFactory(protocol -> "aiutf8".equals(protocol)
+			? new URLStreamHandler() {
+				@Override
+				protected HttpURLConnection openConnection(final URL u) {
+					return new HttpURLConnection(u) {
+						@Override public void connect() {}
+						@Override public void disconnect() {}
+						@Override public boolean usingProxy() { return false; }
+						@Override public OutputStream getOutputStream() { return CAPTURED; }
+						@Override public InputStream getInputStream() { return new ByteArrayInputStream(new byte[0]); }
+					};
+				}
+			}
+			: null);
+	}
+
+	@Test
+	void streamRequestBodyIsEncodedAsUtf8() {
+		CAPTURED.reset();
+
+		final AIConfig config = new AIConfigBuilder(ModelName.HUTOOL.getValue()).setApiKey("test-key").build();
+		config.setApiUrl("aiutf8://ai.example.com");
+
+		final BaseAIService service = new BaseAIService(config);
+
+		final Map<String, Object> paramMap = new HashMap<>();
+		paramMap.put("prompt", "你好，世界"); // non-ASCII text
+
+		service.sendPostStream("/chat", paramMap, line -> {});
+
+		final byte[] expected = JSONUtil.toJsonStr(paramMap).getBytes(StandardCharsets.UTF_8);
+		assertArrayEquals(expected, CAPTURED.toByteArray(),
+			"streaming request body must be UTF-8 encoded regardless of the JVM default charset");
+	}
+}


### PR DESCRIPTION
## What is wrong

`BaseAIService.sendPostStream` and `GeminiServiceImpl.sendPostStream` serialize the JSON request body with `String.getBytes()`, which uses the **JVM default charset** instead of UTF-8.

## Where

- `hutool-ai/src/main/java/cn/hutool/ai/core/BaseAIService.java` **line 151**
- `hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java` **line 526**

```java
try (OutputStream os = connection.getOutputStream()) {
    String jsonInputString = JSONUtil.toJsonStr(paramMap);
    os.write(jsonInputString.getBytes());   // default charset, not UTF-8
    os.flush();
}
```

## How it fails

On any platform whose default charset is not UTF-8 (for example GBK on Chinese Windows, JDK 8-17), a streaming request containing non-ASCII text is byte-corrupted before it is sent. The server decodes the `application/json` body as UTF-8 and receives mojibake, so the prompt is garbled or the request is rejected with a 400. The non-streaming `sendPost` path already sends UTF-8 (through `HttpRequest.body(...)`), so only the streaming path diverges.

## Test

`BaseAIServiceCharsetTest` captures the bytes written to the connection and asserts they equal the UTF-8 encoding of the body. Run against the unfixed code with a non-UTF-8 default charset (`-Dfile.encoding=ISO-8859-1`), it fails:

```
streaming request body must be UTF-8 encoded regardless of the JVM default charset
 ==> array lengths differ, expected: <28> but was: <18>
```

(28 = the UTF-8 bytes; 18 = the mangled default-charset bytes.)

## Fix

Encode the streaming body as UTF-8, matching the non-streaming path:

```java
os.write(jsonInputString.getBytes(java.nio.charset.StandardCharsets.UTF_8));
```

## Verification

The test fails before the change and passes after, verified by execution under `-Dfile.encoding=ISO-8859-1` on JDK 8 (`hutool-ai` module). On a UTF-8-default JVM the test passes either way, which is why the reproduction forces a non-UTF-8 default.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
