### PR TITLE
Separate video parameter flag and value with a space

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/model/hutool/HutoolServiceImpl.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/model/hutool/HutoolServiceImpl.java
@@ -362,7 +362,7 @@ public class HutoolServiceImpl extends BaseAIService implements HutoolService {
 				//如果没有文本参数就重新增加
 				StringBuilder textBuilder = new StringBuilder();
 				for (HutoolCommon.HutoolVideo videoParam : videoParams) {
-					textBuilder.append(videoParam.getType()).append(videoParam.getValue()).append(" ");
+					textBuilder.append(videoParam.getType()).append(" ").append(videoParam.getValue()).append(" ");
 				}
 				textMap.put("type", "text");
 				textMap.put("text", textBuilder.toString());

--- a/hutool-ai/src/test/java/cn/hutool/ai/model/hutool/HutoolVideoParamTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/model/hutool/HutoolVideoParamTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.model.hutool;
+
+import cn.hutool.ai.ModelName;
+import cn.hutool.ai.core.AIConfig;
+import cn.hutool.ai.core.AIConfigBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HutoolVideoParamTest {
+
+	@Test
+	void videoParamFlagAndValueAreSpaceSeparatedWithoutText() throws Exception {
+		final AIConfig config = new AIConfigBuilder(ModelName.HUTOOL.getValue()).setApiKey("test-key").build();
+		final HutoolServiceImpl service = new HutoolServiceImpl(config);
+
+		final Method build = HutoolServiceImpl.class.getDeclaredMethod(
+			"buildGenerationsTasksRequestBody", String.class, String.class, List.class);
+		build.setAccessible(true);
+
+		// Blank text exercises the else branch that assembles the parameter string from scratch.
+		final String body = (String) build.invoke(service, "", "https://example.com/a.png",
+			Collections.singletonList(HutoolCommon.HutoolVideo.RATIO_16_9));
+
+		assertTrue(body.contains("--rt 16:9"),
+			"video flag and value must be space-separated (body: " + body + ")");
+		assertFalse(body.contains("--rt16:9"),
+			"video flag and value must not be concatenated (body: " + body + ")");
+	}
+}


### PR DESCRIPTION
## What is wrong

`HutoolServiceImpl.buildGenerationsTasksRequestBody`, on the no-text branch, appends each video parameter's flag and value with no separator between them.

## Where

`hutool-ai/src/main/java/cn/hutool/ai/model/hutool/HutoolServiceImpl.java` **line 365** (the `else` branch taken when the request has no text prompt, for example image-to-video or parameters only):

```java
} else {
    //如果没有文本参数就重新增加
    StringBuilder textBuilder = new StringBuilder();
    for (HutoolCommon.HutoolVideo videoParam : videoParams) {
        textBuilder.append(videoParam.getType()).append(videoParam.getValue()).append(" ");
    }
    ...
}
```

## How it fails

With `getType()` = `--rt` and `getValue()` = `16:9`, this produces glued tokens such as `--rt16:9 --dur5 --fps24` instead of `--rt 16:9 --dur 5 --fps 24`. The provider cannot parse the flags, so the aspect ratio, duration, fps, resolution and watermark settings are silently dropped (or the request is rejected). The sibling text branch a few lines above already space-separates them, so only the no-text path is affected.

## Test

`HutoolVideoParamTest` invokes the builder with no text and one parameter (`RATIO_16_9`) and asserts the produced body is space-separated. Against the unfixed code it fails:

```
video flag and value must be space-separated
 (body: {"model":"hutool","content":[{"image_url":{"url":"https://example.com/a.png"},"type":"image_url"},{"text":"--rt16:9 ","type":"text"}]})
 ==> expected: <true> but was: <false>
```

## Fix

Insert the separator, matching the text branch:

```java
textBuilder.append(videoParam.getType()).append(" ").append(videoParam.getValue()).append(" ");
```

## Verification

The test fails before the change and passes after, verified by execution on JDK 8 (`hutool-ai` module).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
