### PR TITLE
test: fix ArrayUtil.lastIndexOfSub test case

### DIFF
--- a/hutool-core/src/test/java/cn/hutool/core/util/ArrayUtilTest.java
+++ b/hutool-core/src/test/java/cn/hutool/core/util/ArrayUtilTest.java
@@ -417,10 +417,11 @@ public class ArrayUtilTest {
 
 	@Test
 	public void lastIndexOfSubTest2() {
-		Integer[] a = {0x12, 0x56, 0x78, 0x56, 0x21, 0x9A};
+		Integer[] a = {0x12, 0x56, 0x78, 0x56, 0x78, 0x9A};
 		Integer[] b = {0x56, 0x78};
-		int i = ArrayUtil.indexOfSub(a, b);
-		assertEquals(1, i);
+
+		int i = ArrayUtil.lastIndexOfSub(a, b);
+		assertEquals(3, i);
 	}
 
 	@Test


### PR DESCRIPTION
## What does this PR do?

Fix an incorrect test case in ArrayUtilTest.

The test method `lastIndexOfSubTest2` was calling
`ArrayUtil.indexOfSub` instead of `ArrayUtil.lastIndexOfSub`,
so it did not verify the behavior of `lastIndexOfSub`.

## Changes

- Replace `indexOfSub` with `lastIndexOfSub`
- Add duplicated sub-array scenario to verify the last occurrence index

## Test

Run:

ArrayUtilTest#lastIndexOfSubTest2

Result:

PASS