### PR TITLE
Ignore query string and fragment when detecting a media URL MIME type

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java
@@ -289,6 +289,19 @@ public class GeminiServiceImpl extends BaseAIService implements GeminiService {
 		return paramMap;
 	}
 
+	/**
+	 * Detects the MIME type of a media URL by its path, ignoring any query string or fragment.
+	 * {@link FileUtil#getMimeType(String)} matches on the file extension, so a URL such as
+	 * {@code https://host/a.png?v=1} would otherwise fail to resolve.
+	 *
+	 * @param url the media URL
+	 * @return the detected MIME type, or {@code null} if it cannot be determined
+	 */
+	private static String detectMimeType(final String url) {
+		final String path = StrUtil.subBefore(StrUtil.subBefore(url, "?", false), "#", false);
+		return FileUtil.getMimeType(path);
+	}
+
 	private Map<String, Object> buildMultimodalRequestMap(String prompt, final List<String> mediaList) {
 		final List<Map<String, Object>> parts = new ArrayList<>();
 		parts.add(MapUtil.ofEntries(MapUtil.entry("text", prompt)));
@@ -318,7 +331,7 @@ public class GeminiServiceImpl extends BaseAIService implements GeminiService {
 					try {
 						final byte[] bytes = HttpUtil.downloadBytes(media);
 						//尝试识别下载文件的 MIME，无法识别则不强加后缀逻辑，通过流内容自适应
-						String mime = FileUtil.getMimeType(media);
+						String mime = detectMimeType(media);
 						if (StrUtil.isBlank(mime)) {
 							// 基础兜底
 							mime = "image/jpeg";

--- a/hutool-ai/src/test/java/cn/hutool/ai/model/gemini/GeminiMimeTypeTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/model/gemini/GeminiMimeTypeTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.model.gemini;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GeminiMimeTypeTest {
+
+	@Test
+	void detectsMimeTypeOfUrlWithQueryStringAndFragment() throws Exception {
+		final Method detect = GeminiServiceImpl.class.getDeclaredMethod("detectMimeType", String.class);
+		detect.setAccessible(true);
+
+		// CDN / presigned image URLs commonly carry a query string or fragment; the extension
+		// is still ".png", so the MIME type must resolve to image/png rather than being lost.
+		assertEquals("image/png", detect.invoke(null, "https://cdn.example.com/photo.png?v=123&x=1"));
+		assertEquals("image/png", detect.invoke(null, "https://cdn.example.com/photo.png#section"));
+		// A plain URL must still resolve exactly as before.
+		assertEquals("image/png", detect.invoke(null, "https://cdn.example.com/photo.png"));
+	}
+}


### PR DESCRIPTION
## What is wrong

Multimodal image URLs that carry a query string or fragment lose their MIME type, so the image is sent to Gemini with the wrong `mime_type`.

## Where

`hutool-ai/src/main/java/cn/hutool/ai/model/gemini/GeminiServiceImpl.java`, the `http(s)` media branch of `buildMultimodalRequestMap`:

```java
final byte[] bytes = HttpUtil.downloadBytes(media);
String mime = FileUtil.getMimeType(media); // media is a full URL
if (StrUtil.isBlank(mime)) {
    mime = "image/jpeg";
}
```

## How it fails

`FileUtil.getMimeType` detects the type from the file extension. For a common CDN / presigned URL such as `https://cdn.example.com/photo.png?v=123`, the trailing `?v=123` means there is no clean `.png` to match, so it returns `null` and the code falls back to `image/jpeg`. A PNG (or GIF / WebP) is then sent to Gemini mislabeled as JPEG.

## Test

`GeminiMimeTypeTest` exercises the extracted `detectMimeType` helper. Against a lookup that does not strip the query string it fails:

```
expected: <image/png> but was: <null>
```

## Fix

Extract `detectMimeType(url)` that strips the query string and fragment before calling `FileUtil.getMimeType`, and use it at the call site. A plain URL with no query resolves exactly as before.

```java
private static String detectMimeType(final String url) {
    final String path = StrUtil.subBefore(StrUtil.subBefore(url, "?", false), "#", false);
    return FileUtil.getMimeType(path);
}
```

## Verification

The test fails before the change and passes after, verified by execution on JDK 8 (`hutool-ai` module).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
