### PR TITLE
Merge additional config into the Doubao tokenization request

### DIFF
--- a/hutool-ai/src/main/java/cn/hutool/ai/model/doubao/DoubaoServiceImpl.java
+++ b/hutool-ai/src/main/java/cn/hutool/ai/model/doubao/DoubaoServiceImpl.java
@@ -316,6 +316,8 @@ public class DoubaoServiceImpl extends BaseAIService implements DoubaoService {
 		final Map<String, Object> paramMap = new HashMap<>();
 		paramMap.put("model", config.getModel());
 		paramMap.put("text", text);
+		//合并其他参数
+		paramMap.putAll(config.getAdditionalConfigMap());
 		return JSONUtil.toJsonStr(paramMap);
 	}
 

--- a/hutool-ai/src/test/java/cn/hutool/ai/model/doubao/DoubaoTokenizationConfigTest.java
+++ b/hutool-ai/src/test/java/cn/hutool/ai/model/doubao/DoubaoTokenizationConfigTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Hutool Team and hutool.cn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cn.hutool.ai.model.doubao;
+
+import cn.hutool.ai.ModelName;
+import cn.hutool.ai.core.AIConfig;
+import cn.hutool.ai.core.AIConfigBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DoubaoTokenizationConfigTest {
+
+	@Test
+	void tokenizationRequestIncludesAdditionalConfig() throws Exception {
+		final AIConfig config = new AIConfigBuilder(ModelName.DOUBAO.getValue())
+			.setApiKey("test-key")
+			.putAdditionalConfig("custom_param", "custom_value")
+			.build();
+		final DoubaoServiceImpl service = new DoubaoServiceImpl(config);
+
+		final Method build = DoubaoServiceImpl.class.getDeclaredMethod("buildTokenizationRequestBody", String[].class);
+		build.setAccessible(true);
+		final String body = (String) build.invoke(service, (Object) new String[] {"hello"});
+
+		assertTrue(body.contains("custom_param"),
+			"tokenization request must forward user-set additional config, like the other Doubao endpoints (body: " + body + ")");
+	}
+}


### PR DESCRIPTION
## What is wrong

`DoubaoServiceImpl.tokenization()` silently drops user-set additional config parameters, unlike every other Doubao endpoint.

## Where

`hutool-ai/src/main/java/cn/hutool/ai/model/doubao/DoubaoServiceImpl.java`, `buildTokenizationRequestBody`:

```java
private String buildTokenizationRequestBody(String[] text) {
    final Map<String, Object> paramMap = new HashMap<>();
    paramMap.put("model", config.getModel());
    paramMap.put("text", text);
    return JSONUtil.toJsonStr(paramMap); // config.getAdditionalConfigMap() is never merged
}
```

## How it fails

Every other request-body builder in this class merges `config.getAdditionalConfigMap()` (the `//合并其他参数` line) so that parameters set through the public config API are honored on the chat, vision, embedding, image and video endpoints. `buildTokenizationRequestBody` is the only one of them that omits it, so any parameter a user sets via `putAdditionalConfig(...)` is silently dropped for `tokenization()`.

## Test

`DoubaoTokenizationConfigTest` sets an additional config parameter and asserts the tokenization request body carries it. Against the unfixed builder it fails:

```
Tests run: 1, Failures: 1   (custom_param absent from the request body)
```

## Fix

Merge the additional config map, matching the sibling builders:

```java
paramMap.put("text", text);
//合并其他参数
paramMap.putAll(config.getAdditionalConfigMap());
return JSONUtil.toJsonStr(paramMap);
```

## Verification

The test fails before the change and passes after, verified by execution on JDK 8 (`hutool-ai` module).

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
