### PR TITLE
Attach generationConfig to the Gemini chatJson request

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
@@ -104,6 +104,7 @@ public class GeminiServiceImpl extends BaseAIService implements GeminiService {
 		}
 		//指定响应MIME类型为JSON
 		genConfig.put("response_mime_type", "application/json");
+		paramMap.put("generationConfig", genConfig);
 
 		final HttpResponse response = sendPost(getEndpoint(false), JSONUtil.toJsonStr(paramMap));
 		return response.body();

--- a/hutool-ai/src/test/java/cn/hutool/ai/model/gemini/GeminiChatJsonTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/model/gemini/GeminiChatJsonTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.model.gemini;
+
+import cn.hutool.ai.ModelName;
+import cn.hutool.ai.core.AIConfig;
+import cn.hutool.ai.core.AIConfigBuilder;
+import cn.hutool.ai.core.Message;
+import cn.hutool.http.HttpResponse;
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class GeminiChatJsonTest {
+
+	/** Sentinel used to capture the serialized request body without performing a real HTTP call. */
+	private static final class CapturedBody extends RuntimeException {
+		final String body;
+		CapturedBody(final String body) { this.body = body; }
+	}
+
+	@Test
+	void chatJsonRequestCarriesResponseMimeType() {
+		final AIConfig config = new AIConfigBuilder(ModelName.GEMINI.getValue()).setApiKey("test-key").build();
+
+		final GeminiServiceImpl service = new GeminiServiceImpl(config) {
+			@Override
+			protected HttpResponse sendPost(final String endpoint, final String paramJson) {
+				throw new CapturedBody(paramJson);
+			}
+		};
+
+		try {
+			service.chatJson(Collections.singletonList(new Message("user", "hello")));
+			fail("expected chatJson to issue a POST request");
+		} catch (final CapturedBody captured) {
+			final JSONObject request = JSONUtil.parseObj(captured.body);
+			final JSONObject generationConfig = request.getJSONObject("generationConfig");
+			assertNotNull(generationConfig, "chatJson must attach generationConfig to the request");
+			assertEquals("application/json", generationConfig.getStr("response_mime_type"),
+				"chatJson must request JSON output via response_mime_type");
+		}
+	}
+}


### PR DESCRIPTION
## What is wrong

`GeminiServiceImpl.chatJson` builds a `generationConfig` map to request JSON output, but on the default path it never attaches that map to the request.

## Where

`hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java`, method `chatJson` (**lines 100-107**):

```java
final Map<String, Object> paramMap = buildChatRequestMap(messages);
Map<String, Object> genConfig = MapUtil.get(paramMap, "generationConfig", Map.class);
if (genConfig == null) {
    genConfig = new HashMap<>();
}
//指定响应MIME类型为JSON
genConfig.put("response_mime_type", "application/json");
// genConfig is never put back into paramMap when it was absent

final HttpResponse response = sendPost(getEndpoint(false), JSONUtil.toJsonStr(paramMap));
```

## How it fails

`buildChatRequestMap` never adds a `generationConfig` entry, so on the normal path `genConfig` is a **fresh** `HashMap` that is populated with `response_mime_type` and then discarded. The serialized request therefore contains no `generationConfig`, Gemini is never told to return JSON, and `chatJson` silently degrades to a plain `chat` call, that is its entire purpose is lost.

## Test

`GeminiChatJsonTest` overrides `sendPost` to capture the serialized request body and asserts it carries `generationConfig.response_mime_type`. Against the unfixed code it fails:

```
chatJson must attach generationConfig to the request ==> expected: not <null>
```

## Fix

Put the map back into the request after configuring it:

```java
genConfig.put("response_mime_type", "application/json");
paramMap.put("generationConfig", genConfig);
```

This is harmless when `generationConfig` already existed, since `MapUtil.get` returned that same instance and it is simply re-put.

## Verification

The test fails before the change and passes after, verified by execution on JDK 8 (`hutool-ai` module).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
