### PR TITLE
Build the Gemini upload URL with the upload path, not the full base URL

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
@@ -259,7 +259,7 @@ public class GeminiServiceImpl extends BaseAIService implements GeminiService {
 		//如果是反代或自定义节点，动态拼接
 		try {
 			final URL url = new URL(apiUrl);
-			return new URL(url.getProtocol(), url.getHost(), url.getPort(), UPLOAD_BASE_URL).toString();
+			return new URL(url.getProtocol(), url.getHost(), url.getPort(), "/upload/v1beta/files").toString();
 		} catch (Exception e) {
 			return apiUrl.replace("/models/", "/upload/v1beta/files").split("/models")[0];
 		}

--- a/hutool-ai/src/test/java/cn/hutool/ai/model/gemini/GeminiUploadUrlTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/model/gemini/GeminiUploadUrlTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.model.gemini;
+
+import cn.hutool.ai.ModelName;
+import cn.hutool.ai.core.AIConfig;
+import cn.hutool.ai.core.AIConfigBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GeminiUploadUrlTest {
+
+	@Test
+	void uploadBaseUrlForCustomEndpointIsWellFormed() throws Exception {
+		// A reverse-proxy / custom node endpoint (not the official host).
+		final AIConfig config = new AIConfigBuilder(ModelName.GEMINI.getValue()).setApiKey("test-key").build();
+		config.setApiUrl("https://myproxy.example.com/v1beta");
+
+		final GeminiServiceImpl service = new GeminiServiceImpl(config);
+		final Method getUploadBaseUrl = GeminiServiceImpl.class.getDeclaredMethod("getUploadBaseUrl");
+		getUploadBaseUrl.setAccessible(true);
+
+		final String uploadUrl = (String) getUploadBaseUrl.invoke(service);
+
+		assertEquals("https://myproxy.example.com/upload/v1beta/files", uploadUrl,
+			"the upload URL must keep the proxy host and append only the upload path");
+	}
+}


### PR DESCRIPTION
## What is wrong

`GeminiServiceImpl.getUploadBaseUrl()` builds a malformed upload URL for a reverse-proxy / custom endpoint, so file upload through any non-official endpoint fails.

## Where

`hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java`, `getUploadBaseUrl()`:

```java
try {
    final URL url = new URL(apiUrl);
    return new URL(url.getProtocol(), url.getHost(), url.getPort(), UPLOAD_BASE_URL).toString();
}
```

where `UPLOAD_BASE_URL` is the **full** string `"https://generativelanguage.googleapis.com/upload/v1beta/files"`.

## How it fails

The 4-argument `URL(protocol, host, port, file)` constructor treats its last argument as the **path**, not a full URL. Passing the full `UPLOAD_BASE_URL` embeds a whole URL in the path, so for a custom `apiUrl` like `https://myproxy.example.com/v1beta` it produces:

```
https://myproxy.example.comhttps://generativelanguage.googleapis.com/upload/v1beta/files
```

`uploadFile()` then POSTs to that broken URL, so uploads through a reverse proxy or custom node fail.

## Test

`GeminiUploadUrlTest` reflectively calls `getUploadBaseUrl()` with `apiUrl = https://myproxy.example.com/v1beta`. Against the unfixed code it fails:

```
expected: <https://myproxy.example.com/upload/v1beta/files>
 but was: <https://myproxy.example.comhttps://generativelanguage.googleapis.com/upload/v1beta/files>
```

## Fix

Pass the upload **path** as the URL file, not the full constant:

```java
return new URL(url.getProtocol(), url.getHost(), url.getPort(), "/upload/v1beta/files").toString();
```

## Verification

The test fails before the change and passes after, verified by execution on JDK 8 (`hutool-ai` module).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
